### PR TITLE
feat(m3): add public web shell

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1,15 +1,22 @@
 # apps/web
 
-公开简历展示端占位目录。
+公开简历展示端。
 
-## 未来职责
+## 当前职责
 
-- 提供公开简历展示
-- 负责 SEO / SSR 页面壳
-- 调用统一业务后端 `apps/server`
+- 提供公开简历最小展示壳
+- 只读取 `apps/server` 已发布内容
+- 提供最小 `zh/en` 语言切换
+- 提供最小 `light / dark` 主题切换
+
+## 环境变量
+
+- `RESUME_API_BASE_URL`：服务端渲染时优先使用的后端地址
+- `NEXT_PUBLIC_API_BASE_URL`：兼容前后端统一配置的公开 API 地址
+- 默认回退：`http://localhost:3001`
 
 ## 当前阶段不做
 
-- 不创建 `Next.js` 工程
-- 不实现页面、路由、样式
-- 不接入真实 API
+- 不做复杂视觉设计
+- 不做模板切换
+- 不在 `Next Route Handlers` 中承载业务逻辑

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1,0 +1,262 @@
+:root {
+  color-scheme: light;
+  --background: #f5f7fb;
+  --surface: rgba(255, 255, 255, 0.92);
+  --surface-muted: #f8fafc;
+  --text: #0f172a;
+  --text-muted: #64748b;
+  --border: rgba(148, 163, 184, 0.2);
+  --accent: #2563eb;
+  --accent-soft: #eff6ff;
+  --accent-contrast: #ffffff;
+  --shadow: 0 24px 50px rgba(15, 23, 42, 0.08);
+  font-family:
+    Inter, -apple-system, BlinkMacSystemFont, 'PingFang SC', 'Helvetica Neue',
+    sans-serif;
+}
+
+html[data-theme='dark'] {
+  color-scheme: dark;
+  --background: #020617;
+  --surface: rgba(15, 23, 42, 0.92);
+  --surface-muted: #0f172a;
+  --text: #e2e8f0;
+  --text-muted: #94a3b8;
+  --border: rgba(51, 65, 85, 0.92);
+  --accent: #60a5fa;
+  --accent-soft: rgba(37, 99, 235, 0.15);
+  --accent-contrast: #020617;
+  --shadow: 0 24px 50px rgba(2, 6, 23, 0.5);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  min-height: 100%;
+}
+
+body {
+  min-height: 100vh;
+  background:
+    radial-gradient(circle at top, rgba(59, 130, 246, 0.12), transparent 30%),
+    var(--background);
+  color: var(--text);
+}
+
+button,
+a {
+  color: inherit;
+}
+
+button {
+  font: inherit;
+}
+
+.page-shell {
+  width: min(1080px, 100%);
+  margin: 0 auto;
+  padding: 2rem 1.25rem 3rem;
+  display: grid;
+  gap: 1.25rem;
+}
+
+.hero-card,
+.section-card,
+.empty-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 24px;
+  box-shadow: var(--shadow);
+}
+
+.hero-card {
+  padding: 1.5rem;
+  display: grid;
+  gap: 1.25rem;
+}
+
+.hero-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.hero-copy {
+  display: grid;
+  gap: 0.6rem;
+}
+
+.eyebrow {
+  margin: 0;
+  color: var(--accent);
+  font-size: 0.85rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.headline {
+  margin: 0;
+  font-size: clamp(2rem, 4vw, 3.2rem);
+  line-height: 1.05;
+}
+
+.subtitle,
+.muted,
+.section-subtitle,
+.meta-text {
+  color: var(--text-muted);
+}
+
+.subtitle,
+.section-subtitle {
+  margin: 0;
+  line-height: 1.7;
+}
+
+.toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  justify-content: flex-end;
+}
+
+.toolbar-group {
+  display: inline-flex;
+  gap: 0.5rem;
+  padding: 0.35rem;
+  border-radius: 999px;
+  background: var(--surface-muted);
+  border: 1px solid var(--border);
+}
+
+.toggle-button {
+  border: 0;
+  border-radius: 999px;
+  padding: 0.65rem 0.95rem;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.toggle-button.is-active {
+  background: var(--accent);
+  color: var(--accent-contrast);
+}
+
+.hero-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.meta-pill,
+.link-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  min-height: 40px;
+  padding: 0.65rem 0.9rem;
+  border-radius: 999px;
+  background: var(--surface-muted);
+  border: 1px solid var(--border);
+}
+
+.link-grid,
+.tag-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.section-grid {
+  display: grid;
+  grid-template-columns: 1.2fr 0.8fr;
+  gap: 1.25rem;
+}
+
+.section-card {
+  padding: 1.4rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.section-title {
+  margin: 0;
+  font-size: 1.25rem;
+}
+
+.timeline {
+  display: grid;
+  gap: 1rem;
+}
+
+.timeline-item {
+  display: grid;
+  gap: 0.55rem;
+  padding: 1rem;
+  border-radius: 18px;
+  background: var(--surface-muted);
+  border: 1px solid var(--border);
+}
+
+.item-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: baseline;
+}
+
+.item-title,
+.item-subtitle {
+  margin: 0;
+}
+
+.item-title {
+  font-size: 1.02rem;
+}
+
+.item-subtitle {
+  color: var(--text-muted);
+  font-size: 0.94rem;
+}
+
+.item-summary {
+  margin: 0;
+  line-height: 1.7;
+}
+
+.bullet-list {
+  margin: 0;
+  padding-left: 1.15rem;
+  display: grid;
+  gap: 0.45rem;
+}
+
+.empty-card {
+  padding: 2rem;
+  display: grid;
+  gap: 0.8rem;
+  text-align: center;
+}
+
+@media (max-width: 900px) {
+  .hero-header,
+  .item-header {
+    flex-direction: column;
+  }
+
+  .toolbar {
+    justify-content: flex-start;
+  }
+
+  .section-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,0 +1,21 @@
+import './globals.css';
+
+import type { Metadata } from 'next';
+import type { ReactNode } from 'react';
+
+export const metadata: Metadata = {
+  title: 'my-resume web',
+  description: 'Public resume web shell',
+};
+
+export default function RootLayout({
+  children,
+}: Readonly<{
+  children: ReactNode;
+}>) {
+  return (
+    <html data-template="default" data-theme="light" lang="zh-CN">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,0 +1,11 @@
+import { PublishedResumeShell } from '../components/published-resume-shell';
+import { DEFAULT_API_BASE_URL } from '../lib/env';
+import { fetchPublishedResume } from '../lib/published-resume-api';
+
+export default async function WebHomePage() {
+  const publishedResume = await fetchPublishedResume({
+    apiBaseUrl: DEFAULT_API_BASE_URL,
+  });
+
+  return <PublishedResumeShell publishedResume={publishedResume} />;
+}

--- a/apps/web/components/published-resume-shell.spec.tsx
+++ b/apps/web/components/published-resume-shell.spec.tsx
@@ -1,0 +1,112 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it } from 'vitest';
+
+import { PublishedResumeShell } from './published-resume-shell';
+
+const publishedResume = {
+  status: 'published' as const,
+  publishedAt: '2026-03-25T00:00:00.000Z',
+  resume: {
+    profile: {
+      fullName: {
+        zh: '付寅生',
+        en: 'Yinsheng Fu',
+      },
+      headline: {
+        zh: '全栈开发工程师',
+        en: 'Full-Stack Engineer',
+      },
+      summary: {
+        zh: '专注前端工程化与 Node.js 后端。',
+        en: 'Focused on frontend engineering and Node.js backend development.',
+      },
+      location: {
+        zh: '上海',
+        en: 'Shanghai',
+      },
+      email: 'demo@example.com',
+      phone: '+86 13800000000',
+      website: 'https://example.com',
+      links: [],
+      interests: [],
+    },
+    education: [],
+    experiences: [],
+    projects: [
+      {
+        name: {
+          zh: '个人简历 Monorepo',
+          en: 'Personal Resume Monorepo',
+        },
+        role: {
+          zh: '作者',
+          en: 'Author',
+        },
+        startDate: '2026-03',
+        endDate: '进行中',
+        summary: {
+          zh: '逐步构建三端项目。',
+          en: 'Incrementally building a three-surface project.',
+        },
+        highlights: [],
+        technologies: ['Next.js', 'NestJS'],
+        links: [],
+      },
+    ],
+    skills: [
+      {
+        name: {
+          zh: '前端工程化',
+          en: 'Frontend Engineering',
+        },
+        keywords: ['TypeScript', 'React'],
+      },
+    ],
+    highlights: [],
+  },
+};
+
+describe('PublishedResumeShell', () => {
+  it('should render zh content by default and switch to en', async () => {
+    const user = userEvent.setup();
+
+    render(<PublishedResumeShell publishedResume={publishedResume} />);
+
+    expect(screen.getByRole('heading', { name: '付寅生' })).toBeInTheDocument();
+    expect(
+      screen.getByText('专注前端工程化与 Node.js 后端。'),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'EN' }));
+
+    expect(
+      screen.getByRole('heading', { name: 'Yinsheng Fu' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('Focused on frontend engineering and Node.js backend development.'),
+    ).toBeInTheDocument();
+  });
+
+  it('should toggle light and dark theme on the document element', async () => {
+    const user = userEvent.setup();
+
+    render(<PublishedResumeShell publishedResume={publishedResume} />);
+
+    expect(document.documentElement.dataset.theme).toBe('light');
+
+    await user.click(screen.getByRole('button', { name: 'Dark' }));
+    expect(document.documentElement.dataset.theme).toBe('dark');
+
+    await user.click(screen.getByRole('button', { name: 'Light' }));
+    expect(document.documentElement.dataset.theme).toBe('light');
+  });
+
+  it('should render empty state when no published content is available', () => {
+    render(<PublishedResumeShell publishedResume={null} />);
+
+    expect(
+      screen.getByText('当前还没有已发布的公开简历内容。'),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/web/components/published-resume-shell.tsx
+++ b/apps/web/components/published-resume-shell.tsx
@@ -1,0 +1,262 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+
+import {
+  LocalizedText,
+  ResumeLocale,
+  ResumeProjectItem,
+  ResumePublishedSnapshot,
+  ResumeSkillGroup,
+} from '../lib/published-resume-types';
+
+type ThemeMode = 'light' | 'dark';
+
+function readLocalizedText(value: LocalizedText, locale: ResumeLocale): string {
+  return value[locale];
+}
+
+function formatProjectPeriod(
+  project: ResumeProjectItem,
+  locale: ResumeLocale,
+): string {
+  if (locale === 'zh') {
+    return `${project.startDate} - ${project.endDate}`;
+  }
+
+  return `${project.startDate} - ${project.endDate}`;
+}
+
+function renderSkillGroup(
+  skillGroup: ResumeSkillGroup,
+  locale: ResumeLocale,
+): string {
+  return `${readLocalizedText(skillGroup.name, locale)} · ${skillGroup.keywords.join(', ')}`;
+}
+
+export function PublishedResumeShell({
+  publishedResume,
+}: {
+  publishedResume: ResumePublishedSnapshot | null;
+}) {
+  const [locale, setLocale] = useState<ResumeLocale>('zh');
+  const [theme, setTheme] = useState<ThemeMode>('light');
+
+  useEffect(() => {
+    document.documentElement.dataset.theme = theme;
+  }, [theme]);
+
+  const rawProfile = publishedResume?.resume.profile;
+  const skills = publishedResume?.resume.skills ?? [];
+  const projects = publishedResume?.resume.projects ?? [];
+
+  const localizedProfile = useMemo(() => {
+    if (!rawProfile) {
+      return null;
+    }
+
+    return {
+      fullName: readLocalizedText(rawProfile.fullName, locale),
+      headline: readLocalizedText(rawProfile.headline, locale),
+      summary: readLocalizedText(rawProfile.summary, locale),
+      location: readLocalizedText(rawProfile.location, locale),
+      interests: rawProfile.interests.map((item) =>
+        readLocalizedText(item, locale),
+      ),
+      links: rawProfile.links.map((link) => ({
+        label: readLocalizedText(link.label, locale),
+        url: link.url,
+      })),
+    };
+  }, [locale, rawProfile]);
+
+  if (!publishedResume || !localizedProfile || !rawProfile) {
+    return (
+      <main className="page-shell">
+        <section className="empty-card">
+          <p className="eyebrow">公开简历</p>
+          <h1>当前还没有已发布的公开简历内容。</h1>
+          <p className="muted">
+            请先通过后台更新草稿并执行发布动作，公开站才会读取到最新已发布版本。
+          </p>
+        </section>
+      </main>
+    );
+  }
+
+  const profile = rawProfile;
+
+  return (
+    <main className="page-shell">
+      <section className="hero-card">
+        <div className="hero-header">
+          <div className="hero-copy">
+            <p className="eyebrow">公开简历</p>
+            <h1 className="headline">{localizedProfile.fullName}</h1>
+            <p className="subtitle">{localizedProfile.headline}</p>
+            <p className="subtitle">{localizedProfile.summary}</p>
+          </div>
+
+          <div className="toolbar">
+            <div aria-label="语言切换" className="toolbar-group" role="group">
+              <button
+                className={`toggle-button ${locale === 'zh' ? 'is-active' : ''}`}
+                onClick={() => setLocale('zh')}
+                type="button"
+              >
+                中文
+              </button>
+              <button
+                className={`toggle-button ${locale === 'en' ? 'is-active' : ''}`}
+                onClick={() => setLocale('en')}
+                type="button"
+              >
+                EN
+              </button>
+            </div>
+
+            <div aria-label="主题切换" className="toolbar-group" role="group">
+              <button
+                className={`toggle-button ${theme === 'light' ? 'is-active' : ''}`}
+                onClick={() => setTheme('light')}
+                type="button"
+              >
+                Light
+              </button>
+              <button
+                className={`toggle-button ${theme === 'dark' ? 'is-active' : ''}`}
+                onClick={() => setTheme('dark')}
+                type="button"
+              >
+                Dark
+              </button>
+            </div>
+          </div>
+        </div>
+
+        <div className="hero-meta">
+          <span className="meta-pill">{localizedProfile.location}</span>
+          <span className="meta-pill">{profile.email}</span>
+          <span className="meta-pill">{profile.website}</span>
+          <span className="meta-pill">
+            {locale === 'zh' ? '已发布于' : 'Published at'}{' '}
+            <span className="meta-text">{publishedResume.publishedAt}</span>
+          </span>
+        </div>
+
+        {localizedProfile.links.length > 0 ? (
+          <div className="link-grid">
+            {localizedProfile.links.map((link) => (
+              <a
+                className="link-pill"
+                href={link.url}
+                key={link.url}
+                rel="noreferrer"
+                target="_blank"
+              >
+                {link.label}
+              </a>
+            ))}
+          </div>
+        ) : null}
+      </section>
+
+      <section className="section-grid">
+        <section className="section-card">
+          <div>
+            <p className="eyebrow">
+              {locale === 'zh' ? '项目经历' : 'Projects'}
+            </p>
+            <h2 className="section-title">
+              {locale === 'zh' ? '已发布项目内容' : 'Published project content'}
+            </h2>
+            <p className="section-subtitle">
+              {locale === 'zh'
+                ? '公开站只读取已发布内容，不会直接暴露后台草稿。'
+                : 'The public site only reads published content and never exposes draft data directly.'}
+            </p>
+          </div>
+
+          <div className="timeline">
+            {projects.map((project) => (
+              <article className="timeline-item" key={project.name.en}>
+                <div className="item-header">
+                  <div>
+                    <h3 className="item-title">
+                      {readLocalizedText(project.name, locale)}
+                    </h3>
+                    <p className="item-subtitle">
+                      {readLocalizedText(project.role, locale)}
+                    </p>
+                  </div>
+                  <span className="meta-text">
+                    {formatProjectPeriod(project, locale)}
+                  </span>
+                </div>
+
+                <p className="item-summary">
+                  {readLocalizedText(project.summary, locale)}
+                </p>
+
+                {project.technologies.length > 0 ? (
+                  <div className="tag-grid">
+                    {project.technologies.map((tech) => (
+                      <span className="meta-pill" key={tech}>
+                        {tech}
+                      </span>
+                    ))}
+                  </div>
+                ) : null}
+              </article>
+            ))}
+          </div>
+        </section>
+
+        <section className="section-card">
+          <div>
+            <p className="eyebrow">{locale === 'zh' ? '技能' : 'Skills'}</p>
+            <h2 className="section-title">
+              {locale === 'zh' ? '公开技能摘要' : 'Published skill summary'}
+            </h2>
+          </div>
+
+          <div className="timeline">
+            {skills.map((skillGroup) => (
+              <article
+                className="timeline-item"
+                key={`${skillGroup.name.en}-${skillGroup.keywords.join('-')}`}
+              >
+                <h3 className="item-title">
+                  {readLocalizedText(skillGroup.name, locale)}
+                </h3>
+                <p className="item-summary">
+                  {renderSkillGroup(skillGroup, locale)}
+                </p>
+              </article>
+            ))}
+          </div>
+
+          {localizedProfile.interests.length > 0 ? (
+            <>
+              <div>
+                <p className="eyebrow">
+                  {locale === 'zh' ? '兴趣' : 'Interests'}
+                </p>
+                <h2 className="section-title">
+                  {locale === 'zh' ? '个人兴趣' : 'Personal interests'}
+                </h2>
+              </div>
+              <div className="tag-grid">
+                {localizedProfile.interests.map((interest) => (
+                  <span className="meta-pill" key={interest}>
+                    {interest}
+                  </span>
+                ))}
+              </div>
+            </>
+          ) : null}
+        </section>
+      </section>
+    </main>
+  );
+}

--- a/apps/web/lib/env.ts
+++ b/apps/web/lib/env.ts
@@ -1,0 +1,4 @@
+export const DEFAULT_API_BASE_URL =
+  process.env.RESUME_API_BASE_URL ??
+  process.env.NEXT_PUBLIC_API_BASE_URL ??
+  'http://localhost:3001';

--- a/apps/web/lib/published-resume-api.spec.ts
+++ b/apps/web/lib/published-resume-api.spec.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { fetchPublishedResume } from './published-resume-api';
+
+describe('published resume api', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should return published snapshot when server responds successfully', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          status: 'published',
+          publishedAt: '2026-03-25T00:00:00.000Z',
+          resume: {
+            profile: {
+              fullName: {
+                zh: '付寅生',
+                en: 'Yinsheng Fu',
+              },
+              headline: {
+                zh: '全栈开发工程师',
+                en: 'Full-Stack Engineer',
+              },
+              summary: {
+                zh: '示例摘要',
+                en: 'Example summary',
+              },
+              location: {
+                zh: '上海',
+                en: 'Shanghai',
+              },
+              email: 'demo@example.com',
+              phone: '+86 13800000000',
+              website: 'https://example.com',
+              links: [],
+              interests: [],
+            },
+            education: [],
+            experiences: [],
+            projects: [],
+            skills: [],
+            highlights: [],
+          },
+        }),
+      }),
+    );
+
+    const result = await fetchPublishedResume({
+      apiBaseUrl: 'http://localhost:3001',
+    });
+
+    expect(fetch).toHaveBeenCalledWith(
+      'http://localhost:3001/resume/published',
+      expect.objectContaining({
+        cache: 'no-store',
+      }),
+    );
+    expect(result?.status).toBe('published');
+    expect(result?.resume.profile.fullName.en).toBe('Yinsheng Fu');
+  });
+
+  it('should return null when no published resume exists yet', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+      }),
+    );
+
+    const result = await fetchPublishedResume({
+      apiBaseUrl: 'http://localhost:3001',
+    });
+
+    expect(result).toBeNull();
+  });
+});

