### PR TITLE
feat(server): add markdown resume export

### DIFF
--- a/apps/server/src/modules/resume/resume-markdown-export.service.spec.ts
+++ b/apps/server/src/modules/resume/resume-markdown-export.service.spec.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { createExampleStandardResume } from './domain/standard-resume';
+import { ResumeMarkdownExportService } from './resume-markdown-export.service';
+
+describe('ResumeMarkdownExportService', () => {
+  const service = new ResumeMarkdownExportService();
+
+  it('should render a published resume as chinese markdown by default', () => {
+    const resume = createExampleStandardResume();
+
+    const markdown = service.render(resume, 'zh');
+
+    expect(markdown).toContain('# 付寅生');
+    expect(markdown).toContain('## 个人简介');
+    expect(markdown).toContain('全栈开发工程师');
+    expect(markdown).toContain('### 示例科技');
+    expect(markdown).toContain('Vue 3 / React / TypeScript / NestJS');
+  });
+
+  it('should render english markdown when locale is en', () => {
+    const resume = createExampleStandardResume();
+
+    const markdown = service.render(resume, 'en');
+
+    expect(markdown).toContain('# Yinsheng Fu');
+    expect(markdown).toContain('## Summary');
+    expect(markdown).toContain('Full-Stack Engineer');
+    expect(markdown).toContain('### Example Tech');
+    expect(markdown).toContain('Focused on frontend engineering');
+  });
+});

