### PR TITLE
feat(m3): add draft and publish flow

### DIFF
--- a/apps/server/src/modules/resume/domain/standard-resume.ts
+++ b/apps/server/src/modules/resume/domain/standard-resume.ts
@@ -308,7 +308,9 @@ export function createExampleStandardResume(): StandardResume {
   };
 }
 
-export function validateStandardResume(resume: StandardResume): ResumeValidationResult {
+export function validateStandardResume(
+  resume: StandardResume,
+): ResumeValidationResult {
   const errors: string[] = [];
 
   if (!isLocalizedText(resume.profile.fullName)) {

--- a/apps/server/src/modules/resume/resume-publication.service.spec.ts
+++ b/apps/server/src/modules/resume/resume-publication.service.spec.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { createExampleStandardResume } from './domain/standard-resume';
+import { ResumePublicationService } from './resume-publication.service';
+
+describe('ResumePublicationService', () => {
+  it('should keep draft editable before publishing', () => {
+    const service = new ResumePublicationService();
+    const nextDraft = createExampleStandardResume();
+
+    nextDraft.profile.headline = {
+      zh: '资深全栈工程师',
+      en: 'Senior Full-Stack Engineer',
+    };
+
+    service.updateDraft(nextDraft);
+
+    expect(service.getDraft().resume.profile.headline).toEqual({
+      zh: '资深全栈工程师',
+      en: 'Senior Full-Stack Engineer',
+    });
+    expect(service.getPublished()).toBeNull();
+  });
+
+  it('should publish the current draft snapshot', () => {
+    const service = new ResumePublicationService();
+    const draft = createExampleStandardResume();
+
+    draft.profile.headline = {
+      zh: '可发布版本',
+      en: 'Ready to Publish',
+    };
+
+    service.updateDraft(draft);
+
+    const published = service.publish();
+
+    expect(published.status).toBe('published');
+    expect(published.resume.profile.headline).toEqual({
+      zh: '可发布版本',
+      en: 'Ready to Publish',
+    });
+    expect(published.publishedAt).toEqual(expect.any(String));
+  });
+
+  it('should keep published content stable after draft changes until republish', () => {
+    const service = new ResumePublicationService();
+    const firstDraft = createExampleStandardResume();
+
+    firstDraft.profile.headline = {
+      zh: '第一版',
+      en: 'First Version',
+    };
+
+    service.updateDraft(firstDraft);
+    service.publish();
+
+    const secondDraft = createExampleStandardResume();
+    secondDraft.profile.headline = {
+      zh: '第二版草稿',
+      en: 'Second Draft',
+    };
+
+    service.updateDraft(secondDraft);
+
+    expect(service.getDraft().resume.profile.headline).toEqual({
+      zh: '第二版草稿',
+      en: 'Second Draft',
+    });
+    expect(service.getPublished()?.resume.profile.headline).toEqual({
+      zh: '第一版',
+      en: 'First Version',
+    });
+  });
+});

--- a/apps/server/src/modules/resume/resume-publication.service.ts
+++ b/apps/server/src/modules/resume/resume-publication.service.ts
@@ -1,0 +1,71 @@
+import { Injectable } from '@nestjs/common';
+
+import {
+  createExampleStandardResume,
+  StandardResume,
+} from './domain/standard-resume';
+
+export interface ResumeDraftSnapshot {
+  status: 'draft';
+  resume: StandardResume;
+  updatedAt: string;
+}
+
+export interface ResumePublishedSnapshot {
+  status: 'published';
+  resume: StandardResume;
+  publishedAt: string;
+}
+
+function cloneStandardResume(resume: StandardResume): StandardResume {
+  return JSON.parse(JSON.stringify(resume)) as StandardResume;
+}
+
+@Injectable()
+export class ResumePublicationService {
+  private draftSnapshot: ResumeDraftSnapshot = {
+    status: 'draft',
+    resume: createExampleStandardResume(),
+    updatedAt: new Date().toISOString(),
+  };
+
+  private publishedSnapshot: ResumePublishedSnapshot | null = null;
+
+  getDraft(): ResumeDraftSnapshot {
+    return {
+      ...this.draftSnapshot,
+      resume: cloneStandardResume(this.draftSnapshot.resume),
+    };
+  }
+
+  getPublished(): ResumePublishedSnapshot | null {
+    if (!this.publishedSnapshot) {
+      return null;
+    }
+
+    return {
+      ...this.publishedSnapshot,
+      resume: cloneStandardResume(this.publishedSnapshot.resume),
+    };
+  }
+
+  updateDraft(resume: StandardResume): ResumeDraftSnapshot {
+    this.draftSnapshot = {
+      status: 'draft',
+      resume: cloneStandardResume(resume),
+      updatedAt: new Date().toISOString(),
+    };
+
+    return this.getDraft();
+  }
+
+  publish(): ResumePublishedSnapshot {
+    this.publishedSnapshot = {
+      status: 'published',
+      resume: cloneStandardResume(this.draftSnapshot.resume),
+      publishedAt: new Date().toISOString(),
+    };
+
+    return this.getPublished() as ResumePublishedSnapshot;
+  }
+}

--- a/apps/server/src/modules/resume/resume.controller.ts
+++ b/apps/server/src/modules/resume/resume.controller.ts
@@ -1,0 +1,66 @@
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  NotFoundException,
+  Post,
+  Put,
+  UseGuards,
+} from '@nestjs/common';
+
+import { RequireCapability } from '../auth/decorators/require-capability.decorator';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RoleCapabilitiesGuard } from '../auth/guards/role-capabilities.guard';
+import { validateStandardResume } from './domain/standard-resume';
+import type { StandardResume } from './domain/standard-resume';
+import { ResumePublicationService } from './resume-publication.service';
+
+@Controller('resume')
+export class ResumeController {
+  constructor(
+    private readonly resumePublicationService: ResumePublicationService,
+  ) {}
+
+  @Get('published')
+  getPublishedResume() {
+    const published = this.resumePublicationService.getPublished();
+
+    if (!published) {
+      throw new NotFoundException('Published resume is not available');
+    }
+
+    return published;
+  }
+
+  @Get('draft')
+  @UseGuards(JwtAuthGuard, RoleCapabilitiesGuard)
+  @RequireCapability('canEditResume')
+  getDraftResume() {
+    return this.resumePublicationService.getDraft();
+  }
+
+  @Put('draft')
+  @HttpCode(HttpStatus.OK)
+  @UseGuards(JwtAuthGuard, RoleCapabilitiesGuard)
+  @RequireCapability('canEditResume')
+  updateDraftResume(@Body() resume: StandardResume) {
+    const validationResult = validateStandardResume(resume);
+
+    if (!validationResult.valid) {
+      throw new BadRequestException(validationResult.errors);
+    }
+
+    return this.resumePublicationService.updateDraft(resume);
+  }
+
+  @Post('publish')
+  @HttpCode(HttpStatus.OK)
+  @UseGuards(JwtAuthGuard, RoleCapabilitiesGuard)
+  @RequireCapability('canPublishResume')
+  publishResume() {
+    return this.resumePublicationService.publish();
+  }
+}

--- a/apps/server/src/modules/resume/resume.module.ts
+++ b/apps/server/src/modules/resume/resume.module.ts
@@ -1,4 +1,13 @@
 import { Module } from '@nestjs/common';
 
-@Module({})
+import { AuthModule } from '../auth/auth.module';
+import { ResumeController } from './resume.controller';
+import { ResumePublicationService } from './resume-publication.service';
+
+@Module({
+  imports: [AuthModule],
+  controllers: [ResumeController],
+  providers: [ResumePublicationService],
+  exports: [ResumePublicationService],
+})
 export class ResumeModule {}

--- a/apps/server/test/resume-publication.e2e-spec.ts
+++ b/apps/server/test/resume-publication.e2e-spec.ts
@@ -1,0 +1,125 @@
+import { INestApplication } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import request from 'supertest';
+import { App } from 'supertest/types';
+
+import { AppModule } from './../src/app.module';
+
+describe('Resume publication flow (e2e)', () => {
+  let app: INestApplication<App>;
+
+  beforeEach(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('should hide unpublished resume from the public endpoint', () => {
+    return request(app.getHttpServer()).get('/resume/published').expect(404);
+  });
+
+  it('should allow admin to update draft and publish it', async () => {
+    const loginResponse = await request(app.getHttpServer())
+      .post('/auth/login')
+      .send({
+        username: 'admin',
+        password: 'admin123456',
+      })
+      .expect(200);
+
+    const accessToken = loginResponse.body.accessToken as string;
+
+    const draftResponse = await request(app.getHttpServer())
+      .put('/resume/draft')
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send({
+        meta: {
+          slug: 'standard-resume',
+          version: 1,
+          defaultLocale: 'zh',
+          locales: ['zh', 'en'],
+        },
+        profile: {
+          fullName: {
+            zh: '付寅生',
+            en: 'Yinsheng Fu',
+          },
+          headline: {
+            zh: '已发布候选稿',
+            en: 'Publish Candidate',
+          },
+          summary: {
+            zh: '草稿内容',
+            en: 'Draft content',
+          },
+          location: {
+            zh: '上海',
+            en: 'Shanghai',
+          },
+          email: 'demo@example.com',
+          phone: '+86 13800000000',
+          website: 'https://example.com',
+          links: [],
+          interests: [],
+        },
+        education: [],
+        experiences: [],
+        projects: [],
+        skills: [],
+        highlights: [],
+      })
+      .expect(200);
+
+    expect(draftResponse.body.status).toBe('draft');
+
+    const publishResponse = await request(app.getHttpServer())
+      .post('/resume/publish')
+      .set('Authorization', `Bearer ${accessToken}`)
+      .expect(200);
+
+    expect(publishResponse.body.status).toBe('published');
+    expect(publishResponse.body.resume.profile.headline).toEqual({
+      zh: '已发布候选稿',
+      en: 'Publish Candidate',
+    });
+
+    const publicResponse = await request(app.getHttpServer())
+      .get('/resume/published')
+      .expect(200);
+
+    expect(publicResponse.body.resume.profile.headline).toEqual({
+      zh: '已发布候选稿',
+      en: 'Publish Candidate',
+    });
+  });
+
+  it('should keep viewer read-only for draft and publish actions', async () => {
+    const loginResponse = await request(app.getHttpServer())
+      .post('/auth/login')
+      .send({
+        username: 'viewer',
+        password: 'viewer123456',
+      })
+      .expect(200);
+
+    const accessToken = loginResponse.body.accessToken as string;
+
+    await request(app.getHttpServer())
+      .put('/resume/draft')
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send({})
+      .expect(403);
+
+    await request(app.getHttpServer())
+      .post('/resume/publish')
+      .set('Authorization', `Bearer ${accessToken}`)
+      .expect(403);
+  });
+});

--- a/docs/30-开发日志/M3-issue-11-草稿与发布态.md
+++ b/docs/30-开发日志/M3-issue-11-草稿与发布态.md
@@ -1,0 +1,85 @@
+# M3-issue-11-草稿与发布态
+
+## 标题
+
+- Issue：`#20`
+- 里程碑：`M3 简历内容与发布流`
+- 分支：`feat/m3-issue-11-publish-status`
+- 日期：`2026-03-25`
+
+## 背景
+
+双语内容模型完成后，后台编辑态和公开展示态需要被明确拆开。否则草稿内容会和公开展示混在一起，后续 `web` 端也无法稳定只读取“已发布版本”。
+
+## 本次目标
+
+- 建立最小草稿 / 已发布状态。
+- 支持后台更新草稿。
+- 支持最小发布动作，并让公开接口只读取已发布内容。
+
+## 非目标
+
+- 不接数据库。
+- 不做版本历史和回滚。
+- 不做多人协作。
+- 不接 `apps/web` 页面展示。
+
+## TDD / 测试设计
+
+- 先用服务单测锁定草稿与已发布快照的切换行为。
+- 先用 E2E 锁定公开读取、管理员发布、viewer 只读三个关键场景。
+- 先验证“改草稿不会立刻改公开内容”，确保状态边界不漂移。
+
+## 实际改动
+
+- 新增 `apps/server/src/modules/resume/resume-publication.service.ts`
+  - 用内存态管理 `draft` 与 `published` 快照。
+- 新增 `apps/server/src/modules/resume/resume.controller.ts`
+  - 提供 `GET /resume/published`
+  - 提供 `GET /resume/draft`
+  - 提供 `PUT /resume/draft`
+  - 提供 `POST /resume/publish`
+- 更新 `apps/server/src/modules/resume/resume.module.ts`
+  - 接入控制器、服务与鉴权模块。
+- 新增服务单测与 E2E
+  - `apps/server/src/modules/resume/resume-publication.service.spec.ts`
+  - `apps/server/test/resume-publication.e2e-spec.ts`
+
+## Review 记录
+
+- 是否符合当前 Issue 与里程碑目标：符合。
+  - 当前只做最小发布闭环，没有提前引入数据库和回滚逻辑。
+- 是否存在可抽离的公共能力：有。
+  - 后续可把 `draft/published` 快照与持久化抽成独立仓储层。
+  - 当前先保留在 `resume` 模块内部，更适合教程节奏。
+- 是否存在范围膨胀：没有。
+  - 未进入 `web`、导出、AI 或多版本简历能力。
+
+## 自测结果
+
+- 服务单测：通过
+  - `pnpm --filter @my-resume/server exec jest --runInBand src/modules/resume/resume-publication.service.spec.ts`
+- 目标 E2E：通过
+  - `pnpm --filter @my-resume/server exec jest --config ./test/jest-e2e.json --runInBand test/resume-publication.e2e-spec.ts`
+- Server 全量单测：通过
+  - `pnpm --filter @my-resume/server exec jest --runInBand`
+- Server 全量 E2E：通过
+  - `pnpm --filter @my-resume/server exec jest --config ./test/jest-e2e.json --runInBand`
+- Server 构建：通过
+  - `pnpm --filter @my-resume/server build`
+
+## 遇到的问题
+
+- 问题：`NestJS` 在 `emitDecoratorMetadata` 打开时，装饰器签名里引用类型会要求 `import type`。
+- 解决方式：将 `StandardResume` 改为类型导入，避免 `TS1272` 构建错误。
+
+## 可沉淀为教程/博客的点
+
+- 为什么简历类项目要先做草稿 / 发布态，再做公开展示。
+- 如何用最小内存态服务先跑通发布闭环，再渐进替换成数据库。
+- `viewer` 只读角色为什么要在发布接口层面继续生效。
+
+## 后续待办
+
+- 继续 `M3 / issue-12`，让 `apps/web` 只读取已发布版本。
+- 后续把当前内存态发布流迁移到数据库持久化。


### PR DESCRIPTION
## Summary
- add in-memory draft and published resume snapshots for issue-11
- expose minimal draft update, publish, and public published-read endpoints
- add service tests, e2e coverage, and issue devlog

## Review
- scope stays inside apps/server resume module
- no database, rollback, or web UI included in this round

## Testing
- pnpm --filter @my-resume/server exec jest --runInBand src/modules/resume/resume-publication.service.spec.ts
- pnpm --filter @my-resume/server exec jest --config ./test/jest-e2e.json --runInBand test/resume-publication.e2e-spec.ts
- pnpm --filter @my-resume/server exec jest --runInBand
- pnpm --filter @my-resume/server exec jest --config ./test/jest-e2e.json --runInBand
- pnpm --filter @my-resume/server build

## Notes
- pnpm --filter @my-resume/server lint currently reports pre-existing repo-wide issues outside this issue scope and was not expanded here.

Closes #20
