### PR TITLE
feat(server): add cached ai analysis reports

### DIFF
--- a/apps/server/src/modules/ai/ai-report.controller.ts
+++ b/apps/server/src/modules/ai/ai-report.controller.ts
@@ -1,0 +1,32 @@
+import { Body, Controller, Get, Param, Post, UseGuards } from '@nestjs/common';
+
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import {
+  AnalysisLocale,
+  AnalysisScenario,
+  AnalysisReportCacheService,
+} from './analysis-report-cache.service';
+
+interface CacheReportBody {
+  scenario: AnalysisScenario;
+  content: string;
+  locale?: AnalysisLocale;
+}
+
+@Controller('ai/reports')
+@UseGuards(JwtAuthGuard)
+export class AiReportController {
+  constructor(
+    private readonly analysisReportCacheService: AnalysisReportCacheService,
+  ) {}
+
+  @Post('cache')
+  cacheReport(@Body() body: CacheReportBody) {
+    return this.analysisReportCacheService.getOrCreateReport(body);
+  }
+
+  @Get('cache/:reportId')
+  getCachedReport(@Param('reportId') reportId: string) {
+    return this.analysisReportCacheService.getReportById(reportId);
+  }
+}

--- a/apps/server/src/modules/ai/ai.module.ts
+++ b/apps/server/src/modules/ai/ai.module.ts
@@ -2,6 +2,8 @@ import { Module } from '@nestjs/common';
 
 import { AuthModule } from '../auth/auth.module';
 import { AiFileController } from './ai-file.controller';
+import { AiReportController } from './ai-report.controller';
+import { AnalysisReportCacheService } from './analysis-report-cache.service';
 import { resolveAiRuntimeConfig } from './config/ai-config';
 import { AiService } from './ai.service';
 import { FileExtractionService } from './file-extraction.service';
@@ -10,7 +12,7 @@ import { createAiProvider } from './providers/ai-provider.factory';
 
 @Module({
   imports: [AuthModule],
-  controllers: [AiFileController],
+  controllers: [AiFileController, AiReportController],
   providers: [
     {
       provide: AI_RUNTIME_CONFIG,
@@ -26,8 +28,9 @@ import { createAiProvider } from './providers/ai-provider.factory';
       useFactory: createAiProvider,
     },
     AiService,
+    AnalysisReportCacheService,
     FileExtractionService,
   ],
-  exports: [AiService, FileExtractionService],
+  exports: [AiService, AnalysisReportCacheService, FileExtractionService],
 })
 export class AiModule {}

--- a/apps/server/src/modules/ai/analysis-report-cache.service.spec.ts
+++ b/apps/server/src/modules/ai/analysis-report-cache.service.spec.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { AnalysisReportCacheService } from './analysis-report-cache.service';
+
+describe('AnalysisReportCacheService', () => {
+  const service = new AnalysisReportCacheService();
+
+  it('should create a stable mock report and reuse cache for the same input', () => {
+    const first = service.getOrCreateReport({
+      scenario: 'jd-match',
+      content: 'NestJS React TypeScript Redis',
+      locale: 'zh',
+    });
+
+    const second = service.getOrCreateReport({
+      scenario: 'jd-match',
+      content: 'NestJS   React TypeScript Redis',
+      locale: 'zh',
+    });
+
+    expect(first.cached).toBe(false);
+    expect(second.cached).toBe(true);
+    expect(second.report.reportId).toBe(first.report.reportId);
+    expect(second.report.summary).toBe(first.report.summary);
+  });
+
+  it('should create different cache keys for different scenarios', () => {
+    const jdReport = service.getOrCreateReport({
+      scenario: 'jd-match',
+      content: 'React Next.js TypeScript',
+      locale: 'zh',
+    });
+    const offerReport = service.getOrCreateReport({
+      scenario: 'offer-compare',
+      content: 'React Next.js TypeScript',
+      locale: 'zh',
+    });
+
+    expect(jdReport.report.reportId).not.toBe(offerReport.report.reportId);
+    expect(jdReport.report.scenario).toBe('jd-match');
+    expect(offerReport.report.scenario).toBe('offer-compare');
+  });
+
+  it('should read a cached report by report id', () => {
+    const created = service.getOrCreateReport({
+      scenario: 'resume-review',
+      content: 'Vue React NestJS Resume Review',
+      locale: 'en',
+    });
+
+    const report = service.getReportById(created.report.reportId);
+
+    expect(report.reportId).toBe(created.report.reportId);
+    expect(report.locale).toBe('en');
+  });
+});