--- a/apps/server/src/modules/resume/resume-markdown-export.service.ts
+++ b/apps/server/src/modules/resume/resume-markdown-export.service.ts
@@ -1,0 +1,270 @@
+import { Injectable } from '@nestjs/common';
+
+import {
+  LocalizedText,
+  ResumeLocale,
+  StandardResume,
+} from './domain/standard-resume';
+
+type MarkdownSection = {
+  title: string;
+  lines: string[];
+};
+
+const SECTION_TITLES: Record<
+  ResumeLocale,
+  {
+    summary: string;
+    highlights: string;
+    experience: string;
+    projects: string;
+    education: string;
+    skills: string;
+    interests: string;
+    links: string;
+  }
+> = {
+  zh: {
+    summary: '个人简介',
+    highlights: '亮点',
+    experience: '工作经历',
+    projects: '项目经历',
+    education: '教育经历',
+    skills: '技能清单',
+    interests: '兴趣方向',
+    links: '相关链接',
+  },
+  en: {
+    summary: 'Summary',
+    highlights: 'Highlights',
+    experience: 'Experience',
+    projects: 'Projects',
+    education: 'Education',
+    skills: 'Skills',
+    interests: 'Interests',
+    links: 'Links',
+  },
+};
+
+function readLocalizedText(value: LocalizedText, locale: ResumeLocale): string {
+  return value[locale].trim();
+}
+
+function joinNonEmpty(
+  parts: Array<string | null | undefined>,
+  separator = ' · ',
+) {
+  return parts
+    .map((part) => part?.trim())
+    .filter(Boolean)
+    .join(separator);
+}
+
+function renderBulletList(items: string[]): string[] {
+  return items.filter(Boolean).map((item) => `- ${item}`);
+}
+
+@Injectable()
+export class ResumeMarkdownExportService {
+  render(resume: StandardResume, locale: ResumeLocale): string {
+    const sections = [
+      this.renderProfileSection(resume, locale),
+      this.renderHighlightsSection(resume, locale),
+      this.renderExperienceSection(resume, locale),
+      this.renderProjectsSection(resume, locale),
+      this.renderEducationSection(resume, locale),
+      this.renderSkillsSection(resume, locale),
+    ].filter((section): section is MarkdownSection => section !== null);
+
+    return sections
+      .flatMap((section) => [`## ${section.title}`, ...section.lines, ''])
+      .join('\n')
+      .trim();
+  }
+
+  private renderProfileSection(
+    resume: StandardResume,
+    locale: ResumeLocale,
+  ): MarkdownSection {
+    const titles = SECTION_TITLES[locale];
+    const profile = resume.profile;
+
+    const lines = [
+      `# ${readLocalizedText(profile.fullName, locale)}`,
+      readLocalizedText(profile.headline, locale),
+      joinNonEmpty([
+        readLocalizedText(profile.location, locale),
+        profile.email,
+        profile.phone,
+        profile.website,
+      ]),
+      '',
+      readLocalizedText(profile.summary, locale),
+    ].filter(Boolean) as string[];
+
+    if (profile.links.length > 0) {
+      lines.push('', `### ${titles.links}`);
+      lines.push(
+        ...renderBulletList(
+          profile.links.map((link) => {
+            const label = readLocalizedText(link.label, locale);
+            return `[${label}](${link.url})`;
+          }),
+        ),
+      );
+    }
+
+    if (profile.interests.length > 0) {
+      lines.push('', `### ${titles.interests}`);
+      lines.push(
+        ...renderBulletList(
+          profile.interests.map((interest) =>
+            readLocalizedText(interest, locale),
+          ),
+        ),
+      );
+    }
+
+    return {
+      title: titles.summary,
+      lines,
+    };
+  }
+
+  private renderHighlightsSection(
+    resume: StandardResume,
+    locale: ResumeLocale,
+  ): MarkdownSection | null {
+    if (resume.highlights.length === 0) {
+      return null;
+    }
+
+    return {
+      title: SECTION_TITLES[locale].highlights,
+      lines: resume.highlights.flatMap((item) => [
+        `### ${readLocalizedText(item.title, locale)}`,
+        readLocalizedText(item.description, locale),
+        '',
+      ]),
+    };
+  }
+
+  private renderExperienceSection(
+    resume: StandardResume,
+    locale: ResumeLocale,
+  ): MarkdownSection | null {
+    if (resume.experiences.length === 0) {
+      return null;
+    }
+
+    const lines = resume.experiences.flatMap((item) => [
+      `### ${readLocalizedText(item.companyName, locale)}`,
+      joinNonEmpty([
+        readLocalizedText(item.role, locale),
+        readLocalizedText(item.employmentType, locale),
+        `${item.startDate} - ${item.endDate}`,
+        readLocalizedText(item.location, locale),
+      ]),
+      '',
+      readLocalizedText(item.summary, locale),
+      ...renderBulletList(
+        item.highlights.map((highlight) =>
+          readLocalizedText(highlight, locale),
+        ),
+      ),
+      `**Tech:** ${item.technologies.join(' / ')}`,
+      '',
+    ]);
+
+    return {
+      title: SECTION_TITLES[locale].experience,
+      lines,
+    };
+  }
+
+  private renderProjectsSection(
+    resume: StandardResume,
+    locale: ResumeLocale,
+  ): MarkdownSection | null {
+    if (resume.projects.length === 0) {
+      return null;
+    }
+
+    const lines = resume.projects.flatMap((item) => [
+      `### ${readLocalizedText(item.name, locale)}`,
+      joinNonEmpty([
+        readLocalizedText(item.role, locale),
+        `${item.startDate} - ${item.endDate}`,
+      ]),
+      '',
+      readLocalizedText(item.summary, locale),
+      ...renderBulletList(
+        item.highlights.map((highlight) =>
+          readLocalizedText(highlight, locale),
+        ),
+      ),
+      item.technologies.length > 0
+        ? `**Tech:** ${item.technologies.join(' / ')}`
+        : '',
+      ...renderBulletList(
+        item.links.map((link) => {
+          const label = readLocalizedText(link.label, locale);
+          return `[${label}](${link.url})`;
+        }),
+      ),
+      '',
+    ]);
+
+    return {
+      title: SECTION_TITLES[locale].projects,
+      lines,
+    };
+  }
+
+  private renderEducationSection(
+    resume: StandardResume,
+    locale: ResumeLocale,
+  ): MarkdownSection | null {
+    if (resume.education.length === 0) {
+      return null;
+    }
+
+    const lines = resume.education.flatMap((item) => [
+      `### ${readLocalizedText(item.schoolName, locale)}`,
+      joinNonEmpty([
+        readLocalizedText(item.degree, locale),
+        readLocalizedText(item.fieldOfStudy, locale),
+        `${item.startDate} - ${item.endDate}`,
+        readLocalizedText(item.location, locale),
+      ]),
+      ...renderBulletList(
+        item.highlights.map((highlight) =>
+          readLocalizedText(highlight, locale),
+        ),
+      ),
+      '',
+    ]);
+
+    return {
+      title: SECTION_TITLES[locale].education,
+      lines,
+    };
+  }
+
+  private renderSkillsSection(
+    resume: StandardResume,
+    locale: ResumeLocale,
+  ): MarkdownSection | null {
+    if (resume.skills.length === 0) {
+      return null;
+    }
+
+    return {
+      title: SECTION_TITLES[locale].skills,
+      lines: resume.skills.map(
+        (group) =>
+          `- **${readLocalizedText(group.name, locale)}**: ${group.keywords.join(' / ')}`,
+      ),
+    };
+  }
+}