--- a/apps/web/lib/published-resume-api.ts
+++ b/apps/web/lib/published-resume-api.ts
@@ -1,0 +1,30 @@
+import { ResumePublishedSnapshot } from './published-resume-types';
+
+interface FetchPublishedResumeInput {
+  apiBaseUrl: string;
+}
+
+function joinApiUrl(apiBaseUrl: string, pathname: string): string {
+  return `${apiBaseUrl.replace(/\/$/, '')}${pathname}`;
+}
+
+export async function fetchPublishedResume(
+  input: FetchPublishedResumeInput,
+): Promise<ResumePublishedSnapshot | null> {
+  const response = await fetch(
+    joinApiUrl(input.apiBaseUrl, '/resume/published'),
+    {
+      cache: 'no-store',
+    },
+  );
+
+  if (response.status === 404) {
+    return null;
+  }
+
+  if (!response.ok) {
+    throw new Error('公开简历读取失败');
+  }
+
+  return (await response.json()) as ResumePublishedSnapshot;
+}

--- a/apps/web/lib/published-resume-types.ts
+++ b/apps/web/lib/published-resume-types.ts
@@ -1,0 +1,81 @@
+export type ResumeLocale = 'zh' | 'en';
+
+export interface LocalizedText {
+  zh: string;
+  en: string;
+}
+
+export interface ResumeProfileLink {
+  label: LocalizedText;
+  url: string;
+}
+
+export interface ResumeProfile {
+  fullName: LocalizedText;
+  headline: LocalizedText;
+  summary: LocalizedText;
+  location: LocalizedText;
+  email: string;
+  phone: string;
+  website: string;
+  links: ResumeProfileLink[];
+  interests: LocalizedText[];
+}
+
+export interface ResumeEducationItem {
+  schoolName: LocalizedText;
+  degree: LocalizedText;
+  fieldOfStudy: LocalizedText;
+  startDate: string;
+  endDate: string;
+  location: LocalizedText;
+  highlights: LocalizedText[];
+}
+
+export interface ResumeExperienceItem {
+  companyName: LocalizedText;
+  role: LocalizedText;
+  employmentType: LocalizedText;
+  startDate: string;
+  endDate: string;
+  location: LocalizedText;
+  summary: LocalizedText;
+  highlights: LocalizedText[];
+  technologies: string[];
+}
+
+export interface ResumeProjectItem {
+  name: LocalizedText;
+  role: LocalizedText;
+  startDate: string;
+  endDate: string;
+  summary: LocalizedText;
+  highlights: LocalizedText[];
+  technologies: string[];
+  links: ResumeProfileLink[];
+}
+
+export interface ResumeSkillGroup {
+  name: LocalizedText;
+  keywords: string[];
+}
+
+export interface ResumeHighlightItem {
+  title: LocalizedText;
+  description: LocalizedText;
+}
+
+export interface StandardResume {
+  profile: ResumeProfile;
+  education: ResumeEducationItem[];
+  experiences: ResumeExperienceItem[];
+  projects: ResumeProjectItem[];
+  skills: ResumeSkillGroup[];
+  highlights: ResumeHighlightItem[];
+}
+
+export interface ResumePublishedSnapshot {
+  status: 'published';
+  resume: StandardResume;
+  publishedAt: string;
+}

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,0 +1,5 @@
+import type { NextConfig } from 'next';
+
+const nextConfig: NextConfig = {};
+
+export default nextConfig;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@my-resume/web",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "tsc --noEmit",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "next": "^15.5.2",
+    "react": "^19.1.1",
+    "react-dom": "^19.1.1"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^6.8.0",
+    "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.1",
+    "@types/react": "^19.1.9",
+    "@types/react-dom": "^19.1.7",
+    "jsdom": "^26.1.0",
+    "typescript": "^5.9.2",
+    "vitest": "^3.2.4"
+  }
+}

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,0 +1,30 @@
+{
+  "extends": "../../packages/config/tsconfig.base.json",
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["dom", "dom.iterable", "es2022"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": ["node_modules"]
+}

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: ['./vitest.setup.ts'],
+  },
+  esbuild: {
+    jsx: 'automatic',
+  },
+});

