### PR TITLE
feat(m2): add jwt login flow

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@nestjs/common": "^11.0.1",
     "@nestjs/core": "^11.0.1",
+    "@nestjs/jwt": "^11.0.2",
     "@nestjs/platform-express": "^11.0.1",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1"

--- a/apps/server/src/modules/auth/auth.controller.ts
+++ b/apps/server/src/modules/auth/auth.controller.ts
@@ -1,0 +1,34 @@
+import {
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
+
+import { CurrentAuthUser } from './decorators/current-auth-user.decorator';
+import { JwtAuthGuard } from './guards/jwt-auth.guard';
+import { LoginDto } from './dto/login.dto';
+import { AuthService } from './auth.service';
+import type { AuthUser } from './domain/auth-user';
+
+@Controller('auth')
+export class AuthController {
+  constructor(private readonly authService: AuthService) {}
+
+  @Post('login')
+  @HttpCode(HttpStatus.OK)
+  async login(@Body() loginDto: LoginDto) {
+    return this.authService.login(loginDto);
+  }
+
+  @Get('me')
+  @UseGuards(JwtAuthGuard)
+  getCurrentUser(@CurrentAuthUser() authUser: AuthUser) {
+    return {
+      user: this.authService.serializeUser(authUser),
+    };
+  }
+}

--- a/apps/server/src/modules/auth/auth.module.ts
+++ b/apps/server/src/modules/auth/auth.module.ts
@@ -1,4 +1,21 @@
 import { Module } from '@nestjs/common';
+import { JwtModule } from '@nestjs/jwt';
 
-@Module({})
+import { AuthController } from './auth.controller';
+import { AuthService } from './auth.service';
+import { JwtAuthGuard } from './guards/jwt-auth.guard';
+
+@Module({
+  imports: [
+    JwtModule.register({
+      secret: process.env.AUTH_JWT_SECRET ?? 'my-resume-dev-jwt-secret',
+      signOptions: {
+        expiresIn: '1h',
+      },
+    }),
+  ],
+  controllers: [AuthController],
+  providers: [AuthService, JwtAuthGuard],
+  exports: [AuthService],
+})
 export class AuthModule {}

--- a/apps/server/src/modules/auth/auth.service.spec.ts
+++ b/apps/server/src/modules/auth/auth.service.spec.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from '@jest/globals';
+import { JwtService } from '@nestjs/jwt';
+
+import { AuthService } from './auth.service';
+import { UserRole } from './domain/user-role.enum';
+
+describe('AuthService', () => {
+  const jwtService = new JwtService({
+    secret: 'test-jwt-secret',
+    signOptions: {
+      expiresIn: '1h',
+    },
+  });
+
+  const authService = new AuthService(jwtService);
+
+  it('should issue an access token for the admin demo account', async () => {
+    const loginResult = await authService.login({
+      username: 'admin',
+      password: 'admin123456',
+    });
+
+    expect(loginResult.tokenType).toBe('Bearer');
+    expect(loginResult.accessToken).toEqual(expect.any(String));
+    expect(loginResult.user).toMatchObject({
+      username: 'admin',
+      role: UserRole.ADMIN,
+      isActive: true,
+    });
+    expect(loginResult.user.capabilities.canTriggerAiAnalysis).toBe(true);
+  });
+
+  it('should reject invalid credentials', async () => {
+    await expect(
+      authService.login({
+        username: 'admin',
+        password: 'wrong-password',
+      }),
+    ).rejects.toThrow('Invalid credentials');
+  });
+});

--- a/apps/server/src/modules/auth/auth.service.ts
+++ b/apps/server/src/modules/auth/auth.service.ts
@@ -1,0 +1,122 @@
+import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+
+import { buildRoleCapabilities } from './domain/auth-role-policy';
+import { AuthUser } from './domain/auth-user';
+import { UserRole } from './domain/user-role.enum';
+import { LoginDto } from './dto/login.dto';
+import { AuthTokenPayload } from './interfaces/auth-token-payload.interface';
+
+interface DemoAccount extends AuthUser {
+  password: string;
+}
+
+export interface AuthUserView extends AuthUser {
+  capabilities: ReturnType<typeof buildRoleCapabilities>;
+}
+
+export interface LoginResult {
+  accessToken: string;
+  tokenType: 'Bearer';
+  expiresIn: number;
+  user: AuthUserView;
+}
+
+const ACCESS_TOKEN_EXPIRES_IN_SECONDS = 60 * 60;
+
+const DEMO_ACCOUNTS: DemoAccount[] = [
+  {
+    id: 'admin-demo-user',
+    username: 'admin',
+    password: 'admin123456',
+    role: UserRole.ADMIN,
+    isActive: true,
+  },
+  {
+    id: 'viewer-demo-user',
+    username: 'viewer',
+    password: 'viewer123456',
+    role: UserRole.VIEWER,
+    isActive: true,
+  },
+];
+
+@Injectable()
+export class AuthService {
+  constructor(private readonly jwtService: JwtService) {}
+
+  async login(loginDto: LoginDto): Promise<LoginResult> {
+    const authUser = this.validateCredentials(loginDto);
+
+    if (!authUser) {
+      throw new UnauthorizedException('Invalid credentials');
+    }
+
+    const accessToken = await this.jwtService.signAsync({
+      sub: authUser.id,
+      username: authUser.username,
+      role: authUser.role,
+    });
+
+    return {
+      accessToken,
+      tokenType: 'Bearer',
+      expiresIn: ACCESS_TOKEN_EXPIRES_IN_SECONDS,
+      user: this.serializeUser(authUser),
+    };
+  }
+
+  async verifyAccessToken(accessToken: string): Promise<AuthUser> {
+    try {
+      const payload =
+        await this.jwtService.verifyAsync<AuthTokenPayload>(accessToken);
+
+      const authUser = DEMO_ACCOUNTS.find(
+        (account) =>
+          account.id === payload.sub &&
+          account.username === payload.username &&
+          account.role === payload.role &&
+          account.isActive,
+      );
+
+      if (!authUser) {
+        throw new UnauthorizedException('Invalid token');
+      }
+
+      return this.stripPassword(authUser);
+    } catch (error) {
+      if (error instanceof UnauthorizedException) {
+        throw error;
+      }
+
+      throw new UnauthorizedException('Invalid token');
+    }
+  }
+
+  serializeUser(authUser: AuthUser): AuthUserView {
+    return {
+      ...authUser,
+      capabilities: buildRoleCapabilities(authUser.role),
+    };
+  }
+
+  private validateCredentials(loginDto: LoginDto): AuthUser | null {
+    const account = DEMO_ACCOUNTS.find(
+      (candidate) =>
+        candidate.username === loginDto.username &&
+        candidate.password === loginDto.password &&
+        candidate.isActive,
+    );
+
+    return account ? this.stripPassword(account) : null;
+  }
+
+  private stripPassword(account: DemoAccount): AuthUser {
+    return {
+      id: account.id,
+      username: account.username,
+      role: account.role,
+      isActive: account.isActive,
+    };
+  }
+}

--- a/apps/server/src/modules/auth/decorators/current-auth-user.decorator.ts
+++ b/apps/server/src/modules/auth/decorators/current-auth-user.decorator.ts
@@ -1,0 +1,10 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+
+import { AuthenticatedRequest } from '../interfaces/authenticated-request.interface';
+
+export const CurrentAuthUser = createParamDecorator(
+  (_data: unknown, context: ExecutionContext) => {
+    const request = context.switchToHttp().getRequest<AuthenticatedRequest>();
+    return request.authUser;
+  },
+);

--- a/apps/server/src/modules/auth/dto/login.dto.ts
+++ b/apps/server/src/modules/auth/dto/login.dto.ts
@@ -1,0 +1,4 @@
+export class LoginDto {
+  username!: string;
+  password!: string;
+}

--- a/apps/server/src/modules/auth/guards/jwt-auth.guard.ts
+++ b/apps/server/src/modules/auth/guards/jwt-auth.guard.ts
@@ -1,0 +1,33 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
+
+import { AuthService } from '../auth.service';
+import { AuthenticatedRequest } from '../interfaces/authenticated-request.interface';
+
+@Injectable()
+export class JwtAuthGuard implements CanActivate {
+  constructor(private readonly authService: AuthService) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest<AuthenticatedRequest>();
+    const bearerToken = request.headers.authorization;
+
+    if (!bearerToken?.startsWith('Bearer ')) {
+      throw new UnauthorizedException('Missing bearer token');
+    }
+
+    const accessToken = bearerToken.slice('Bearer '.length).trim();
+
+    if (!accessToken) {
+      throw new UnauthorizedException('Missing bearer token');
+    }
+
+    request.authUser = await this.authService.verifyAccessToken(accessToken);
+
+    return true;
+  }
+}

