### PR TITLE
feat(m2): add viewer read-only guards

### DIFF
--- a/apps/admin/app/globals.css
+++ b/apps/admin/app/globals.css
@@ -152,6 +152,20 @@ input {
   font-size: 0.9rem;
 }
 
+.readonly-box {
+  padding: 1rem;
+  border-radius: 16px;
+  background: #fff7ed;
+  border: 1px solid #fdba74;
+  color: #9a3412;
+}
+
+.action-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+}
+
 @media (max-width: 960px) {
   .page-shell {
     grid-template-columns: minmax(0, 1fr);
@@ -160,6 +174,10 @@ input {
   }
 
   .info-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .action-grid {
     grid-template-columns: 1fr;
   }
 }

--- a/apps/admin/components/admin-dashboard-shell.tsx
+++ b/apps/admin/components/admin-dashboard-shell.tsx
@@ -3,19 +3,24 @@
 import Link from 'next/link';
 import { useEffect, useState } from 'react';
 
-import { fetchCurrentUser } from '../lib/auth-api';
+import { fetchCurrentUser, postProtectedAction } from '../lib/auth-api';
 import { AuthUserView } from '../lib/auth-types';
 import { DEFAULT_API_BASE_URL } from '../lib/env';
 import {
   clearAccessToken,
   readAccessToken,
 } from '../lib/session-storage';
+import { RoleActionPanel } from './role-action-panel';
 
 export function AdminDashboardShell() {
   const [status, setStatus] = useState<'loading' | 'ready' | 'unauthorized'>(
     'loading',
   );
   const [currentUser, setCurrentUser] = useState<AuthUserView | null>(null);
+  const [pendingAction, setPendingAction] = useState<
+    'publish' | 'ai-analysis' | null
+  >(null);
+  const [feedbackMessage, setFeedbackMessage] = useState<string | null>(null);
 
   useEffect(() => {
     const accessToken = readAccessToken();
@@ -61,6 +66,37 @@ export function AdminDashboardShell() {
     );
   }
 
+  async function handleProtectedAction(pathname: '/auth/demo/publish' | '/auth/demo/ai-analysis') {
+    const accessToken = readAccessToken();
+
+    if (!accessToken) {
+      setStatus('unauthorized');
+      return;
+    }
+
+    const nextPendingAction =
+      pathname === '/auth/demo/publish' ? 'publish' : 'ai-analysis';
+
+    setPendingAction(nextPendingAction);
+    setFeedbackMessage(null);
+
+    try {
+      const result = await postProtectedAction({
+        apiBaseUrl: DEFAULT_API_BASE_URL,
+        accessToken,
+        pathname,
+      });
+
+      setFeedbackMessage(result.message);
+    } catch (error) {
+      setFeedbackMessage(
+        error instanceof Error ? error.message : '操作失败，请稍后重试',
+      );
+    } finally {
+      setPendingAction(null);
+    }
+  }
+
   return (
     <main className="page-shell single-card">
       <section className="card stack">
@@ -92,6 +128,14 @@ export function AdminDashboardShell() {
             </strong>
           </div>
         </div>
+
+        <RoleActionPanel
+          currentUser={currentUser}
+          feedbackMessage={feedbackMessage}
+          onPublish={() => handleProtectedAction('/auth/demo/publish')}
+          onTriggerAi={() => handleProtectedAction('/auth/demo/ai-analysis')}
+          pendingAction={pendingAction}
+        />
 
         <button
           onClick={() => {

--- a/apps/admin/components/role-action-panel.spec.tsx
+++ b/apps/admin/components/role-action-panel.spec.tsx
@@ -1,0 +1,68 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import { RoleActionPanel } from './role-action-panel';
+
+const viewerUser = {
+  id: 'viewer-demo-user',
+  username: 'viewer',
+  role: 'viewer' as const,
+  isActive: true,
+  capabilities: {
+    canPublishResume: false,
+    canTriggerAiAnalysis: false,
+  },
+};
+
+const adminUser = {
+  id: 'admin-demo-user',
+  username: 'admin',
+  role: 'admin' as const,
+  isActive: true,
+  capabilities: {
+    canPublishResume: true,
+    canTriggerAiAnalysis: true,
+  },
+};
+
+describe('RoleActionPanel', () => {
+  it('should show viewer read-only notice and disable sensitive actions', () => {
+    render(
+      <RoleActionPanel
+        currentUser={viewerUser}
+        onPublish={vi.fn()}
+        onTriggerAi={vi.fn()}
+        pendingAction={null}
+        feedbackMessage={null}
+      />,
+    );
+
+    expect(screen.getByText('当前账号为 viewer，只能查看，不能修改或触发真实操作。')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '发布简历（管理员）' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: '触发 AI 分析（管理员）' })).toBeDisabled();
+  });
+
+  it('should enable sensitive actions for admin', async () => {
+    const user = userEvent.setup();
+    const onPublish = vi.fn().mockResolvedValue(undefined);
+    const onTriggerAi = vi.fn().mockResolvedValue(undefined);
+    cleanup();
+
+    render(
+      <RoleActionPanel
+        currentUser={adminUser}
+        onPublish={onPublish}
+        onTriggerAi={onTriggerAi}
+        pendingAction={null}
+        feedbackMessage={null}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: '发布简历（管理员）' }));
+    await user.click(screen.getByRole('button', { name: '触发 AI 分析（管理员）' }));
+
+    expect(onPublish).toHaveBeenCalled();
+    expect(onTriggerAi).toHaveBeenCalled();
+  });
+});

--- a/apps/admin/components/role-action-panel.tsx
+++ b/apps/admin/components/role-action-panel.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { AuthUserView } from '../lib/auth-types';
+
+interface RoleActionPanelProps {
+  currentUser: AuthUserView;
+  pendingAction: 'publish' | 'ai-analysis' | null;
+  feedbackMessage: string | null;
+  onPublish: () => Promise<void>;
+  onTriggerAi: () => Promise<void>;
+}
+
+export function RoleActionPanel({
+  currentUser,
+  pendingAction,
+  feedbackMessage,
+  onPublish,
+  onTriggerAi,
+}: RoleActionPanelProps) {
+  const isViewer = currentUser.role === 'viewer';
+
+  return (
+    <section className="card stack">
+      <div>
+        <p className="eyebrow">角色体验</p>
+        <h2>viewer / admin 能力边界</h2>
+        <p className="muted">
+          当前阶段用最小演示动作验证“viewer 只读、admin 可写”。
+        </p>
+      </div>
+
+      {isViewer ? (
+        <div className="readonly-box">
+          当前账号为 viewer，只能查看，不能修改或触发真实操作。
+        </div>
+      ) : (
+        <div className="status-box">
+          当前账号为 admin，可执行发布与 AI 分析等敏感动作。
+        </div>
+      )}
+
+      <div className="action-grid">
+        <button
+          disabled={isViewer || pendingAction !== null}
+          onClick={() => void onPublish()}
+          type="button"
+        >
+          {pendingAction === 'publish' ? '发布中...' : '发布简历（管理员）'}
+        </button>
+        <button
+          disabled={isViewer || pendingAction !== null}
+          onClick={() => void onTriggerAi()}
+          type="button"
+        >
+          {pendingAction === 'ai-analysis'
+            ? '触发中...'
+            : '触发 AI 分析（管理员）'}
+        </button>
+      </div>
+
+      {feedbackMessage ? <p className="muted">{feedbackMessage}</p> : null}
+    </section>
+  );
+}

--- a/apps/admin/lib/auth-api.spec.ts
+++ b/apps/admin/lib/auth-api.spec.ts
@@ -1,6 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { fetchCurrentUser, loginWithPassword } from './auth-api';
+import {
+  fetchCurrentUser,
+  loginWithPassword,
+  postProtectedAction,
+} from './auth-api';
 
 describe('auth api client', () => {
   beforeEach(() => {
@@ -78,5 +82,34 @@ describe('auth api client', () => {
       }),
     );
     expect(currentUser.username).toBe('viewer');
+  });
+
+  it('should post protected action with bearer token', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          message: 'ok',
+        }),
+      }),
+    );
+
+    const response = await postProtectedAction({
+      apiBaseUrl: 'http://localhost:3001',
+      accessToken: 'demo-token',
+      pathname: '/auth/demo/publish',
+    });
+
+    expect(fetch).toHaveBeenCalledWith(
+      'http://localhost:3001/auth/demo/publish',
+      expect.objectContaining({
+        method: 'POST',
+        headers: {
+          Authorization: 'Bearer demo-token',
+        },
+      }),
+    );
+    expect(response.message).toBe('ok');
   });
 });