--- a/apps/web/vitest.setup.ts
+++ b/apps/web/vitest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest';

--- a/docs/30-开发日志/M3-issue-12-web-公开读取已发布版本.md
+++ b/docs/30-开发日志/M3-issue-12-web-公开读取已发布版本.md
@@ -1,0 +1,99 @@
+# M3-issue-12-web-公开读取已发布版本
+
+## 标题
+
+- Issue：`#17`
+- 里程碑：`M3 简历内容与发布流`
+- 分支：`feat/m3-issue-12-web-published-read`
+- 日期：`2026-03-25`
+
+## 背景
+
+`issue-11` 已经在 `apps/server` 中完成了最小草稿 / 发布闭环。接下来需要有一个真正的公开展示端来验证：公开站只读取已发布内容，而不是直接读取后台草稿。
+
+## 本次目标
+
+- 创建 `apps/web` 最小 `Next.js App Router` 展示壳。
+- 只读取 `apps/server` 的已发布简历内容。
+- 支持最小 `zh/en` 语言切换。
+- 在展示层顺手落下最小 `light / dark` 主题切换钩子。
+
+## 非目标
+
+- 不做复杂视觉设计。
+- 不做模板切换。
+- 不做后台编辑能力。
+- 不在 `Next Route Handlers` 中承载业务逻辑。
+
+## TDD / 测试设计
+
+- 先用 `published-resume-api.spec.ts` 锁定公开读取接口行为：
+  - `200` 返回已发布快照
+  - `404` 返回空状态
+- 先用 `published-resume-shell.spec.tsx` 锁定展示壳行为：
+  - 默认显示中文
+  - 能切换到英文
+  - 能切换 `light / dark`
+  - 无已发布内容时显示空状态
+
+## 实际改动
+
+- 新建 `apps/web` 最小 `Next.js` 工程：
+  - `package.json`
+  - `tsconfig.json`
+  - `next.config.ts`
+  - `vitest` 配置
+- 新建公开展示页面骨架：
+  - `apps/web/app/layout.tsx`
+  - `apps/web/app/page.tsx`
+  - `apps/web/app/globals.css`
+- 新建公开简历读取能力：
+  - `apps/web/lib/published-resume-api.ts`
+  - `apps/web/lib/published-resume-types.ts`
+  - `apps/web/lib/env.ts`
+- 新建展示壳组件：
+  - `apps/web/components/published-resume-shell.tsx`
+- 新建测试：
+  - `apps/web/lib/published-resume-api.spec.ts`
+  - `apps/web/components/published-resume-shell.spec.tsx`
+- 更新 `apps/web/README.md`
+  - 说明当前职责、主题切换和 API 地址环境变量
+
+## Review 记录
+
+- 是否符合当前 Issue 与里程碑目标：符合。
+  - 当前只做公开只读壳，没有扩展到模板系统和复杂视觉。
+- 是否存在可抽离的公共能力：有。
+  - `published-resume-api` 后续可逐步合并到共享 `api-client`。
+  - 主题切换当前先留在页面壳内部，后续可抽到 `packages/ui`。
+- 是否存在范围膨胀：可控。
+  - 本轮顺带补了 `light / dark` 最小切换，但没有进入模板切换和设计系统重构。
+
+## 自测结果
+
+- `apps/web` 单测：通过
+  - `pnpm --filter @my-resume/web test`
+- `apps/web` 类型检查：通过
+  - `pnpm --filter @my-resume/web typecheck`
+- `apps/web` 构建：通过
+  - `pnpm --filter @my-resume/web build`
+- 真实联调验证：通过
+  - 使用本地 `apps/server` 已发布内容
+  - 使用 `RESUME_API_BASE_URL=http://127.0.0.1:6789`
+  - 实际抓取 `web` 页面 HTML，确认包含“付寅生 / 全栈开发工程师 / 个人简历 Monorepo / 公开简历”等已发布内容
+
+## 遇到的问题
+
+- 问题：你本地 `apps/server` 实际监听端口不是默认 `3001`，而是环境变量驱动的 `6789`。
+- 解决方式：`apps/web/lib/env.ts` 增加 `RESUME_API_BASE_URL` 优先级，避免服务端渲染阶段被固定到默认地址。
+
+## 可沉淀为教程/博客的点
+
+- 为什么公开展示端应该只读已发布内容，而不是直接读取草稿。
+- `Next.js App Router` 如何只做展示壳，不承接业务逻辑。
+- 为什么展示型项目在最小壳阶段就要预留 `light / dark` 和模板扩展钩子。
+
+## 后续待办
+
+- `M3` 内容主线已经收口，可以开始回看里程碑是否需要补一份教程大纲。
+- 后续继续进入 `M4 / M5 / M6`，或按需要先补 `packages/ui` / `api-client` 共享抽象。

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -219,6 +219,43 @@ importers:
         specifier: ^8.20.0
         version: 8.57.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
 