--- a/apps/server/src/modules/auth/interfaces/auth-token-payload.interface.ts
+++ b/apps/server/src/modules/auth/interfaces/auth-token-payload.interface.ts
@@ -1,0 +1,9 @@
+import { UserRole } from '../domain/user-role.enum';
+
+export interface AuthTokenPayload {
+  sub: string;
+  username: string;
+  role: UserRole;
+  iat?: number;
+  exp?: number;
+}

--- a/apps/server/src/modules/auth/interfaces/authenticated-request.interface.ts
+++ b/apps/server/src/modules/auth/interfaces/authenticated-request.interface.ts
@@ -1,0 +1,7 @@
+import { Request } from 'express';
+
+import { AuthUser } from '../domain/auth-user';
+
+export interface AuthenticatedRequest extends Request {
+  authUser?: AuthUser;
+}

--- a/apps/server/test/auth.e2e-spec.ts
+++ b/apps/server/test/auth.e2e-spec.ts
@@ -1,0 +1,87 @@
+import { INestApplication } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import request from 'supertest';
+import { App } from 'supertest/types';
+
+import { AppModule } from './../src/app.module';
+
+describe('AuthModule (e2e)', () => {
+  let app: INestApplication<App>;
+
+  beforeEach(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('should login with the demo admin account', async () => {
+    const response = await request(app.getHttpServer())
+      .post('/auth/login')
+      .send({
+        username: 'admin',
+        password: 'admin123456',
+      })
+      .expect(200);
+
+    expect(response.body).toMatchObject({
+      tokenType: 'Bearer',
+      user: {
+        username: 'admin',
+        role: 'admin',
+        isActive: true,
+      },
+    });
+    expect(response.body.accessToken).toEqual(expect.any(String));
+  });
+
+  it('should reject invalid credentials', () => {
+    return request(app.getHttpServer())
+      .post('/auth/login')
+      .send({
+        username: 'admin',
+        password: 'wrong-password',
+      })
+      .expect(401);
+  });
+
+  it('should read current user from bearer token', async () => {
+    const loginResponse = await request(app.getHttpServer())
+      .post('/auth/login')
+      .send({
+        username: 'viewer',
+        password: 'viewer123456',
+      })
+      .expect(200);
+
+    const accessToken = loginResponse.body.accessToken as string;
+
+    const meResponse = await request(app.getHttpServer())
+      .get('/auth/me')
+      .set('Authorization', `Bearer ${accessToken}`)
+      .expect(200);
+
+    expect(meResponse.body).toMatchObject({
+      user: {
+        username: 'viewer',
+        role: 'viewer',
+        isActive: true,
+        capabilities: {
+          canEditResume: false,
+          canPublishResume: false,
+          canTriggerAiAnalysis: false,
+        },
+      },
+    });
+  });
+
+  it('should reject protected access without bearer token', () => {
+    return request(app.getHttpServer()).get('/auth/me').expect(401);
+  });
+});

--- a/docs/30-开发日志/M2-issue-07-JWT-登录最小闭环.md
+++ b/docs/30-开发日志/M2-issue-07-JWT-登录最小闭环.md
@@ -1,0 +1,161 @@
+# M2 / issue-07 JWT 登录最小闭环
+
+- Issue：`#13`
+- 里程碑：`M2 鉴权与角色：最小登录闭环`
+- 分支：`feat/m2-issue-07-jwt-login`
+- 日期：`2026-03-24`
+
+## 背景
+
+`issue-06` 已经把 `admin / viewer` 的角色模型和权限边界固定下来。  
+下一步需要让 `apps/server` 先具备最小登录能力，形成“登录 → 签发 token → 访问受保护接口”的闭环，作为后续 `apps/admin` 登录壳和 viewer 只读体验的基础。
+
+## 本次目标
+
+- 提供最小登录接口
+- 签发可校验的 JWT 访问令牌
+- 提供最小受保护接口，验证登录态
+- 保持当前阶段不接数据库，先用 demo 账号完成教学闭环
+
+## 非目标
+
+- 不接数据库持久化
+- 不实现刷新令牌复杂策略
+- 不接前端完整页面
+- 不引入 Passport 体系的完整封装
+
+## TDD / 测试设计
+
+### 单元测试
+
+- 新增 `apps/server/src/modules/auth/auth.service.spec.ts`
+- 先描述两个核心行为：
+  - demo `admin` 账号登录成功并返回 token
+  - 非法凭证登录失败
+
+### E2E 测试
+
+- 新增 `apps/server/test/auth.e2e-spec.ts`
+- 先描述四个闭环场景：
+  - `POST /auth/login` 成功登录
+  - 非法凭证返回 `401`
+  - 带 `Bearer Token` 访问 `GET /auth/me` 成功
+  - 未携带 token 访问受保护接口返回 `401`
+
+### 首次失败记录
+
+- `pnpm --filter @my-resume/server exec jest --runInBand src/modules/auth/auth.service.spec.ts`
+- 结果：失败
+- 原因：缺少 `AuthService`
+
+- `pnpm --filter @my-resume/server exec jest --config ./test/jest-e2e.json --runInBand test/auth.e2e-spec.ts`
+- 结果：失败
+- 原因：`/auth/login` 与 `/auth/me` 路由尚未实现
+
+## 实际改动
+
+- 新增 `AuthController`
+  - `POST /auth/login`
+  - `GET /auth/me`
+- 新增 `AuthService`
+  - 内存 demo 账号校验
+  - JWT 签发
+  - token 校验与用户恢复
+- 新增 `JwtAuthGuard`
+  - 从 `Authorization` 头中提取 `Bearer Token`
+  - 拒绝缺失或非法 token
+- 新增 `CurrentAuthUser` 装饰器
+- 新增 `LoginDto`
+- 新增认证相关接口类型：
+  - `AuthTokenPayload`
+  - `AuthenticatedRequest`
+- 在 `AuthModule` 中引入 `@nestjs/jwt`
+- 增加 `@nestjs/jwt` 依赖
+
+## Review 记录
+
+### 是否符合当前 Issue 与里程碑目标
+
+符合。当前只做了：
+
+- 最小登录接口
+- 最小 JWT 签发与校验
+- 最小受保护接口
+- 以 demo 账号完成后端闭环
+
+没有提前进入：
+
+- 数据库存储
+- 刷新令牌
+- 前端登录页
+- `viewer` 页面体验细化
+
+### 是否存在可继续抽离的点
+
+- `DEMO_ACCOUNTS` 后续可迁移到基础设施层或配置层
+- 当前阶段保持放在 `AuthService` 内更利于教学，暂不继续抽离
+- `JwtAuthGuard`、`CurrentAuthUser` 已沉淀为可复用的最小认证基础件
+
+### Review 结论
+
+- 通过
+- 进入自测
+
+## 自测结果
+
+### 1. `AuthService` 单测
+
+- `pnpm --filter @my-resume/server exec jest --runInBand src/modules/auth/auth.service.spec.ts`
+- 结果：通过
+
+### 2. 认证闭环 E2E
+
+- `pnpm --filter @my-resume/server exec jest --config ./test/jest-e2e.json --runInBand test/auth.e2e-spec.ts`
+- 结果：通过
+
+### 3. `apps/server` 全量单测
+
+- `pnpm --filter @my-resume/server exec jest --runInBand`
+- 结果：通过
+
+### 4. `apps/server` 全量 E2E
+
+- `pnpm --filter @my-resume/server exec jest --config ./test/jest-e2e.json --runInBand`
+- 结果：通过
+
+### 5. `apps/server` 构建
+
+- `pnpm --filter @my-resume/server build`
+- 结果：通过
+
+### 6. 根级验证
+
+- `pnpm run typecheck`
+- 结果：通过
+- `pnpm run build`
+- 结果：通过
+- 备注：根项目构建仍提示 `tailwind.config.cjs` 的 ESM warning，但与本次任务无关，且构建成功
+
+## 遇到的问题
+
+### 1. `NestJS` 装饰器元数据与类型导入冲突
+
+- 现象：`AuthController` 构建时报 `TS1272`
+- 原因：在 `isolatedModules + emitDecoratorMetadata` 下，装饰器签名里的类型需要 `import type`
+- 处理：将 `AuthUser` 改为类型导入
+
+### 2. 当前登录实现容易过度设计
+
+- 风险：为了“更完整”而过早引入数据库、刷新令牌、Passport
+- 处理：本轮只保留 demo 账号 + JWT 最小闭环，优先保证教程节奏
+
+## 可沉淀为教程 / 博客的点
+
+- 为什么在教程型项目里先做“最小登录闭环”，而不是一口气上完整鉴权体系
+- 不接数据库时，如何用 demo 账号完成 JWT 教学验证
+- `NestJS` 中不依赖 Passport 也能跑通最小 JWT 闭环
+- 如何用单测 + E2E 把登录行为先锁住再实现
+
+## 后续待办
+
+- 继续 `issue-08`：`apps/admin` 最小登录壳

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,6 +93,9 @@ importers:
       '@nestjs/core':
         specifier: ^11.0.1
         version: 11.1.17(@nestjs/common@11.1.17(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.17)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/jwt':
+        specifier: ^11.0.2
+        version: 11.0.2(@nestjs/common@11.1.17(reflect-metadata@0.2.2)(rxjs@7.8.2))
       '@nestjs/platform-express':
         specifier: ^11.0.1
         version: 11.1.17(@nestjs/common@11.1.17(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.17)
@@ -921,6 +924,11 @@ packages:
       '@nestjs/websockets':
         optional: true
 
+  '@nestjs/jwt@11.0.2':
+    resolution: {integrity: sha512-rK8aE/3/Ma45gAWfCksAXUNbOoSOUudU0Kn3rT39htPF7wsYXtKfjALKeKKJbFrIWbLjsbqfXX5bIJNvgBugGA==}
+    peerDependencies:
+      '@nestjs/common': ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0
+
   '@nestjs/platform-express@11.1.17':
     resolution: {integrity: sha512-mAf4eOsSBsTOn/VbrUO1gsjW6dVh91qqXPMXun4dN8SnNjf7PTQagM9o8d6ab8ZBpNe6UdZftdrZoDetU+n4Qg==}
     peerDependencies:
@@ -1200,8 +1208,14 @@ packages:
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
+  '@types/jsonwebtoken@9.0.10':
+    resolution: {integrity: sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==}
+
   '@types/methods@1.1.4':
     resolution: {integrity: sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==}
+
+  '@types/ms@2.1.0':
+    resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
   '@types/node@20.19.37':
     resolution: {integrity: sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==}
@@ -1800,6 +1814,9 @@ packages:
   bser@2.1.1:
     resolution: {integrity: sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==}
 
+  buffer-equal-constant-time@1.0.1:
+    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
+
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
 
@@ -2082,6 +2099,9 @@ packages:
 
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
+  ecdsa-sig-formatter@1.0.11:
+    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
@@ -2820,6 +2840,16 @@ packages:
   jsonfile@6.2.0:
     resolution: {integrity: sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==}
 
+  jsonwebtoken@9.0.3:
+    resolution: {integrity: sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==}
+    engines: {node: '>=12', npm: '>=6'}
+
+  jwa@2.0.1:
+    resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
+
+  jws@4.0.1:
+    resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
+
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
@@ -2854,11 +2884,32 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
+  lodash.includes@4.3.0:
+    resolution: {integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==}
+
+  lodash.isboolean@3.0.3:
+    resolution: {integrity: sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==}
+
+  lodash.isinteger@4.0.4:
+    resolution: {integrity: sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==}
+
+  lodash.isnumber@3.0.3:
+    resolution: {integrity: sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==}
+
+  lodash.isplainobject@4.0.6:
+    resolution: {integrity: sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==}
+
+  lodash.isstring@4.0.1:
+    resolution: {integrity: sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==}
+
   lodash.memoize@4.1.2:
     resolution: {integrity: sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==}
 
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+
+  lodash.once@4.1.1:
+    resolution: {integrity: sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==}
 
   lodash@4.17.23:
     resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
@@ -4867,6 +4918,12 @@ snapshots:
     optionalDependencies:
       '@nestjs/platform-express': 11.1.17(@nestjs/common@11.1.17(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.17)
 
+  '@nestjs/jwt@11.0.2(@nestjs/common@11.1.17(reflect-metadata@0.2.2)(rxjs@7.8.2))':
+    dependencies:
+      '@nestjs/common': 11.1.17(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@types/jsonwebtoken': 9.0.10
+      jsonwebtoken: 9.0.3
+
   '@nestjs/platform-express@11.1.17(@nestjs/common@11.1.17(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.17)':
     dependencies:
       '@nestjs/common': 11.1.17(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -5121,7 +5178,14 @@ snapshots:
 
   '@types/json-schema@7.0.15': {}
 
+  '@types/jsonwebtoken@9.0.10':
+    dependencies:
+      '@types/ms': 2.1.0
+      '@types/node': 22.19.15
+
   '@types/methods@1.1.4': {}
+
+  '@types/ms@2.1.0': {}
 
   '@types/node@20.19.37':
     dependencies:
@@ -5824,6 +5888,8 @@ snapshots:
     dependencies:
       node-int64: 0.4.0
 
+  buffer-equal-constant-time@1.0.1: {}
+
   buffer-from@1.1.2: {}
 
   buffer@5.7.1:
@@ -6064,6 +6130,10 @@ snapshots:
       gopd: 1.2.0
 
   eastasianwidth@0.2.0: {}
+
+  ecdsa-sig-formatter@1.0.11:
+    dependencies:
+      safe-buffer: 5.2.1
 
   ee-first@1.1.1: {}
 
@@ -7043,6 +7113,30 @@ snapshots:
     optionalDependencies:
       graceful-fs: 4.2.11
 
+  jsonwebtoken@9.0.3:
+    dependencies:
+      jws: 4.0.1
+      lodash.includes: 4.3.0
+      lodash.isboolean: 3.0.3
+      lodash.isinteger: 4.0.4
+      lodash.isnumber: 3.0.3
+      lodash.isplainobject: 4.0.6
+      lodash.isstring: 4.0.1
+      lodash.once: 4.1.1
+      ms: 2.1.3
+      semver: 7.7.4
+
+  jwa@2.0.1:
+    dependencies:
+      buffer-equal-constant-time: 1.0.1
+      ecdsa-sig-formatter: 1.0.11
+      safe-buffer: 5.2.1
+
+  jws@4.0.1:
+    dependencies:
+      jwa: 2.0.1
+      safe-buffer: 5.2.1
+
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
@@ -7070,9 +7164,23 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
+  lodash.includes@4.3.0: {}
+
+  lodash.isboolean@3.0.3: {}
+
+  lodash.isinteger@4.0.4: {}
+
+  lodash.isnumber@3.0.3: {}
+
+  lodash.isplainobject@4.0.6: {}
+
+  lodash.isstring@4.0.1: {}
+
   lodash.memoize@4.1.2: {}
 
   lodash.merge@4.6.2: {}
+
+  lodash.once@4.1.1: {}
 
   lodash@4.17.23: {}
 


### PR DESCRIPTION
## Summary
- add minimal JWT login and current-user endpoints in apps/server
- keep auth flow database-free with demo admin/viewer accounts
- add unit tests, e2e tests and devlog for issue-07

## Test Plan
- pnpm --filter @my-resume/server exec jest --runInBand src/modules/auth/auth.service.spec.ts
- pnpm --filter @my-resume/server exec jest --config ./test/jest-e2e.json --runInBand test/auth.e2e-spec.ts
- pnpm --filter @my-resume/server exec jest --runInBand
- pnpm --filter @my-resume/server exec jest --config ./test/jest-e2e.json --runInBand
- pnpm --filter @my-resume/server build
- pnpm run typecheck
- pnpm run build

Closes #13