### PR TITLE
feat(m4): add ai provider adapter

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,32 @@
+NODE_ENV=development
+
+# 服务监听配置
+PORT=6789
+API_HOST=0.0.0.0
+
+# 允许跨域的前端来源，多个地址用英文逗号分隔
+CORS_ORIGINS=http://localhost:5945,http://127.0.0.1:5945,http://10.10.70.216:5945
+
+# 数据库
+
+# 鉴权
+JWT_SECRET=replace-with-your-own-secret
+
+# AI Provider 配置示例
+# mock / qiniu / deepseek / openai-compatible
+AI_PROVIDER=qiniu
+
+# 七牛云（OpenAI-compatible）
+QINIU_AI_API_KEY=replace-with-your-own-key
+QINIU_AI_BASE_URL=https://api.qnaigc.com/v1
+QINIU_AI_MODEL=deepseek-v3
+
+# DeepSeek（OpenAI-compatible）
+# DEEPSEEK_API_KEY=replace-with-your-own-key
+# DEEPSEEK_BASE_URL=https://api.deepseek.com/v1
+# DEEPSEEK_MODEL=deepseek-chat
+
+# 其他 OpenAI-compatible Provider
+# OPENAI_COMPATIBLE_API_KEY=replace-with-your-own-key
+# OPENAI_COMPATIBLE_BASE_URL=https://your-provider.example.com/v1
+# OPENAI_COMPATIBLE_MODEL=your-model

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+.nuxt
+.local

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -21,9 +21,11 @@
   },
   "dependencies": {
     "@nestjs/common": "^11.0.1",
+    "@nestjs/config": "^4.0.3",
     "@nestjs/core": "^11.0.1",
     "@nestjs/jwt": "^11.0.2",
     "@nestjs/platform-express": "^11.0.1",
+    "dotenv": "^17.3.1",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1"
   },

--- a/apps/server/src/app.module.ts
+++ b/apps/server/src/app.module.ts
@@ -1,10 +1,21 @@
 import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+
