### PR TITLE
feat(m3): add bilingual resume content model

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10
+          version: 10.8.0
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/apps/server/src/app.module.ts
+++ b/apps/server/src/app.module.ts
@@ -6,6 +6,7 @@ import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { AiModule } from './modules/ai/ai.module';
 import { AuthModule } from './modules/auth/auth.module';
+import { ResumeModule } from './modules/resume/resume.module';
 
 @Module({
   imports: [
@@ -15,6 +16,7 @@ import { AuthModule } from './modules/auth/auth.module';
     }),
     AuthModule,
     AiModule,
+    ResumeModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/apps/server/src/modules/resume/domain/standard-resume.spec.ts
+++ b/apps/server/src/modules/resume/domain/standard-resume.spec.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from '@jest/globals';
+
+import {
+  createEmptyLocalizedText,
+  createEmptyStandardResume,
+  createExampleStandardResume,
+  getStandardResumeModuleKeys,
+  isLocalizedText,
+  validateStandardResume,
+} from './standard-resume';
+
+describe('standard resume domain', () => {
+  it('should expose stable module boundaries for the standard resume', () => {
+    expect(getStandardResumeModuleKeys()).toEqual([
+      'profile',
+      'education',
+      'experiences',
+      'projects',
+      'skills',
+      'highlights',
+    ]);
+  });
+
+  it('should create an empty bilingual resume skeleton', () => {
+    const resume = createEmptyStandardResume();
+
+    expect(resume.meta.defaultLocale).toBe('zh');
+    expect(resume.meta.locales).toEqual(['zh', 'en']);
+    expect(resume.profile.fullName).toEqual({
+      zh: '',
+      en: '',
+    });
+    expect(resume.education).toEqual([]);
+    expect(resume.experiences).toEqual([]);
+    expect(resume.projects).toEqual([]);
+    expect(resume.skills).toEqual([]);
+    expect(resume.highlights).toEqual([]);
+  });
+
+  it('should keep localized text objects strict and bilingual', () => {
+    expect(isLocalizedText(createEmptyLocalizedText())).toBe(true);
+    expect(isLocalizedText({ zh: '你好', en: 'Hello' })).toBe(true);
+    expect(isLocalizedText({ zh: '只有中文' })).toBe(false);
+    expect(isLocalizedText({ zh: '你好', en: 'Hello', ja: 'こんにちは' })).toBe(
+      false,
+    );
+  });
+
+  it('should validate a complete standard resume example', () => {
+    const resume = createExampleStandardResume();
+
+    expect(validateStandardResume(resume)).toEqual({
+      valid: true,
+      errors: [],
+    });
+  });
+
+  it('should reject invalid bilingual content shapes', () => {
+    const resume = createExampleStandardResume() as ReturnType<
+      typeof createExampleStandardResume
+    > & {
+      profile: {
+        fullName: { zh: string };
+      };
+    };
+
+    resume.profile.fullName = {
+      zh: '付寅生',
+    };
+
+    expect(validateStandardResume(resume)).toEqual({
+      valid: false,
+      errors: ['profile.fullName must be a localized text object'],
+    });
+  });
+});

--- a/apps/server/src/modules/resume/domain/standard-resume.ts
+++ b/apps/server/src/modules/resume/domain/standard-resume.ts
@@ -1,0 +1,334 @@
+export type ResumeLocale = 'zh' | 'en';
+
+export interface LocalizedText {
+  zh: string;
+  en: string;
+}
+
+export interface ResumeMeta {
+  slug: 'standard-resume';
+  version: 1;
+  defaultLocale: ResumeLocale;
+  locales: ResumeLocale[];
+}
+
+export interface ResumeProfileLink {
+  label: LocalizedText;
+  url: string;
+}
+
+export interface ResumeProfile {
+  fullName: LocalizedText;
+  headline: LocalizedText;
+  summary: LocalizedText;
+  location: LocalizedText;
+  email: string;
+  phone: string;
+  website: string;
+  links: ResumeProfileLink[];
+  interests: LocalizedText[];
+}
+
+export interface ResumeEducationItem {
+  schoolName: LocalizedText;
+  degree: LocalizedText;
+  fieldOfStudy: LocalizedText;
+  startDate: string;
+  endDate: string;
+  location: LocalizedText;
+  highlights: LocalizedText[];
+}
+
+export interface ResumeExperienceItem {
+  companyName: LocalizedText;
+  role: LocalizedText;
+  employmentType: LocalizedText;
+  startDate: string;
+  endDate: string;
+  location: LocalizedText;
+  summary: LocalizedText;
+  highlights: LocalizedText[];
+  technologies: string[];
+}
+
+export interface ResumeProjectItem {
+  name: LocalizedText;
+  role: LocalizedText;
+  startDate: string;
+  endDate: string;
+  summary: LocalizedText;
+  highlights: LocalizedText[];
+  technologies: string[];
+  links: ResumeProfileLink[];
+}
+
+export interface ResumeSkillGroup {
+  name: LocalizedText;
+  keywords: string[];
+}
+
+export interface ResumeHighlightItem {
+  title: LocalizedText;
+  description: LocalizedText;
+}
+
+export interface StandardResume {
+  meta: ResumeMeta;
+  profile: ResumeProfile;
+  education: ResumeEducationItem[];
+  experiences: ResumeExperienceItem[];
+  projects: ResumeProjectItem[];
+  skills: ResumeSkillGroup[];
+  highlights: ResumeHighlightItem[];
+}
+
+const STANDARD_RESUME_MODULE_KEYS = [
+  'profile',
+  'education',
+  'experiences',
+  'projects',
+  'skills',
+  'highlights',
+] as const;
+
+type StandardResumeModuleKey = (typeof STANDARD_RESUME_MODULE_KEYS)[number];
+
+export interface ResumeValidationResult {
+  valid: boolean;
+  errors: string[];
+}
+
+export function getStandardResumeModuleKeys(): StandardResumeModuleKey[] {
+  return [...STANDARD_RESUME_MODULE_KEYS];
+}
+
+export function createEmptyLocalizedText(): LocalizedText {
+  return {
+    zh: '',
+    en: '',
+  };
+}
+
+export function isLocalizedText(value: unknown): value is LocalizedText {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  const candidate = value as Record<string, unknown>;
+  const keys = Object.keys(candidate).sort();
+
+  return (
+    keys.length === 2 &&
+    keys[0] === 'en' &&
+    keys[1] === 'zh' &&
+    typeof candidate.zh === 'string' &&
+    typeof candidate.en === 'string'
+  );
+}
+
+export function createEmptyStandardResume(): StandardResume {
+  return {
+    meta: {
+      slug: 'standard-resume',
+      version: 1,
+      defaultLocale: 'zh',
+      locales: ['zh', 'en'],
+    },
+    profile: {
+      fullName: createEmptyLocalizedText(),
+      headline: createEmptyLocalizedText(),
+      summary: createEmptyLocalizedText(),
+      location: createEmptyLocalizedText(),
+      email: '',
+      phone: '',
+      website: '',
+      links: [],
+      interests: [],
+    },
+    education: [],
+    experiences: [],
+    projects: [],
+    skills: [],
+    highlights: [],
+  };
+}
+
+export function createExampleStandardResume(): StandardResume {
+  return {
+    meta: {
+      slug: 'standard-resume',
+      version: 1,
+      defaultLocale: 'zh',
+      locales: ['zh', 'en'],
+    },
+    profile: {
+      fullName: {
+        zh: '付寅生',
+        en: 'Yinsheng Fu',
+      },
+      headline: {
+        zh: '全栈开发工程师',
+        en: 'Full-Stack Engineer',
+      },
+      summary: {
+        zh: '专注于前端工程化、Node.js 后端与 AI 工具链落地。',
+        en: 'Focused on frontend engineering, Node.js backend development, and AI workflow integration.',
+      },
+      location: {
+        zh: '中国 上海',
+        en: 'Shanghai, China',
+      },
+      email: 'demo@example.com',
+      phone: '+86 13800000000',
+      website: 'https://example.com',
+      links: [
+        {
+          label: {
+            zh: 'GitHub',
+            en: 'GitHub',
+          },
+          url: 'https://github.com/Fridolph',
+        },
+      ],
+      interests: [
+        {
+          zh: '开源项目',
+          en: 'Open Source',
+        },
+      ],
+    },
+    education: [
+      {
+        schoolName: {
+          zh: '示例大学',
+          en: 'Example University',
+        },
+        degree: {
+          zh: '本科',
+          en: 'Bachelor',
+        },
+        fieldOfStudy: {
+          zh: '软件工程',
+          en: 'Software Engineering',
+        },
+        startDate: '2016-09',
+        endDate: '2020-06',
+        location: {
+          zh: '中国',
+          en: 'China',
+        },
+        highlights: [
+          {
+            zh: '主修软件工程与分布式系统',
+            en: 'Focused on software engineering and distributed systems.',
+          },
+        ],
+      },
+    ],
+    experiences: [
+      {
+        companyName: {
+          zh: '示例科技',
+          en: 'Example Tech',
+        },
+        role: {
+          zh: '前端负责人',
+          en: 'Frontend Lead',
+        },
+        employmentType: {
+          zh: '全职',
+          en: 'Full-time',
+        },
+        startDate: '2022-01',
+        endDate: '至今',
+        location: {
+          zh: '上海',
+          en: 'Shanghai',
+        },
+        summary: {
+          zh: '负责中后台平台前端架构与研发规范建设。',
+          en: 'Led frontend architecture and engineering standards for internal platforms.',
+        },
+        highlights: [
+          {
+            zh: '推动 monorepo 与组件标准化',
+            en: 'Promoted monorepo adoption and UI component standardization.',
+          },
+        ],
+        technologies: ['Vue 3', 'React', 'TypeScript', 'NestJS'],
+      },
+    ],
+    projects: [
+      {
+        name: {
+          zh: '个人简历 Monorepo',
+          en: 'Personal Resume Monorepo',
+        },
+        role: {
+          zh: '作者 / 维护者',
+          en: 'Author / Maintainer',
+        },
+        startDate: '2026-03',
+        endDate: '进行中',
+        summary: {
+          zh: '以教程型方式逐步构建 admin / web / server 三端项目。',
+          en: 'Building an admin / web / server monorepo incrementally as a tutorial-driven project.',
+        },
+        highlights: [
+          {
+            zh: '落地鉴权、AI Provider 适配器与内容建模',
+            en: 'Implemented authentication, AI provider adapters, and content modeling.',
+          },
+        ],
+        technologies: ['Next.js', 'NestJS', 'pnpm workspace', 'Turborepo'],
+        links: [],
+      },
+    ],
+    skills: [
+      {
+        name: {
+          zh: '前端工程化',
+          en: 'Frontend Engineering',
+        },
+        keywords: ['Vue 3', 'React', 'TypeScript', 'Vite'],
+      },
+    ],
+    highlights: [
+      {
+        title: {
+          zh: '教程型开源实践',
+          en: 'Tutorial-driven Open Source Practice',
+        },
+        description: {
+          zh: '强调小步提交、开发日志与里程碑教程沉淀。',
+          en: 'Focused on small commits, dev logs, and milestone-based tutorial outputs.',
+        },
+      },
+    ],
+  };
+}
+
+export function validateStandardResume(resume: StandardResume): ResumeValidationResult {
+  const errors: string[] = [];
+
+  if (!isLocalizedText(resume.profile.fullName)) {
+    errors.push('profile.fullName must be a localized text object');
+  }
+
+  if (!isLocalizedText(resume.profile.headline)) {
+    errors.push('profile.headline must be a localized text object');
+  }
+
+  if (!isLocalizedText(resume.profile.summary)) {
+    errors.push('profile.summary must be a localized text object');
+  }
+
+  if (!isLocalizedText(resume.profile.location)) {
+    errors.push('profile.location must be a localized text object');
+  }
+
+  return {
+    valid: errors.length === 0,
+    errors,
+  };
+}

--- a/apps/server/src/modules/resume/resume.module.ts
+++ b/apps/server/src/modules/resume/resume.module.ts
@@ -1,0 +1,4 @@
+import { Module } from '@nestjs/common';
+
+@Module({})
+export class ResumeModule {}

--- a/docs/30-开发日志/M3-issue-10-双语内容模型.md
+++ b/docs/30-开发日志/M3-issue-10-双语内容模型.md
@@ -1,0 +1,90 @@
+# M3-issue-10-双语内容模型
+
+## 标题
+
+- Issue：`#19`
+- 里程碑：`M3 简历内容与发布流`
+- 分支：`feat/m3-issue-10-bilingual-content-model`
+- 日期：`2026-03-25`
+
+## 背景
+
+`M3` 的第一步不是直接接数据库、CRUD 或发布流，而是先把“标准双语简历”这件事的领域边界定义清楚。
+
+如果内容模型一开始就不稳定，后面无论是后台编辑、公开展示、发布态，还是导出与 AI 分析，都会被反复牵连。对于教程型项目来说，先把数据骨架讲清楚，也更适合读者逐步理解系统是如何长出来的。
+
+## 本次目标
+
+- 为标准版简历建立清晰、稳定的双语内容模型。
+- 明确 v1 简历模块边界，为后续 CRUD 与发布流做准备。
+- 用测试先锁定运行时约束，避免后续结构随意漂移。
+
+## 非目标
+
+- 不接数据库。
+- 不做简历 CRUD 接口。
+- 不做草稿 / 发布态。
+- 不做导出、AI、JD 定制版能力。
+
+## TDD / 测试设计
+
+- 先验证标准简历的模块边界是否稳定。
+- 先验证空白简历骨架是否默认包含 `zh/en` 双语结构。
+- 先验证 `LocalizedText` 是否保持严格的双语字段约束。
+- 先验证一个完整示例数据是否能通过校验。
+- 先验证非法内容结构是否会被识别并返回明确错误。
+
+这样做的目的，是先把“什么是合法的标准双语简历”讲清楚，再去写后面的存储和接口。
+
+## 实际改动
+
+- 新增 `apps/server/src/modules/resume/domain/standard-resume.ts`
+  - 定义 `StandardResume`、`LocalizedText` 以及各模块内容结构。
+  - 提供空白骨架工厂 `createEmptyStandardResume()`。
+  - 提供示例数据工厂 `createExampleStandardResume()`。
+  - 提供基础运行时校验函数 `validateStandardResume()`。
+- 新增 `apps/server/src/modules/resume/domain/standard-resume.spec.ts`
+  - 通过测试锁定模块边界、双语骨架和校验规则。
+- 新增 `apps/server/src/modules/resume/resume.module.ts`
+  - 为后续 `M3` 的 CRUD、发布流和内容服务预留模块边界。
+- 更新 `apps/server/src/app.module.ts`
+  - 将 `ResumeModule` 接入主应用。
+
+## Review 记录
+
+- 是否符合当前 Issue 与里程碑目标：符合。
+  - 当前只完成“标准双语内容模型”这一层，没有提前引入数据库、接口或发布态。
+- 是否存在可抽离的公共能力：有，但本次暂不扩张。
+  - `LocalizedText` 与校验函数后续可逐步抽为更通用的内容建模工具。
+  - 当前阶段保持在 `resume/domain` 内部，更利于教程讲解和读者理解。
+- 是否存在范围膨胀：没有。
+  - 明确没有引入 `resume_variant`、JD 定制版、多模板或导出逻辑。
+
+## 自测结果
+
+- 类型检查：通过
+  - `pnpm run typecheck`
+- Server 单元测试：通过
+  - `pnpm --filter @my-resume/server exec jest --runInBand`
+- Server E2E：通过
+  - `pnpm --filter @my-resume/server exec jest --config ./test/jest-e2e.json --runInBand`
+  - 有 `Jest did not exit one second after the test run has completed` 提示，当前不影响通过，后续可单独排查 open handles。
+- 构建验证：通过
+  - `pnpm --filter @my-resume/server build`
+  - `pnpm run build`
+
+## 遇到的问题
+
+- 问题：如何在教程节奏下控制 `M3` 的范围，避免一上来就把数据表、接口、发布态全部铺满。
+- 解决方式：把本期聚焦为“领域模型 + 测试约束 + 模块边界”，其余内容拆到后续 Issue。
+
+## 可沉淀为教程/博客的点
+
+- 为什么双语简历项目应该先定义内容模型，再接数据库。
+- `LocalizedText` 这种字段级双语结构为什么比后期补丁式国际化更稳。
+- 教程型项目中，如何用 TDD 先锁定领域边界，而不是直接写接口。
+
+## 后续待办
+
+- 继续 `M3` 后续 Issue，例如草稿 / 发布态设计与内容读写流程。
+- 后续补齐数据库表结构、内容服务与公开站读取路径。


### PR DESCRIPTION
## Summary
- add standard bilingual resume domain model for M3 issue-10
- cover module boundaries, empty skeleton, strict localized text and validation by tests
- add issue devlog for tutorial-friendly traceability

## Testing
- pnpm --filter @my-resume/server exec jest --runInBand
- pnpm --filter @my-resume/server exec jest --config ./test/jest-e2e.json --runInBand
- pnpm --filter @my-resume/server build
- pnpm run typecheck
- pnpm run build

Closes #19