--- a/apps/server/src/modules/resume/resume.controller.ts
+++ b/apps/server/src/modules/resume/resume.controller.ts
@@ -8,20 +8,25 @@ import {
   NotFoundException,
   Post,
   Put,
+  Query,
+  Res,
   UseGuards,
 } from '@nestjs/common';
+import type { Response } from 'express';
 
 import { RequireCapability } from '../auth/decorators/require-capability.decorator';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { RoleCapabilitiesGuard } from '../auth/guards/role-capabilities.guard';
-import { validateStandardResume } from './domain/standard-resume';
+import { ResumeLocale, validateStandardResume } from './domain/standard-resume';
 import type { StandardResume } from './domain/standard-resume';
+import { ResumeMarkdownExportService } from './resume-markdown-export.service';
 import { ResumePublicationService } from './resume-publication.service';
 
 @Controller('resume')
 export class ResumeController {
   constructor(
     private readonly resumePublicationService: ResumePublicationService,
+    private readonly resumeMarkdownExportService: ResumeMarkdownExportService,
   ) {}
 
   @Get('published')
@@ -33,6 +38,35 @@ export class ResumeController {
     }
 
     return published;
+  }
+
+  @Get('published/export/markdown')
+  exportPublishedResumeMarkdown(
+    @Query('locale') localeQuery: string | undefined,
+    @Res() response: Response,
+  ) {
+    const published = this.resumePublicationService.getPublished();
+
+    if (!published) {
+      throw new NotFoundException('Published resume is not available');
+    }
+
+    const locale = this.resolveExportLocale(
+      localeQuery,
+      published.resume.meta.defaultLocale,
+    );
+    const markdown = this.resumeMarkdownExportService.render(
+      published.resume,
+      locale,
+    );
+
+    response.setHeader('Content-Type', 'text/markdown; charset=utf-8');
+    response.setHeader(
+      'Content-Disposition',
+      `attachment; filename="${published.resume.meta.slug}-${locale}.md"`,
+    );
+
+    response.status(HttpStatus.OK).send(markdown);
   }
 
   @Get('draft')
@@ -62,5 +96,20 @@ export class ResumeController {
   @RequireCapability('canPublishResume')
   publishResume() {
     return this.resumePublicationService.publish();
+  }
+
+  private resolveExportLocale(
+    locale: string | undefined,
+    fallbackLocale: ResumeLocale,
+  ): ResumeLocale {
+    if (!locale) {
+      return fallbackLocale;
+    }
+
+    if (locale !== 'zh' && locale !== 'en') {
+      throw new BadRequestException(`Unsupported locale: ${locale}`);
+    }
+
+    return locale;
   }
 }

--- a/apps/server/src/modules/resume/resume.module.ts
+++ b/apps/server/src/modules/resume/resume.module.ts
@@ -2,12 +2,13 @@ import { Module } from '@nestjs/common';
 
 import { AuthModule } from '../auth/auth.module';
 import { ResumeController } from './resume.controller';
+import { ResumeMarkdownExportService } from './resume-markdown-export.service';
 import { ResumePublicationService } from './resume-publication.service';
 
 @Module({
   imports: [AuthModule],
   controllers: [ResumeController],
-  providers: [ResumePublicationService],
-  exports: [ResumePublicationService],
+  providers: [ResumePublicationService, ResumeMarkdownExportService],
+  exports: [ResumePublicationService, ResumeMarkdownExportService],
 })
 export class ResumeModule {}