+import { buildServerEnvFilePaths } from './config/env-paths';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { AiModule } from './modules/ai/ai.module';
 import { AuthModule } from './modules/auth/auth.module';
 
 @Module({
-  imports: [AuthModule],
+  imports: [
+    ConfigModule.forRoot({
+      isGlobal: true,
+      envFilePath: buildServerEnvFilePaths(process.env.NODE_ENV),
+    }),
+    AuthModule,
+    AiModule,
+  ],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/apps/server/src/config/env-paths.spec.ts
+++ b/apps/server/src/config/env-paths.spec.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { buildServerEnvFilePaths } from './env-paths';
+
+describe('buildServerEnvFilePaths', () => {
+  it('should prefer development local env files first', () => {
+    const envFilePaths = buildServerEnvFilePaths('development');
+
+    expect(envFilePaths[0]).toContain('.env.development.local');
+    expect(envFilePaths[1]).toContain('.env.local');
+    expect(envFilePaths[2]).toContain('.env.development');
+    expect(envFilePaths[3]).toContain('.env');
+  });
+});

--- a/apps/server/src/config/env-paths.ts
+++ b/apps/server/src/config/env-paths.ts
@@ -1,0 +1,17 @@
+import { join, resolve } from 'path';
+
+function resolveRepoRoot(): string {
+  return resolve(__dirname, '../../../../');
+}
+
+export function buildServerEnvFilePaths(nodeEnv: string | undefined): string[] {
+  const envName = nodeEnv?.trim() || 'development';
+  const repoRoot = resolveRepoRoot();
+
+  return [
+    join(repoRoot, `.env.${envName}.local`),
+    join(repoRoot, '.env.local'),
+    join(repoRoot, `.env.${envName}`),
+    join(repoRoot, '.env'),
+  ];
+}

--- a/apps/server/src/modules/ai/ai.module.ts
+++ b/apps/server/src/modules/ai/ai.module.ts
@@ -1,0 +1,27 @@
+import { Module } from '@nestjs/common';
+
+import { resolveAiRuntimeConfig } from './config/ai-config';
+import { AiService } from './ai.service';
+import { AI_FETCH, AI_PROVIDER_INSTANCE, AI_RUNTIME_CONFIG } from './ai.tokens';
+import { createAiProvider } from './providers/ai-provider.factory';
+
+@Module({
+  providers: [
+    {
+      provide: AI_RUNTIME_CONFIG,
+      useFactory: () => resolveAiRuntimeConfig(process.env),
+    },
+    {
+      provide: AI_FETCH,
+      useValue: fetch,
+    },
+    {
+      provide: AI_PROVIDER_INSTANCE,
+      inject: [AI_RUNTIME_CONFIG, AI_FETCH],
+      useFactory: createAiProvider,
+    },
+    AiService,
+  ],
+  exports: [AiService],
+})
+export class AiModule {}

--- a/apps/server/src/modules/ai/ai.service.spec.ts
+++ b/apps/server/src/modules/ai/ai.service.spec.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, jest } from '@jest/globals';
+
+import { AiService } from './ai.service';
+import { createAiProvider } from './providers/ai-provider.factory';
+
+describe('AiService', () => {
+  it('should expose the current provider summary through the unified service', async () => {
+    const provider = createAiProvider(
+      {
+        provider: 'mock',
+        mode: 'mock',
+        model: 'mock-resume-advisor',
+      },
+      jest.fn<typeof fetch>(),
+    );
+    const aiService = new AiService(provider);
+
+    expect(aiService.getProviderSummary()).toEqual({
+      provider: 'mock',
+      model: 'mock-resume-advisor',
+      mode: 'mock',
+    });
+  });
+
+  it('should call the current provider via the unified service entry', async () => {
+    const provider = createAiProvider(
+      {
+        provider: 'mock',
+        mode: 'mock',
+        model: 'mock-resume-advisor',
+      },
+      jest.fn<typeof fetch>(),
+    );
+    const aiService = new AiService(provider);
+
+    const result = await aiService.generateText({
+      prompt: '请生成一个简历优化建议摘要',
+    });
+
+    expect(result.text).toContain('简历优化建议摘要');
+  });
+});

--- a/apps/server/src/modules/ai/ai.service.ts
+++ b/apps/server/src/modules/ai/ai.service.ts
@@ -1,0 +1,23 @@
+import { Inject, Injectable } from '@nestjs/common';
+
+import { AI_PROVIDER_INSTANCE } from './ai.tokens';
+import type {
+  AiProvider,
+  GenerateTextInput,
+} from './interfaces/ai-provider.interface';
+
+@Injectable()
+export class AiService {
+  constructor(
+    @Inject(AI_PROVIDER_INSTANCE)
+    private readonly aiProvider: AiProvider,
+  ) {}
+
+  getProviderSummary() {
+    return this.aiProvider.getSummary();
+  }
+
+  generateText(input: GenerateTextInput) {
+    return this.aiProvider.generateText(input);
+  }
+}

--- a/apps/server/src/modules/ai/ai.tokens.ts
+++ b/apps/server/src/modules/ai/ai.tokens.ts
@@ -1,0 +1,3 @@
+export const AI_RUNTIME_CONFIG = Symbol('AI_RUNTIME_CONFIG');
+export const AI_PROVIDER_INSTANCE = Symbol('AI_PROVIDER_INSTANCE');
+export const AI_FETCH = Symbol('AI_FETCH');

--- a/apps/server/src/modules/ai/config/ai-config.spec.ts
+++ b/apps/server/src/modules/ai/config/ai-config.spec.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from '@jest/globals';
+
+import {
+  resolveAiRuntimeConfig,
+  type EnvironmentVariables,
+} from './ai-config';
+
+describe('resolveAiRuntimeConfig', () => {
+  it('should fall back to mock provider when AI_PROVIDER is missing', () => {
+    expect(resolveAiRuntimeConfig({})).toEqual({
+      provider: 'mock',
+      mode: 'mock',
+      model: 'mock-resume-advisor',
+    });
+  });
+
+  it('should resolve qiniu as an openai-compatible provider profile', () => {
+    const env: EnvironmentVariables = {
+      AI_PROVIDER: 'qiniu',
+      QINIU_AI_API_KEY: 'sk-qiniu-demo',
+      QINIU_AI_BASE_URL: 'https://api.qnaigc.com/v1',
+      QINIU_AI_MODEL: 'deepseek-v3',
+    };
+
+    expect(resolveAiRuntimeConfig(env)).toEqual({
+      provider: 'qiniu',
+      mode: 'openai-compatible',
+      apiKey: 'sk-qiniu-demo',
+      baseUrl: 'https://api.qnaigc.com/v1',
+      model: 'deepseek-v3',
+      providerLabel: 'Qiniu AI',
+    });
+  });
+
+  it('should resolve deepseek with default openai-compatible base url', () => {
+    const env: EnvironmentVariables = {
+      AI_PROVIDER: 'deepseek',
+      DEEPSEEK_API_KEY: 'sk-deepseek-demo',
+    };
+
+    expect(resolveAiRuntimeConfig(env)).toEqual({
+      provider: 'deepseek',
+      mode: 'openai-compatible',
+      apiKey: 'sk-deepseek-demo',
+      baseUrl: 'https://api.deepseek.com/v1',
+      model: 'deepseek-chat',
+      providerLabel: 'DeepSeek',
+    });
+  });
+
+  it('should require provider credentials when a real provider is selected', () => {
+    expect(() =>
+      resolveAiRuntimeConfig({
+        AI_PROVIDER: 'qiniu',
+      }),
+    ).toThrow('QINIU_AI_API_KEY is required');
+  });
+});

--- a/apps/server/src/modules/ai/config/ai-config.ts
+++ b/apps/server/src/modules/ai/config/ai-config.ts
@@ -1,0 +1,93 @@
+export type EnvironmentVariables = Partial<Record<string, string | undefined>>;
+
+export type AiRuntimeConfig =
+  | {
+      provider: 'mock';
+      mode: 'mock';
+      model: string;
+    }
+  | {
+      provider: 'qiniu' | 'deepseek' | 'openai-compatible';
+      mode: 'openai-compatible';
+      apiKey: string;
+      baseUrl: string;
+      model: string;
+      providerLabel: string;
+    };
+
+function readRequiredValue(
+  env: EnvironmentVariables,
+  key: string,
+  errorMessage: string,
+): string {
+  const value = env[key]?.trim();
+
+  if (!value) {
+    throw new Error(errorMessage);
+  }
+
+  return value;
+}
+
+export function resolveAiRuntimeConfig(
+  env: EnvironmentVariables,
+): AiRuntimeConfig {
+  const provider = env.AI_PROVIDER?.trim().toLowerCase();
+
+  if (!provider || provider === 'mock') {
+    return {
+      provider: 'mock',
+      mode: 'mock',
+      model: 'mock-resume-advisor',
+    };
+  }
+
+  if (provider === 'qiniu') {
+    return {
+      provider: 'qiniu',
+      mode: 'openai-compatible',
+      apiKey: readRequiredValue(env, 'QINIU_AI_API_KEY', 'QINIU_AI_API_KEY is required'),
+      baseUrl:
+        env.QINIU_AI_BASE_URL?.trim() || 'https://api.qnaigc.com/v1',
+      model: env.QINIU_AI_MODEL?.trim() || 'deepseek-v3',
+      providerLabel: 'Qiniu AI',
+    };
+  }
+
+  if (provider === 'deepseek') {
+    return {
+      provider: 'deepseek',
+      mode: 'openai-compatible',
+      apiKey: readRequiredValue(env, 'DEEPSEEK_API_KEY', 'DEEPSEEK_API_KEY is required'),
+      baseUrl:
+        env.DEEPSEEK_BASE_URL?.trim() || 'https://api.deepseek.com/v1',
+      model: env.DEEPSEEK_MODEL?.trim() || 'deepseek-chat',
+      providerLabel: 'DeepSeek',
+    };
+  }
+
+  if (provider === 'openai-compatible') {
+    return {
+      provider: 'openai-compatible',
+      mode: 'openai-compatible',
+      apiKey: readRequiredValue(
+        env,
+        'OPENAI_COMPATIBLE_API_KEY',
+        'OPENAI_COMPATIBLE_API_KEY is required',
+      ),
+      baseUrl: readRequiredValue(
+        env,
+        'OPENAI_COMPATIBLE_BASE_URL',
+        'OPENAI_COMPATIBLE_BASE_URL is required',
+      ),
+      model: readRequiredValue(
+        env,
+        'OPENAI_COMPATIBLE_MODEL',
+        'OPENAI_COMPATIBLE_MODEL is required',
+      ),
+      providerLabel: 'OpenAI Compatible',
+    };
+  }
+
+  throw new Error(`Unsupported AI_PROVIDER: ${provider}`);
+}

--- a/apps/server/src/modules/ai/interfaces/ai-provider.interface.ts
+++ b/apps/server/src/modules/ai/interfaces/ai-provider.interface.ts
@@ -1,0 +1,21 @@
+export interface GenerateTextInput {
+  prompt: string;
+  systemPrompt?: string;
+  temperature?: number;
+}
+
+export interface GenerateTextResult {
+  provider: string;
+  model: string;
+  text: string;
+  raw?: unknown;
+}
+
+export interface AiProvider {
+  getSummary(): {
+    provider: string;
+    model: string;
+    mode: string;
+  };
+  generateText(input: GenerateTextInput): Promise<GenerateTextResult>;
+}

--- a/apps/server/src/modules/ai/providers/ai-provider.factory.ts
+++ b/apps/server/src/modules/ai/providers/ai-provider.factory.ts
@@ -1,0 +1,17 @@
+import { AiRuntimeConfig } from '../config/ai-config';
+import { AiProvider } from '../interfaces/ai-provider.interface';
+import { MockAiProvider } from './mock-ai.provider';
+import { OpenAiCompatibleAiProvider } from './openai-compatible-ai.provider';
+
+type FetchLike = typeof fetch;
+
+export function createAiProvider(
+  config: AiRuntimeConfig,
+  fetchFn: FetchLike,
+): AiProvider {
+  if (config.mode === 'mock') {
+    return new MockAiProvider(config);
+  }
+
+  return new OpenAiCompatibleAiProvider(config, fetchFn);
+}

--- a/apps/server/src/modules/ai/providers/mock-ai.provider.spec.ts
+++ b/apps/server/src/modules/ai/providers/mock-ai.provider.spec.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { MockAiProvider } from './mock-ai.provider';
+
+describe('MockAiProvider', () => {
+  it('should return stable fake analysis content for teaching mode', async () => {
+    const provider = new MockAiProvider({
+      provider: 'mock',
+      mode: 'mock',
+      model: 'mock-resume-advisor',
+    });
+
+    const result = await provider.generateText({
+      prompt: '请分析这份简历与 JD 的匹配度',
+      systemPrompt: '你是一名简历顾问',
+    });
+
+    expect(result.provider).toBe('mock');
+    expect(result.model).toBe('mock-resume-advisor');
+    expect(result.text).toContain('Mock AI response');
+    expect(result.text).toContain('请分析这份简历与 JD 的匹配度');
+  });
+});

--- a/apps/server/src/modules/ai/providers/mock-ai.provider.ts
+++ b/apps/server/src/modules/ai/providers/mock-ai.provider.ts
@@ -1,0 +1,37 @@
+import { AiRuntimeConfig } from '../config/ai-config';
+import {
+  AiProvider,
+  GenerateTextInput,
+  GenerateTextResult,
+} from '../interfaces/ai-provider.interface';
+
+export class MockAiProvider implements AiProvider {
+  constructor(
+    private readonly config: Extract<AiRuntimeConfig, { mode: 'mock' }>,
+  ) {}
+
+  getSummary() {
+    return {
+      provider: this.config.provider,
+      model: this.config.model,
+      mode: this.config.mode,
+    };
+  }
+
+  async generateText(input: GenerateTextInput): Promise<GenerateTextResult> {
+    const fragments = [
+      'Mock AI response',
+      input.systemPrompt ? `system=${input.systemPrompt}` : null,
+      `prompt=${input.prompt}`,
+    ].filter(Boolean);
+
+    return {
+      provider: this.config.provider,
+      model: this.config.model,
+      text: fragments.join(' | '),
+      raw: {
+        mocked: true,
+      },
+    };
+  }
+}

--- a/apps/server/src/modules/ai/providers/openai-compatible-ai.provider.spec.ts
+++ b/apps/server/src/modules/ai/providers/openai-compatible-ai.provider.spec.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, jest } from '@jest/globals';
+
+import { OpenAiCompatibleAiProvider } from './openai-compatible-ai.provider';
+
+describe('OpenAiCompatibleAiProvider', () => {
+  it('should call the chat completions endpoint with unified payload', async () => {
+    const fetchMock = jest.fn<typeof fetch>().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        id: 'chatcmpl-demo',
+        choices: [
+          {
+            message: {
+              content: '这是七牛云兼容接口返回的分析内容',
+            },
+          },
+        ],
+      }),
+    } as Response);
+
+    const provider = new OpenAiCompatibleAiProvider(
+      {
+        provider: 'qiniu',
+        mode: 'openai-compatible',
+        apiKey: 'sk-qiniu-demo',
+        baseUrl: 'https://api.qnaigc.com/v1',
+        model: 'deepseek-v3',
+        providerLabel: 'Qiniu AI',
+      },
+      fetchMock,
+    );
+
+    const result = await provider.generateText({
+      systemPrompt: '你是一名简历顾问',
+      prompt: '请用中文给出三条优化建议',
+      temperature: 0.2,
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.qnaigc.com/v1/chat/completions',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          Authorization: 'Bearer sk-qiniu-demo',
+        }),
+      }),
+    );
+    expect(result.provider).toBe('qiniu');
+    expect(result.model).toBe('deepseek-v3');
+    expect(result.text).toBe('这是七牛云兼容接口返回的分析内容');
+  });
+});