--- a/apps/server/src/modules/ai/analysis-report-cache.service.ts
+++ b/apps/server/src/modules/ai/analysis-report-cache.service.ts
@@ -1,0 +1,345 @@
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { createHash } from 'node:crypto';
+
+export type AnalysisScenario = 'jd-match' | 'resume-review' | 'offer-compare';
+export type AnalysisLocale = 'zh' | 'en';
+
+export interface AnalysisReportSection {
+  key: string;
+  title: string;
+  bullets: string[];
+}
+
+export interface AnalysisReport {
+  reportId: string;
+  cacheKey: string;
+  scenario: AnalysisScenario;
+  locale: AnalysisLocale;
+  sourceHash: string;
+  inputPreview: string;
+  summary: string;
+  sections: AnalysisReportSection[];
+  generator: 'mock-cache';
+  createdAt: string;
+}
+
+export interface GetOrCreateReportInput {
+  scenario: AnalysisScenario;
+  content: string;
+  locale?: AnalysisLocale;
+}
+
+export interface CachedAnalysisReportResult {
+  cached: boolean;
+  report: AnalysisReport;
+}
+
+const SUPPORTED_SCENARIOS = new Set<AnalysisScenario>([
+  'jd-match',
+  'resume-review',
+  'offer-compare',
+]);
+
+function normalizeContent(content: string): string {
+  return content.replace(/\s+/g, ' ').trim();
+}
+
+function computeHash(content: string): string {
+  return createHash('sha256').update(content).digest('hex');
+}
+
+function buildInputPreview(content: string): string {
+  return content.slice(0, 120);
+}
+
+function extractKeywords(content: string, locale: AnalysisLocale): string[] {
+  const matches = content.match(/[A-Za-z0-9.+#-]{2,}/g) ?? [];
+  const unique = Array.from(new Set(matches.map((item) => item.toLowerCase())));
+
+  if (unique.length > 0) {
+    return unique.slice(0, 3);
+  }
+
+  return locale === 'en'
+    ? ['resume', 'experience', 'skills']
+    : ['简历', '经历', '技能'];
+}
+
+function buildSummary(
+  scenario: AnalysisScenario,
+  keywords: string[],
+  locale: AnalysisLocale,
+): string {
+  if (locale === 'en') {
+    if (scenario === 'jd-match') {
+      return `Cached JD match preview highlights ${keywords.join(', ')} and keeps the result reusable for the same input.`;
+    }
+
+    if (scenario === 'resume-review') {
+      return `Cached resume review focuses on ${keywords.join(', ')} and keeps a stable mock report for tutorials.`;
+    }
+
+    return `Cached offer comparison starts from ${keywords.join(', ')} and provides a deterministic demo result.`;
+  }
+
+  if (scenario === 'jd-match') {
+    return `当前为缓存版 JD 匹配预览，重点围绕 ${keywords.join('、')} 生成稳定报告，便于教程阶段复用。`;
+  }
+
+  if (scenario === 'resume-review') {
+    return `当前为缓存版简历建议预览，聚焦 ${keywords.join('、')}，用于演示稳定的 mock 分析结果。`;
+  }
+
+  return `当前为缓存版 offer 对比预览，从 ${keywords.join('、')} 等维度给出可复用的演示结论。`;
+}
+
+function buildSections(
+  scenario: AnalysisScenario,
+  keywords: string[],
+  locale: AnalysisLocale,
+): AnalysisReportSection[] {
+  if (locale === 'en') {
+    if (scenario === 'jd-match') {
+      return [
+        {
+          key: 'match-overview',
+          title: 'Match Overview',
+          bullets: [
+            `The current input already mentions ${keywords[0]} and ${keywords[1] ?? keywords[0]}.`,
+            'This report is cached by normalized input and can be reused directly.',
+          ],
+        },
+        {
+          key: 'missing-signals',
+          title: 'Missing Signals',
+          bullets: [
+            'Add more quantified outcomes to improve credibility.',
+            'Clarify collaboration scope, ownership, and delivery impact.',
+          ],
+        },
+        {
+          key: 'next-actions',
+          title: 'Next Actions',
+          bullets: [
+            'Keep this cached preview for viewer demo mode.',
+            'Upgrade to real provider analysis in the next milestone step.',
+          ],
+        },
+      ];
+    }
+
+    if (scenario === 'resume-review') {
+      return [
+        {
+          key: 'strengths',
+          title: 'Strengths',
+          bullets: [
+            `The resume already exposes keywords like ${keywords.join(', ')}.`,
+            'Content blocks are ready for a later bilingual polishing flow.',
+          ],
+        },
+        {
+          key: 'risks',
+          title: 'Risks',
+          bullets: [
+            'Project outcomes may still feel too generic.',
+            'Technical depth can be supported by clearer architecture context.',
+          ],
+        },
+        {
+          key: 'recommendations',
+          title: 'Recommendations',
+          bullets: [
+            'Prepare one stronger summary sentence for each project.',
+            'Reserve this structure for later real AI review output.',
+          ],
+        },
+      ];
+    }
+
+    return [
+      {
+        key: 'comparison',
+        title: 'Comparison Axes',
+        bullets: [
+          `Use ${keywords.join(', ')} as demo dimensions for the mock report.`,
+          'Keep the current output deterministic for repeatable tutorials.',
+        ],
+      },
+      {
+        key: 'suggestion',
+        title: 'Suggestion',
+        bullets: [
+          'Prefer the option with clearer growth path and ownership scope.',
+          'Treat the current result as a cached walkthrough, not final advice.',
+        ],
+      },
+      {
+        key: 'follow-up',
+        title: 'Follow-up',
+        bullets: [
+          'Add real provider orchestration in the next AI milestone step.',
+          'Add viewer read-only access after role boundary refinement.',
+        ],
+      },
+    ];
+  }
+
+  if (scenario === 'jd-match') {
+    return [
+      {
+        key: 'match-overview',
+        title: '匹配概览',
+        bullets: [
+          `当前输入已经覆盖 ${keywords[0]}、${keywords[1] ?? keywords[0]} 等关键信号。`,
+          '结果按归一化输入缓存，可直接复用同一份预设报告。',
+        ],
+      },
+      {
+        key: 'missing-signals',
+        title: '待补信号',
+        bullets: [
+          '可继续补充量化结果与业务影响，增强可信度。',
+          '可补充协作范围、负责模块和落地结果。',
+        ],
+      },
+      {
+        key: 'next-actions',
+        title: '下一步建议',
+        bullets: [
+          '当前结果适合用于 viewer 体验态演示。',
+          '后续再接入真实 Provider 与任务编排。',
+        ],
+      },
+    ];
+  }
+
+  if (scenario === 'resume-review') {
+    return [
+      {
+        key: 'strengths',
+        title: '已有亮点',
+        bullets: [
+          `简历中已经体现 ${keywords.join('、')} 等关键词。`,
+          '内容结构适合后续继续补充双语润色与发布流。',
+        ],
+      },
+      {
+        key: 'risks',
+        title: '风险提示',
+        bullets: [
+          '项目成果描述还可以更具体，避免过于概括。',
+          '技术栈描述可增加架构背景与取舍说明。',
+        ],
+      },
+      {
+        key: 'recommendations',
+        title: '优化建议',
+        bullets: [
+          '为每个项目补一条最强结果描述。',
+          '当前结构先稳定下来，后续再替换成真实 AI 输出。',
+        ],
+      },
+    ];
+  }
+
+  return [
+    {
+      key: 'comparison',
+      title: '对比维度',
+      bullets: [
+        `当前用 ${keywords.join('、')} 作为演示维度生成稳定 mock 结果。`,
+        '适合教程阶段重复演示缓存命中效果。',
+      ],
+    },
+    {
+      key: 'suggestion',
+      title: '建议结论',
+      bullets: [
+        '优先选择成长空间更清晰、职责边界更明确的一方。',
+        '当前输出仅作为缓存示例，不作为真实决策建议。',
+      ],
+    },
+    {
+      key: 'follow-up',
+      title: '后续补充',
+      bullets: [
+        '下一步接入真实 Provider 与管理员触发能力。',
+        '随后再补 viewer 只读缓存体验闭环。',
+      ],
+    },
+  ];
+}
+
+@Injectable()
+export class AnalysisReportCacheService {
+  private readonly cache = new Map<string, AnalysisReport>();
+  private readonly reportIndex = new Map<string, AnalysisReport>();
+
+  getOrCreateReport(input: GetOrCreateReportInput): CachedAnalysisReportResult {
+    const scenario = this.validateScenario(input.scenario);
+    const locale = input.locale ?? 'zh';
+    const normalizedContent = normalizeContent(input.content);
+
+    if (!normalizedContent) {
+      throw new BadRequestException('Content is required');
+    }
+
+    const sourceHash = computeHash(normalizedContent);
+    const cacheKey = `${scenario}:${locale}:${sourceHash}`;
+    const cachedReport = this.cache.get(cacheKey);
+
+    if (cachedReport) {
+      return {
+        cached: true,
+        report: cachedReport,
+      };
+    }
+
+    const keywords = extractKeywords(normalizedContent, locale);
+    const report: AnalysisReport = {
+      reportId: `${scenario}-${sourceHash.slice(0, 12)}`,
+      cacheKey,
+      scenario,
+      locale,
+      sourceHash,
+      inputPreview: buildInputPreview(normalizedContent),
+      summary: buildSummary(scenario, keywords, locale),
+      sections: buildSections(scenario, keywords, locale),
+      generator: 'mock-cache',
+      createdAt: new Date().toISOString(),
+    };
+
+    this.cache.set(cacheKey, report);
+    this.reportIndex.set(report.reportId, report);
+
+    return {
+      cached: false,
+      report,
+    };
+  }
+
+  getReportById(reportId: string): AnalysisReport {
+    const report = this.reportIndex.get(reportId);
+
+    if (!report) {
+      throw new NotFoundException('Cached analysis report not found');
+    }
+
+    return report;
+  }
+
+  private validateScenario(scenario: string): AnalysisScenario {
+    if (!SUPPORTED_SCENARIOS.has(scenario as AnalysisScenario)) {
+      throw new BadRequestException(
+        `Unsupported analysis scenario: ${scenario}`,
+      );
+    }
+
+    return scenario as AnalysisScenario;
+  }
+}

--- a/apps/server/test/ai-report-cache.e2e-spec.ts
+++ b/apps/server/test/ai-report-cache.e2e-spec.ts
@@ -1,0 +1,85 @@
+import { INestApplication } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import request from 'supertest';
+import { App } from 'supertest/types';
+
+import { AppModule } from './../src/app.module';
+
+describe('AI report cache (e2e)', () => {
+  let app: INestApplication<App>;
+
+  beforeEach(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('should reuse the same cached mock report for the same input', async () => {
+    const loginResponse = await request(app.getHttpServer())
+      .post('/auth/login')
+      .send({
+        username: 'admin',
+        password: 'admin123456',
+      })
+      .expect(200);
+
+    const accessToken = loginResponse.body.accessToken as string;
+    const payload = {
+      scenario: 'jd-match',
+      content: 'NestJS React TypeScript Redis BullMQ',
+      locale: 'zh',
+    };
+
+    const first = await request(app.getHttpServer())
+      .post('/ai/reports/cache')
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send(payload)
+      .expect(201);
+
+    const second = await request(app.getHttpServer())
+      .post('/ai/reports/cache')
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send(payload)
+      .expect(201);
+
+    expect(first.body.cached).toBe(false);
+    expect(second.body.cached).toBe(true);
+    expect(second.body.report.reportId).toBe(first.body.report.reportId);
+
+    const detail = await request(app.getHttpServer())
+      .get(`/ai/reports/cache/${first.body.report.reportId}`)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .expect(200);
+
+    expect(detail.body.reportId).toBe(first.body.report.reportId);
+    expect(detail.body.sections).toHaveLength(3);
+  });
+
+  it('should reject unsupported analysis scenarios', async () => {
+    const loginResponse = await request(app.getHttpServer())
+      .post('/auth/login')
+      .send({
+        username: 'admin',
+        password: 'admin123456',
+      })
+      .expect(200);
+
+    const accessToken = loginResponse.body.accessToken as string;
+
+    await request(app.getHttpServer())
+      .post('/ai/reports/cache')
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send({
+        scenario: 'invalid-scenario',
+        content: 'resume content',
+      })
+      .expect(400);
+  });
+});

--- a/docs/30-开发日志/M4-issue-15-缓存分析报告.md
+++ b/docs/30-开发日志/M4-issue-15-缓存分析报告.md
@@ -1,0 +1,166 @@
+# M4 / issue-15 缓存分析报告
+
+- Issue：`#21`
+- 里程碑：`M4 AI 工具链：Mock 到真实 Provider`
+- 分支：`feat/m4-issue-15-cached-analysis-reports`
+- 日期：`2026-03-25`
+
+## 背景
+
+在 provider 适配器和文件提取入口之后，下一步需要先把“分析结果缓存与读取”这条链路站稳。  
+当前我们还不希望过早进入真实模型调用、队列系统和复杂任务编排，因此这一轮只做稳定的 mock 报告缓存。
+
+这样做的意义有两个：
+
+- 后续 `viewer` 角色可以直接读取缓存好的演示结果
+- 后续 `admin` 触发真实 AI 时，也能复用相同的报告读取结构
+
+## 本次目标
+
+- 建立稳定的 mock 分析报告结构
+- 支持同一输入命中同一份缓存结果
+- 提供缓存报告写入 / 读取接口
+- 补齐服务层与接口级测试
+
+## 非目标
+
+- 不接真实模型调用
+- 不接真实队列系统
+- 不做角色权限收紧
+- 不做数据库持久化
+
+## TDD / 测试设计
+
+### 服务层单测
+
+新增 `apps/server/src/modules/ai/analysis-report-cache.service.spec.ts`，先锁定：
+
+- 相同输入会复用同一份缓存报告
+- 不同分析场景会生成不同的缓存 key
+- 可以通过 `reportId` 读取缓存结果
+
+### 接口级 E2E
+
+新增 `apps/server/test/ai-report-cache.e2e-spec.ts`，锁定：
+
+- 登录后可创建 / 复用缓存报告
+- 可以通过 `reportId` 读取缓存详情
+- 不支持的分析场景会返回 `400`
+
+## 首次失败记录
+
+### 1. 缓存服务不存在
+
+- `pnpm --filter @my-resume/server exec jest --runInBand src/modules/ai/analysis-report-cache.service.spec.ts`
+- 结果：失败
+- 原因：缺少 `AnalysisReportCacheService`
+
+### 2. 缓存报告接口不存在
+
+- `pnpm --filter @my-resume/server exec jest --config ./test/jest-e2e.json --runInBand test/ai-report-cache.e2e-spec.ts`
+- 结果：失败
+- 原因：缺少 `/ai/reports/cache` 与 `/ai/reports/cache/:reportId`
+
+## 实际改动
+
+### `apps/server`
+
+- 新增 `AnalysisReportCacheService`
+- 新增 `AiReportController`
+- 在 `AiModule` 中注册缓存报告服务与控制器
+- 支持三类 mock 分析场景：
+  - `jd-match`
+  - `resume-review`
+  - `offer-compare`
+- 使用“场景 + 语言 + 归一化输入 hash”生成稳定缓存 key
+- 返回统一报告结构：
+  - `reportId`
+  - `cacheKey`
+  - `scenario`
+  - `locale`
+  - `sourceHash`
+  - `inputPreview`
+  - `summary`
+  - `sections`
+  - `generator`
+  - `createdAt`
+
+### 当前接口
+
+- `POST /ai/reports/cache`
+  - 根据输入创建或命中缓存报告
+- `GET /ai/reports/cache/:reportId`
+  - 读取已缓存报告详情
+
+## Review 记录
+
+### 是否符合当前 Issue 与里程碑目标
+
+符合。当前只完成了“缓存分析报告”这一层：
+
+- 报告结构稳定
+- 同一输入可复用缓存结果
+- 已有读取接口
+- 已有测试覆盖缓存命中行为
+
+没有提前进入：
+
+- 真实 AI 调用
+- Redis / BullMQ
+- 权限细分到 `admin` 触发、`viewer` 只读
+- 结果持久化到数据库
+
+### 是否存在继续抽离的点
+
+当前先保持最小实现：
+
+- 生成规则集中在 `AnalysisReportCacheService`
+- 控制器只负责读写入口
+- 后续若接入真实任务流，再把“报告生成器”抽为独立 service / strategy
+
+### Review 结论
+
+- 通过
+- 进入自测
+
+## 自测结果
+
+### 1. 服务层专项测试
+
+- `pnpm --filter @my-resume/server exec jest --runInBand src/modules/ai/analysis-report-cache.service.spec.ts`
+- 结果：通过
+
+### 2. 缓存报告 E2E
+
+- `pnpm --filter @my-resume/server exec jest --config ./test/jest-e2e.json --runInBand test/ai-report-cache.e2e-spec.ts`
+- 结果：通过
+
+### 3. `apps/server` 构建
+
+- `pnpm --filter @my-resume/server build`
+- 结果：通过
+
+## 遇到的问题
+
+### 1. 容易把“缓存报告”做成“真实 AI 任务”
+
+- 风险：如果这一步直接引入真实 provider 调用，就会和下一步管理员触发能力耦合在一起
+- 处理：当前只生成稳定的 mock 报告，把缓存和读取结构先固定下来
+
+### 2. viewer 只读边界现在还不该塞进这一轮
+
+- 风险：如果现在就把角色控制一起做完，会让 issue-15 和 issue-16 的职责混在一起
+- 处理：先保留统一接口，下一轮再收紧为“admin 触发、viewer 只读缓存”
+
+## 可沉淀为教程 / 博客的点
+
+- 为什么在接真实 AI 前，先做“可复用的缓存报告结构”
+- 如何用最小 mock 结果把后续接口契约固定下来
+- 为什么教程型项目更适合把“缓存”和“实时触发”拆成两个 issue
+- 如何用 TDD 锁定“同一输入复用同一份结果”
+
+## 后续待办
+
+- 关闭 `issue-15`
+- 继续 `M4 / issue-16`：`admin` 触发实时 AI、`viewer` 只读缓存结果
+- 后续再评估 Redis / 队列 / 持久化接入时机


### PR DESCRIPTION
## Summary
- add mock cached analysis report service and read controller in apps/server
- support stable cache reuse for jd-match, resume-review, and offer-compare
- add unit, e2e, and devlog coverage for issue-15

## Test
- pnpm --filter @my-resume/server exec jest --runInBand src/modules/ai/analysis-report-cache.service.spec.ts
- pnpm --filter @my-resume/server exec jest --config ./test/jest-e2e.json --runInBand test/ai-report-cache.e2e-spec.ts
- pnpm --filter @my-resume/server build

Closes #21