--- a/apps/server/test/resume-publication.e2e-spec.ts
+++ b/apps/server/test/resume-publication.e2e-spec.ts
@@ -25,6 +25,12 @@ describe('Resume publication flow (e2e)', () => {
     return request(app.getHttpServer()).get('/resume/published').expect(404);
   });
 
+  it('should hide unpublished markdown export from the public endpoint', () => {
+    return request(app.getHttpServer())
+      .get('/resume/published/export/markdown')
+      .expect(404);
+  });
+
   it('should allow admin to update draft and publish it', async () => {
     const loginResponse = await request(app.getHttpServer())
       .post('/auth/login')
@@ -98,6 +104,18 @@ describe('Resume publication flow (e2e)', () => {
       zh: '已发布候选稿',
       en: 'Publish Candidate',
     });
+
+    const markdownResponse = await request(app.getHttpServer())
+      .get('/resume/published/export/markdown?locale=en')
+      .expect(200);
+
+    expect(markdownResponse.headers['content-type']).toContain('text/markdown');
+    expect(markdownResponse.headers['content-disposition']).toContain(
+      'standard-resume-en.md',
+    );
+    expect(markdownResponse.text).toContain('# Yinsheng Fu');
+    expect(markdownResponse.text).toContain('## Summary');
+    expect(markdownResponse.text).toContain('Publish Candidate');
   });
 
   it('should keep viewer read-only for draft and publish actions', async () => {
@@ -121,5 +139,26 @@ describe('Resume publication flow (e2e)', () => {
       .post('/resume/publish')
       .set('Authorization', `Bearer ${accessToken}`)
       .expect(403);
+  });
+
+  it('should reject unsupported markdown export locale', async () => {
+    const loginResponse = await request(app.getHttpServer())
+      .post('/auth/login')
+      .send({
+        username: 'admin',
+        password: 'admin123456',
+      })
+      .expect(200);
+
+    const accessToken = loginResponse.body.accessToken as string;
+
+    await request(app.getHttpServer())
+      .post('/resume/publish')
+      .set('Authorization', `Bearer ${accessToken}`)
+      .expect(200);
+
+    await request(app.getHttpServer())
+      .get('/resume/published/export/markdown?locale=ja')
+      .expect(400);
   });
 });