+  apps/web:
+    dependencies:
+      next:
+        specifier: ^15.5.2
+        version: 15.5.14(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react:
+        specifier: ^19.1.1
+        version: 19.2.4
+      react-dom:
+        specifier: ^19.1.1
+        version: 19.2.4(react@19.2.4)
+    devDependencies:
+      '@testing-library/jest-dom':
+        specifier: ^6.8.0
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: ^16.3.0
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@testing-library/user-event':
+        specifier: ^14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.1)
+      '@types/react':
+        specifier: ^19.1.9
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.1.7
+        version: 19.2.3(@types/react@19.2.14)
+      jsdom:
+        specifier: ^26.1.0
+        version: 26.1.0
+      typescript:
+        specifier: ^5.9.2
+        version: 5.9.3
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@22.19.15)(jsdom@26.1.0)(terser@5.46.1)
+
 packages:
 
   '@adobe/css-tools@4.4.4':


### PR DESCRIPTION
## Summary
- scaffold apps/web as a minimal Next.js public resume shell
- read only published resume content from apps/server
- support minimal zh/en language switching and light/dark theme switching
- add web tests, runtime env handling, and issue devlog

## Review
- scope stays inside apps/web plus issue devlog and lockfile update
- no template switching, complex design, or route-handler business logic included

## Testing
- pnpm --filter @my-resume/web test
- pnpm --filter @my-resume/web typecheck
- pnpm --filter @my-resume/web build
- manual integration: publish resume on local server and confirm rendered web HTML contains published content

## Notes
- RESUME_API_BASE_URL is now preferred for server-side runtime reads, which fits local monorepo runs better when server port differs from the default.

Closes #17