--- a/apps/server/src/modules/ai/providers/openai-compatible-ai.provider.ts
+++ b/apps/server/src/modules/ai/providers/openai-compatible-ai.provider.ts
@@ -1,0 +1,102 @@
+import { AiRuntimeConfig } from '../config/ai-config';
+import {
+  AiProvider,
+  GenerateTextInput,
+  GenerateTextResult,
+} from '../interfaces/ai-provider.interface';
+
+type FetchLike = typeof fetch;
+
+interface OpenAiCompatibleResponse {
+  id?: string;
+  choices?: Array<{
+    message?: {
+      content?: string | Array<{ type: string; text?: string }>;
+    };
+  }>;
+}
+
+function joinChatCompletionsUrl(baseUrl: string): string {
+  return `${baseUrl.replace(/\/$/, '')}/chat/completions`;
+}
+
+function extractMessageContent(response: OpenAiCompatibleResponse): string {
+  const content = response.choices?.[0]?.message?.content;
+
+  if (typeof content === 'string') {
+    return content;
+  }
+
+  if (Array.isArray(content)) {
+    return content
+      .filter((item) => item.type === 'text' && item.text)
+      .map((item) => item.text)
+      .join('\n');
+  }
+
+  throw new Error('Provider response does not include message content');
+}
+
+export class OpenAiCompatibleAiProvider implements AiProvider {
+  constructor(
+    private readonly config: Extract<
+      AiRuntimeConfig,
+      { mode: 'openai-compatible' }
+    >,
+    private readonly fetchFn: FetchLike,
+  ) {}
+
+  getSummary() {
+    return {
+      provider: this.config.provider,
+      model: this.config.model,
+      mode: this.config.mode,
+    };
+  }
+
+  async generateText(input: GenerateTextInput): Promise<GenerateTextResult> {
+    const response = await this.fetchFn(
+      joinChatCompletionsUrl(this.config.baseUrl),
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${this.config.apiKey}`,
+        },
+        body: JSON.stringify({
+          model: this.config.model,
+          temperature: input.temperature ?? 0.2,
+          messages: [
+            ...(input.systemPrompt
+              ? [
+                  {
+                    role: 'system',
+                    content: input.systemPrompt,
+                  },
+                ]
+              : []),
+            {
+              role: 'user',
+              content: input.prompt,
+            },
+          ],
+        }),
+      },
+    );
+
+    if (!response.ok) {
+      throw new Error(
+        `${this.config.providerLabel} request failed with status ${response.status}`,
+      );
+    }
+
+    const payload = (await response.json()) as OpenAiCompatibleResponse;
+
+    return {
+      provider: this.config.provider,
+      model: this.config.model,
+      text: extractMessageContent(payload),
+      raw: payload,
+    };
+  }
+}

--- a/apps/server/src/modules/auth/auth.module.ts
+++ b/apps/server/src/modules/auth/auth.module.ts
@@ -10,7 +10,10 @@ import { RoleCapabilitiesGuard } from './guards/role-capabilities.guard';
 @Module({
   imports: [
     JwtModule.register({
-      secret: process.env.AUTH_JWT_SECRET ?? 'my-resume-dev-jwt-secret',
+      secret:
+        process.env.JWT_SECRET ??
+        process.env.AUTH_JWT_SECRET ??
+        'my-resume-dev-jwt-secret',
       signOptions: {
         expiresIn: '1h',
       },

--- a/docs/30-开发日志/M4-issue-13-provider-适配器接口.md
+++ b/docs/30-开发日志/M4-issue-13-provider-适配器接口.md
@@ -1,0 +1,186 @@
+# M4 / issue-13 provider 适配器接口
+
+- Issue：`#18`
+- 里程碑：`M4 AI 工具链：Mock 到真实 Provider`
+- 分支：`feat/m4-issue-13-ai-provider-adapter`
+- 日期：`2026-03-25`
+
+## 背景
+
+在真正进入文件提取、缓存报告和 AI 工具链前，必须先把 Provider 抽象固定下来。  
+否则后续一旦直接把七牛云、DeepSeek 或其他兼容接口写进业务代码，后面切换模型、切换厂商、补 mock provider 都会越来越痛苦。
+
+这一轮用户已经补了 `.env.development.local`，并明确当前优先使用七牛云兼容接口，因此本轮除了抽适配器，还要把本地环境加载一起接通。
+
+## 本次目标
+
+- 定义统一 AI Provider 接口
+- 支持 `mock` provider
+- 支持 `qiniu / deepseek / openai-compatible` 三类配置解析
+- 提供统一的 `AiService` 入口
+- 让 `apps/server` 可自动读取根目录 `.env.development.local`
+
+## 非目标
+
+- 不实现真实业务 Prompt 编排
+- 不实现文件上传与文本提取
+- 不实现缓存报告
+- 不开放完整 AI API 路由
+
+## TDD / 测试设计
+
+### 配置解析
+
+- 新增 `apps/server/src/modules/ai/config/ai-config.spec.ts`
+- 先锁定：
+  - 未配置时回落到 `mock`
+  - `qiniu` 解析为 OpenAI-compatible profile
+  - `deepseek` 解析为 OpenAI-compatible profile
+  - 缺少必要凭证时报错
+
+### Provider 行为
+
+- 新增 `mock-ai.provider.spec.ts`
+  - `mock` 返回稳定假数据
+- 新增 `openai-compatible-ai.provider.spec.ts`
+  - 统一调用 `/chat/completions`
+  - 正确带上 `Bearer Token`
+
+### 统一服务入口
+
+- 新增 `ai.service.spec.ts`
+  - 暴露当前 provider summary
+  - 通过统一入口调用 provider
+
+### 环境文件顺序
+
+- 新增 `env-paths.spec.ts`
+  - 锁定 `.env.development.local -> .env.local -> .env.development -> .env`
+
+## 首次失败记录
+
+- `pnpm --filter @my-resume/server exec jest --runInBand src/modules/ai/config/ai-config.spec.ts`
+- 结果：失败
+- 原因：缺少 `ai-config`
+
+- `pnpm --filter @my-resume/server exec jest --runInBand src/modules/ai/providers/mock-ai.provider.spec.ts`
+- 结果：失败
+- 原因：缺少 `MockAiProvider`
+
+- `pnpm --filter @my-resume/server exec jest --runInBand src/modules/ai/providers/openai-compatible-ai.provider.spec.ts`
+- 结果：失败
+- 原因：缺少 `OpenAiCompatibleAiProvider`
+
+## 实际改动
+
+### `apps/server`
+
+- 新增 `AiModule`
+- 新增 `AiService`
+- 新增统一接口定义：
+  - `AiProvider`
+  - `GenerateTextInput`
+  - `GenerateTextResult`
+- 新增运行时配置解析：
+  - `resolveAiRuntimeConfig`
+- 新增 provider 实现：
+  - `MockAiProvider`
+  - `OpenAiCompatibleAiProvider`
+- 新增 `createAiProvider` factory
+- 新增环境文件路径解析：
+  - `buildServerEnvFilePaths`
+- 在 `AppModule` 中接入 `ConfigModule`
+- 让 `AuthModule` 同时兼容 `JWT_SECRET` 与旧的 `AUTH_JWT_SECRET`
+
+### 文档与环境示例
+
+- 新增根目录 `.env.example`
+- 补充七牛云、DeepSeek、其他 OpenAI-compatible provider 的示例配置
+
+## Review 记录
+
+### 是否符合当前 Issue 与里程碑目标
+
+符合。当前只做了：
+
+- provider 抽象
+- mock / real-compatible provider 适配层
+- 统一服务入口
+- 本地 env 自动加载
+
+没有提前进入：
+
+- AI 业务接口
+- 文件提取
+- 缓存层
+- prompt 模板体系
+
+### 是否存在可继续抽离的点
+
+- 当前 `AiService` 已经是后续 AI 业务模块的统一入口
+- `OpenAiCompatibleAiProvider` 可继续承接七牛云、DeepSeek、其他兼容厂商
+- 后续若增加 Anthropic / Gemini 等非 OpenAI-compatible 协议，再新增 provider 类即可
+
+### Review 结论
+
+- 通过
+- 可进入自测
+
+## 自测结果
+
+### 1. AI 模块专项测试
+
+- `pnpm --filter @my-resume/server exec jest --runInBand src/modules/ai src/config/env-paths.spec.ts`
+- 结果：通过
+
+### 2. `apps/server` 全量单测
+
+- `pnpm --filter @my-resume/server exec jest --runInBand`
+- 结果：通过
+
+### 3. `apps/server` 全量 E2E
+
+- `pnpm --filter @my-resume/server exec jest --config ./test/jest-e2e.json --runInBand`
+- 结果：通过
+
+### 4. `apps/server` 构建
+
+- `pnpm --filter @my-resume/server build`
+- 结果：通过
+
+### 5. 根级验证
+
+- `pnpm run typecheck`
+- 结果：通过
+- `pnpm run build`
+- 结果：通过
+- 备注：根项目仍存在 `tailwind.config.cjs` 的 ESM warning，但不影响本轮结果
+
+## 遇到的问题
+
+### 1. 只写适配器还不够，本地 env 不会自动读取
+
+- 风险：用户已经写了 `.env.development.local`，但若服务端不主动加载，适配器根本拿不到配置
+- 处理：在 `AppModule` 中接入 `ConfigModule.forRoot()`，并显式指定根目录 env 搜索顺序
+
+### 2. 当前项目里 JWT 变量名与用户实际配置不一致
+
+- 现象：原实现读取 `AUTH_JWT_SECRET`，但用户本地配置写的是 `JWT_SECRET`
+- 处理：兼容两个变量名，优先使用 `JWT_SECRET`
+
+### 3. Provider 抽象很容易一开始就写太重
+
+- 风险：如果过早引入复杂 prompt SDK、工作流层、任务编排，会打乱教程节奏
+- 处理：当前只保留统一 `generateText` 能力，先把抽象和兼容接口站稳
+
+## 可沉淀为教程 / 博客的点
+
+- 为什么 AI 项目第一步不是“接 SDK”，而是先做 provider 适配器
+- 如何用一个 OpenAI-compatible provider 兼容多个厂商
+- 为什么 `.env.development.local` 接好了不代表应用能自动读取
+- mock provider 在教程型项目里有什么价值
+
+## 后续待办
+
+- 继续 `issue-14`：文件提取入口
+- 或按主线回到 `M3 / issue-10`：双语内容模型

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -127,6 +127,9 @@ importers:
       '@nestjs/common':
         specifier: ^11.0.1
         version: 11.1.17(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/config':
+        specifier: ^4.0.3
+        version: 4.0.3(@nestjs/common@11.1.17(reflect-metadata@0.2.2)(rxjs@7.8.2))(rxjs@7.8.2)
       '@nestjs/core':
         specifier: ^11.0.1
         version: 11.1.17(@nestjs/common@11.1.17(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.17)(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -136,6 +139,9 @@ importers:
       '@nestjs/platform-express':
         specifier: ^11.0.1
         version: 11.1.17(@nestjs/common@11.1.17(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.17)
+      dotenv:
+        specifier: ^17.3.1
+        version: 17.3.1
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -1117,6 +1123,12 @@ packages:
         optional: true
       class-validator:
         optional: true
+
+  '@nestjs/config@4.0.3':
+    resolution: {integrity: sha512-FQ3M3Ohqfl+nHAn5tp7++wUQw0f2nAk+SFKe8EpNRnIifPqvfJP6JQxPKtFLMOHbyer4X646prFG4zSRYEssQQ==}
+    peerDependencies:
+      '@nestjs/common': ^10.0.0 || ^11.0.0
+      rxjs: ^7.1.0
 
   '@nestjs/core@11.1.17':
     resolution: {integrity: sha512-lD5mAYekTTurF3vDaa8C2OKPnjiz4tsfxIc5XlcSUzOhkwWf6Ay3HKvt6FmvuWQam6uIIHX52Clg+e6tAvf/cg==}
@@ -2495,6 +2507,22 @@ packages:
 
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
+
+  dotenv-expand@12.0.3:
+    resolution: {integrity: sha512-uc47g4b+4k/M/SeaW1y4OApx+mtLWl92l5LMPP0GNXctZqELk+YGgOPIIC5elYmUH4OuoK3JLhuRUYegeySiFA==}
+    engines: {node: '>=12'}
+
+  dotenv@16.6.1:
+    resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
+    engines: {node: '>=12'}
+
+  dotenv@17.2.3:
+    resolution: {integrity: sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==}
+    engines: {node: '>=12'}
+
+  dotenv@17.3.1:
+    resolution: {integrity: sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==}
+    engines: {node: '>=12'}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -5708,6 +5736,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@nestjs/config@4.0.3(@nestjs/common@11.1.17(reflect-metadata@0.2.2)(rxjs@7.8.2))(rxjs@7.8.2)':
+    dependencies:
+      '@nestjs/common': 11.1.17(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      dotenv: 17.2.3
+      dotenv-expand: 12.0.3
+      lodash: 4.17.23
+      rxjs: 7.8.2
+
   '@nestjs/core@11.1.17(@nestjs/common@11.1.17(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.17)(reflect-metadata@0.2.2)(rxjs@7.8.2)':
     dependencies:
       '@nestjs/common': 11.1.17(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -7098,6 +7134,16 @@ snapshots:
   dom-accessibility-api@0.5.16: {}
 
   dom-accessibility-api@0.6.3: {}
+
+  dotenv-expand@12.0.3:
+    dependencies:
+      dotenv: 16.6.1
+
+  dotenv@16.6.1: {}
+
+  dotenv@17.2.3: {}
+
+  dotenv@17.3.1: {}
 
   dunder-proto@1.0.1:
     dependencies:


### PR DESCRIPTION
## Summary
- add a unified ai provider abstraction in apps/server
- support mock, qiniu, deepseek and generic openai-compatible profiles
- load root env files automatically and document example env config

## Test Plan
- pnpm --filter @my-resume/server exec jest --runInBand src/modules/ai src/config/env-paths.spec.ts
- pnpm --filter @my-resume/server exec jest --runInBand
- pnpm --filter @my-resume/server exec jest --config ./test/jest-e2e.json --runInBand
- pnpm --filter @my-resume/server build
- pnpm run typecheck
- pnpm run build

Closes #18