--- a/docs/30-开发日志/M5-issue-17-Markdown-导出.md
+++ b/docs/30-开发日志/M5-issue-17-Markdown-导出.md
@@ -1,0 +1,156 @@
+# M5 / issue-17 Markdown 导出
+
+- Issue：`#22`
+- 里程碑：`M5 导出与下载：Markdown / PDF`
+- 分支：`feat/m5-issue-17-markdown-export`
+- 日期：`2026-03-25`
+
+## 背景
+
+在已发布简历内容已经跑通之后，最适合作为导出起点的能力就是 Markdown。  
+它比 PDF 更容易解释、调试和测试，也能先把“导出内容必须与已发布版本一致”这条主线固定下来。
+
+因此 M5 的第一步不碰复杂样式布局，先让 `apps/server` 对外输出标准 Markdown 简历。
+
+## 本次目标
+
+- 由 `apps/server` 生成标准 Markdown 简历
+- 导出内容与已发布版本保持一致
+- 支持 `zh / en` 导出
+- 提供公开下载响应
+- 补齐服务层与 E2E 测试
+
+## 非目标
+
+- 不做 PDF 布局
+- 不做多模板切换
+- 不接 `web / admin` 下载按钮
+- 不做文件持久化存储
+
+## TDD / 测试设计
+
+### 服务层单测
+
+新增 `apps/server/src/modules/resume/resume-markdown-export.service.spec.ts`，先锁定：
+
+- 默认可输出中文 Markdown
+- 可按 `locale=en` 输出英文 Markdown
+- 内容包含个人信息、摘要、经历与技术栈等核心模块
+
+### E2E
+
+在 `apps/server/test/resume-publication.e2e-spec.ts` 中补充：
+
+- 未发布时导出接口返回 `404`
+- 发布后可访问 `GET /resume/published/export/markdown`
+- 返回 `text/markdown`
+- 返回附件文件名
+- 不支持的 `locale` 返回 `400`
+
+## 首次失败记录
+
+### 1. Markdown 导出服务不存在
+
+- `pnpm --filter @my-resume/server exec jest --runInBand src/modules/resume/resume-markdown-export.service.spec.ts`
+- 结果：失败
+- 原因：缺少 `ResumeMarkdownExportService`
+
+### 2. 导出接口不存在
+
+- `pnpm --filter @my-resume/server exec jest --config ./test/jest-e2e.json --runInBand test/resume-publication.e2e-spec.ts`
+- 结果：失败
+- 原因：缺少 `GET /resume/published/export/markdown`
+
+## 实际改动
+
+### `apps/server`
+
+- 新增 `ResumeMarkdownExportService`
+- 在 `ResumeController` 中新增：
+  - `GET /resume/published/export/markdown`
+- 导出逻辑直接读取“已发布快照”
+- 支持 `locale=zh | en`
+- 默认使用简历的 `defaultLocale`
+- 设置响应头：
+  - `Content-Type: text/markdown; charset=utf-8`
+  - `Content-Disposition: attachment; filename="standard-resume-{locale}.md"`
+
+### 导出内容范围
+
+当前 Markdown 包含：
+
+- 个人简介
+- 相关链接
+- 兴趣方向
+- 亮点
+- 工作经历
+- 项目经历
+- 教育经历
+- 技能清单
+
+## Review 记录
+
+### 是否符合当前 Issue 与里程碑目标
+
+符合。当前只完成了 Markdown 导出这一个子能力：
+
+- 只导出已发布简历
+- 只做 Markdown
+- 没有提前进入 PDF 或前端下载入口
+
+### 是否存在可继续抽离的点
+
+当前拆分已经比较清晰：
+
+- `ResumePublicationService` 负责已发布数据来源
+- `ResumeMarkdownExportService` 负责纯导出格式化
+- `ResumeController` 只负责公开响应输出
+
+后续做 PDF 时可以平行新增 `ResumePdfExportService`，不需要把 Markdown 逻辑塞回控制器。
+
+### Review 结论
+
+- 通过
+- 可以进入自测与提交阶段
+
+## 自测结果
+
+### 1. Resume 模块单测
+
+- `pnpm --filter @my-resume/server exec jest --runInBand src/modules/resume/resume-publication.service.spec.ts src/modules/resume/resume-markdown-export.service.spec.ts`
+- 结果：通过
+
+### 2. 发布流 E2E
+
+- `pnpm --filter @my-resume/server exec jest --config ./test/jest-e2e.json --runInBand test/resume-publication.e2e-spec.ts`
+- 结果：通过
+
+### 3. `apps/server` 构建
+
+- `pnpm --filter @my-resume/server build`
+- 结果：通过
+
+## 遇到的问题
+
+### 1. 导出应该基于 draft 还是 published 很容易摇摆
+
+- 风险：如果导出读取 draft，会让公开站和导出结果不一致
+- 处理：当前统一只导出 published，先保证行为稳定
+
+### 2. Markdown 很容易在第一轮写成“临时拼字符串”
+
+- 风险：后续做 PDF 或多模板时无法复用结构
+- 处理：单独抽 `ResumeMarkdownExportService`，让格式化职责集中
+
+## 可沉淀为教程 / 博客的点
+
+- 为什么 M5 第一轮先做 Markdown，而不是直接做 PDF
+- 为什么导出必须绑定已发布快照，而不是草稿
+- 如何把“导出格式化”从控制器里独立出来
+- 如何用测试锁定内容一致性与响应头契约
+
+## 后续待办
+
+- 关闭 `issue-17`
+- 继续 `issue-18`：PDF 导出
+- 然后再推进 `issue-19`：`web/admin` 下载入口


### PR DESCRIPTION
## Summary
- add published markdown export in apps/server
- support zh/en markdown rendering from the published resume snapshot
- add service tests, e2e coverage, and issue-17 devlog

## Test
- pnpm --filter @my-resume/server exec jest --runInBand src/modules/resume/resume-publication.service.spec.ts src/modules/resume/resume-markdown-export.service.spec.ts
- pnpm --filter @my-resume/server exec jest --config ./test/jest-e2e.json --runInBand test/resume-publication.e2e-spec.ts
- pnpm --filter @my-resume/server build

Closes #22