--- a/apps/admin/lib/auth-api.ts
+++ b/apps/admin/lib/auth-api.ts
@@ -11,6 +11,14 @@ interface FetchCurrentUserInput {
   accessToken: string;
 }
 
+interface PostProtectedActionInput extends FetchCurrentUserInput {
+  pathname: string;
+}
+
+interface ProtectedActionResponse {
+  message: string;
+}
+
 function joinApiUrl(apiBaseUrl: string, pathname: string): string {
   return `${apiBaseUrl.replace(/\/$/, '')}${pathname}`;
 }
@@ -54,4 +62,21 @@ export async function fetchCurrentUser(
   };
 
   return payload.user;
+}
+
+export async function postProtectedAction(
+  input: PostProtectedActionInput,
+): Promise<ProtectedActionResponse> {
+  const response = await fetch(joinApiUrl(input.apiBaseUrl, input.pathname), {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${input.accessToken}`,
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error('当前角色无权执行该操作');
+  }
+
+  return (await response.json()) as ProtectedActionResponse;
 }

--- a/apps/server/src/modules/auth/auth-demo.controller.ts
+++ b/apps/server/src/modules/auth/auth-demo.controller.ts
@@ -1,0 +1,53 @@
+import {
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
+
+import { CurrentAuthUser } from './decorators/current-auth-user.decorator';
+import { RequireCapability } from './decorators/require-capability.decorator';
+import type { AuthUser } from './domain/auth-user';
+import { AuthService } from './auth.service';
+import { JwtAuthGuard } from './guards/jwt-auth.guard';
+import { RoleCapabilitiesGuard } from './guards/role-capabilities.guard';
+
+@Controller('auth/demo')
+@UseGuards(JwtAuthGuard)
+export class AuthDemoController {
+  constructor(private readonly authService: AuthService) {}
+
+  @Get('viewer-experience')
+  getViewerExperience(@CurrentAuthUser() authUser: AuthUser) {
+    const user = this.authService.serializeUser(authUser);
+
+    return {
+      message: 'viewer read-only experience is available',
+      user,
+    };
+  }
+
+  @Post('publish')
+  @HttpCode(HttpStatus.OK)
+  @UseGuards(RoleCapabilitiesGuard)
+  @RequireCapability('canPublishResume')
+  publishResume(@CurrentAuthUser() authUser: AuthUser) {
+    return {
+      message: 'publish action is available for current role',
+      user: this.authService.serializeUser(authUser),
+    };
+  }
+
+  @Post('ai-analysis')
+  @HttpCode(HttpStatus.OK)
+  @UseGuards(RoleCapabilitiesGuard)
+  @RequireCapability('canTriggerAiAnalysis')
+  triggerAiAnalysis(@CurrentAuthUser() authUser: AuthUser) {
+    return {
+      message: 'ai analysis action is available for current role',
+      user: this.authService.serializeUser(authUser),
+    };
+  }
+}

--- a/apps/server/src/modules/auth/auth.module.ts
+++ b/apps/server/src/modules/auth/auth.module.ts
@@ -2,8 +2,10 @@ import { Module } from '@nestjs/common';
 import { JwtModule } from '@nestjs/jwt';
 
 import { AuthController } from './auth.controller';
+import { AuthDemoController } from './auth-demo.controller';
 import { AuthService } from './auth.service';
 import { JwtAuthGuard } from './guards/jwt-auth.guard';
+import { RoleCapabilitiesGuard } from './guards/role-capabilities.guard';
 
 @Module({
   imports: [
@@ -14,8 +16,8 @@ import { JwtAuthGuard } from './guards/jwt-auth.guard';
       },
     }),
   ],
-  controllers: [AuthController],
-  providers: [AuthService, JwtAuthGuard],
+  controllers: [AuthController, AuthDemoController],
+  providers: [AuthService, JwtAuthGuard, RoleCapabilitiesGuard],
   exports: [AuthService],
 })
 export class AuthModule {}

--- a/apps/server/src/modules/auth/decorators/require-capability.decorator.ts
+++ b/apps/server/src/modules/auth/decorators/require-capability.decorator.ts
@@ -1,0 +1,8 @@
+import { SetMetadata } from '@nestjs/common';
+
+import type { RoleCapabilityKey } from '../domain/auth-role-policy';
+
+export const REQUIRED_ROLE_CAPABILITY = 'required-role-capability';
+
+export const RequireCapability = (capability: RoleCapabilityKey) =>
+  SetMetadata(REQUIRED_ROLE_CAPABILITY, capability);

--- a/apps/server/src/modules/auth/domain/auth-role-policy.ts
+++ b/apps/server/src/modules/auth/domain/auth-role-policy.ts
@@ -9,6 +9,8 @@ export interface RoleCapabilities {
   canTriggerAiAnalysis: boolean;
 }
 
+export type RoleCapabilityKey = keyof RoleCapabilities;
+
 const ROLE_CAPABILITIES: Record<UserRole, RoleCapabilities> = {
   [UserRole.ADMIN]: {
     canAccessAdminSurface: true,

--- a/apps/server/src/modules/auth/guards/role-capabilities.guard.ts
+++ b/apps/server/src/modules/auth/guards/role-capabilities.guard.ts
@@ -1,0 +1,45 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+  Injectable,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+
+import {
+  buildRoleCapabilities,
+  RoleCapabilityKey,
+} from '../domain/auth-role-policy';
+import { AuthenticatedRequest } from '../interfaces/authenticated-request.interface';
+import { REQUIRED_ROLE_CAPABILITY } from '../decorators/require-capability.decorator';
+
+@Injectable()
+export class RoleCapabilitiesGuard implements CanActivate {
+  constructor(private readonly reflector: Reflector) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const capability = this.reflector.getAllAndOverride<RoleCapabilityKey>(
+      REQUIRED_ROLE_CAPABILITY,
+      [context.getHandler(), context.getClass()],
+    );
+
+    if (!capability) {
+      return true;
+    }
+
+    const request = context.switchToHttp().getRequest<AuthenticatedRequest>();
+    const authUser = request.authUser;
+
+    if (!authUser) {
+      throw new ForbiddenException('Authentication context is missing');
+    }
+
+    const capabilities = buildRoleCapabilities(authUser.role);
+
+    if (!capabilities[capability]) {
+      throw new ForbiddenException('Current role is read-only');
+    }
+
+    return true;
+  }
+}

--- a/apps/server/test/auth-viewer-access.e2e-spec.ts
+++ b/apps/server/test/auth-viewer-access.e2e-spec.ts
@@ -1,0 +1,88 @@
+import { INestApplication } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import request from 'supertest';
+import { App } from 'supertest/types';
+
+import { AppModule } from './../src/app.module';
+
+describe('Auth viewer access (e2e)', () => {
+  let app: INestApplication<App>;
+
+  beforeEach(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('should allow viewer to read demo access summary', async () => {
+    const loginResponse = await request(app.getHttpServer())
+      .post('/auth/login')
+      .send({
+        username: 'viewer',
+        password: 'viewer123456',
+      })
+      .expect(200);
+
+    await request(app.getHttpServer())
+      .get('/auth/demo/viewer-experience')
+      .set('Authorization', `Bearer ${loginResponse.body.accessToken as string}`)
+      .expect(200);
+  });
+
+  it('should reject viewer when publishing demo content', async () => {
+    const loginResponse = await request(app.getHttpServer())
+      .post('/auth/login')
+      .send({
+        username: 'viewer',
+        password: 'viewer123456',
+      })
+      .expect(200);
+
+    await request(app.getHttpServer())
+      .post('/auth/demo/publish')
+      .set('Authorization', `Bearer ${loginResponse.body.accessToken as string}`)
+      .expect(403);
+  });
+
+  it('should reject viewer when triggering ai demo action', async () => {
+    const loginResponse = await request(app.getHttpServer())
+      .post('/auth/login')
+      .send({
+        username: 'viewer',
+        password: 'viewer123456',
+      })
+      .expect(200);
+
+    await request(app.getHttpServer())
+      .post('/auth/demo/ai-analysis')
+      .set('Authorization', `Bearer ${loginResponse.body.accessToken as string}`)
+      .expect(403);
+  });
+
+  it('should allow admin to execute sensitive demo actions', async () => {
+    const loginResponse = await request(app.getHttpServer())
+      .post('/auth/login')
+      .send({
+        username: 'admin',
+        password: 'admin123456',
+      })
+      .expect(200);
+
+    await request(app.getHttpServer())
+      .post('/auth/demo/publish')
+      .set('Authorization', `Bearer ${loginResponse.body.accessToken as string}`)
+      .expect(200);
+
+    await request(app.getHttpServer())
+      .post('/auth/demo/ai-analysis')
+      .set('Authorization', `Bearer ${loginResponse.body.accessToken as string}`)
+      .expect(200);
+  });
+});

--- a/docs/30-开发日志/M2-issue-09-viewer-只读守卫与体验.md
+++ b/docs/30-开发日志/M2-issue-09-viewer-只读守卫与体验.md
@@ -1,0 +1,180 @@
+# M2 / issue-09 viewer 只读守卫与体验
+
+- Issue：`#15`
+- 里程碑：`M2 鉴权与角色：最小登录闭环`
+- 分支：`feat/m2-issue-09-viewer-readonly`
+- 日期：`2026-03-24`
+
+## 背景
+
+`issue-08` 已完成 `apps/admin` 最小登录壳，但目前“viewer 只能读、不能写、不能触发敏感动作”的边界还只是角色能力定义，没有真正落到接口守卫和页面体验里。  
+本轮要把这条边界正式落地，避免后续内容管理、发布、AI 工具链接入时角色语义再次分叉。
+
+## 本次目标
+
+- 在 `apps/server` 落地最小角色能力守卫
+- 明确 `viewer` 可读、不可写、不可触发敏感动作
+- 在 `apps/admin` 最小后台壳中体现只读限制
+
+## 非目标
+
+- 不进入真实内容发布实现
+- 不进入 AI 能力实现
+- 不进入缓存报告实现
+- 不扩展完整后台功能
+
+## TDD / 测试设计
+
+### `apps/server`
+
+- 新增 `apps/server/test/auth-viewer-access.e2e-spec.ts`
+- 先描述四个场景：
+  - `viewer` 可访问只读体验接口
+  - `viewer` 调用发布动作返回 `403`
+  - `viewer` 调用 AI 动作返回 `403`
+  - `admin` 可执行两个敏感动作
+
+### `apps/admin`
+
+- 扩展 `apps/admin/lib/auth-api.spec.ts`
+  - 最小受保护动作请求必须携带 `Bearer Token`
+- 新增 `apps/admin/components/role-action-panel.spec.tsx`
+  - `viewer` 应显示只读提示并禁用按钮
+  - `admin` 应可点击敏感动作按钮
+
+### 首次失败记录
+
+- `pnpm --filter @my-resume/server exec jest --config ./test/jest-e2e.json --runInBand test/auth-viewer-access.e2e-spec.ts`
+- 结果：失败
+- 原因：缺少 `demo` 受保护路由
+
+- `pnpm --filter @my-resume/admin test`
+- 结果：失败
+- 原因：
+  - 缺少 `postProtectedAction`
+  - 缺少 `RoleActionPanel`
+
+## 实际改动
+
+### `apps/server`
+
+- 新增 `AuthDemoController`
+  - `GET /auth/demo/viewer-experience`
+  - `POST /auth/demo/publish`
+  - `POST /auth/demo/ai-analysis`
+- 新增 `RequireCapability` 装饰器
+- 新增 `RoleCapabilitiesGuard`
+- 在角色策略中导出 `RoleCapabilityKey`
+- 将敏感动作接口显式切换为 `200 OK`
+
+### `apps/admin`
+
+- 在 `auth-api` 中新增 `postProtectedAction`
+- 新增 `RoleActionPanel`
+- 在 `AdminDashboardShell` 中接入角色体验区
+  - `viewer` 显示只读提示
+  - `admin` 可触发演示动作
+  - 返回动作反馈消息
+- 补充相关样式
+
+## Review 记录
+
+### 是否符合当前 Issue 与里程碑目标
+
+符合。当前只做了：
+
+- 最小角色能力守卫
+- 最小受保护 demo 动作
+- 最小后台只读体验落地
+
+没有提前进入：
+
+- 真实发布业务
+- 真实 AI 任务
+- 后台复杂权限矩阵
+- 完整管理台功能
+
+### 是否存在可继续抽离的点
+
+- `RoleCapabilitiesGuard` 与 `RequireCapability` 已经沉淀为后续模块可复用基础件
+- `RoleActionPanel` 后续可进一步演进为更通用的后台动作面板
+- 当前阶段保留 `AuthDemoController` 作为教学型最小验证载体，不再提前拆业务模块
+
+### Review 结论
+
+- 通过
+- 进入自测
+
+## 自测结果
+
+### 1. `apps/admin` 单测
+
+- `pnpm --filter @my-resume/admin test`
+- 结果：通过
+
+### 2. `apps/server` viewer 边界 E2E
+
+- `pnpm --filter @my-resume/server exec jest --config ./test/jest-e2e.json --runInBand test/auth-viewer-access.e2e-spec.ts`
+- 结果：通过
+
+### 3. `apps/server` 全量单测
+
+- `pnpm --filter @my-resume/server exec jest --runInBand`
+- 结果：通过
+
+### 4. `apps/server` 全量 E2E
+
+- `pnpm --filter @my-resume/server exec jest --config ./test/jest-e2e.json --runInBand`
+- 结果：通过
+
+### 5. `apps/server` 构建
+
+- `pnpm --filter @my-resume/server build`
+- 结果：通过
+
+### 6. `apps/admin` 类型检查与构建
+
+- `pnpm --filter @my-resume/admin typecheck`
+- 结果：通过
+- `pnpm --filter @my-resume/admin build`
+- 结果：通过
+- 备注：依然存在 Tailwind `content` warning，但本轮未引入 Tailwind 方案，不影响当前教学目标
+
+### 7. 真实浏览器联调
+
+- 启动：
+  - `pnpm --filter @my-resume/server start`
+  - `pnpm --filter @my-resume/admin dev --hostname 127.0.0.1 --port 3000`
+- 结果：
+  - 使用 `viewer / viewer123456` 登录后，进入 `/dashboard`
+  - 只读提示正确显示
+  - “发布简历 / 触发 AI 分析” 按钮禁用
+  - 使用 `admin / admin123456` 登录后，两个按钮可点击
+  - 点击后收到成功反馈消息
+
+## 遇到的问题
+
+### 1. 只定义角色能力还不够
+
+- 风险：如果没有真正落到 guard 和接口，角色语义很容易只停留在“文档层”
+- 处理：通过 `RequireCapability + RoleCapabilitiesGuard` 把角色能力绑定到具体接口
+
+### 2. 前端只显示角色字段还不够
+
+- 风险：用户看得到 `viewer`，但不知道它为什么只读
+- 处理：显式增加只读提示与禁用按钮，直接把角色语义表达出来
+
+### 3. 组件测试要注意用例之间的 DOM 清理
+
+- 现象：`RoleActionPanel` 两个测试连续渲染时出现重复按钮查询
+- 处理：在第二个用例前手动 `cleanup()`
+
+## 可沉淀为教程 / 博客的点
+
+- 为什么“viewer 只读”必须同时落在后端守卫与前端体验上
+- 如何把角色能力从静态策略推进到可验证接口
+- 教程型项目里如何用 demo 动作验证权限边界，而不提前进入真实业务
+
+## 后续待办
+
+- M2 已完成，可进入 M3 / issue-10：双语内容模型


### PR DESCRIPTION
## Summary
- add capability-based guards and demo protected endpoints in apps/server
- land viewer read-only experience in the admin dashboard shell
- add server e2e, admin tests, browser validation and devlog for issue-09

## Test Plan
- pnpm --filter @my-resume/admin test
- pnpm --filter @my-resume/admin typecheck
- pnpm --filter @my-resume/admin build
- pnpm --filter @my-resume/server exec jest --runInBand
- pnpm --filter @my-resume/server exec jest --config ./test/jest-e2e.json --runInBand
- pnpm --filter @my-resume/server build
- browser check: viewer read-only + admin sensitive actions

Closes #15