### PR TITLE
feat(server): add pdf resume export

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -44,6 +44,7 @@
     "@types/jest": "^30.0.0",
     "@types/multer": "^2.1.0",
     "@types/node": "^22.10.7",
+    "@types/pdfkit": "^0.17.5",
     "@types/supertest": "^6.0.2",
     "eslint": "^9.18.0",
     "eslint-config-prettier": "^10.0.1",

--- a/apps/server/src/modules/resume/resume-pdf-export.service.spec.ts
+++ b/apps/server/src/modules/resume/resume-pdf-export.service.spec.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { createExampleStandardResume } from './domain/standard-resume';
+import { ResumeMarkdownExportService } from './resume-markdown-export.service';
+import { ResumePdfExportService } from './resume-pdf-export.service';
+
+describe('ResumePdfExportService', () => {
+  const markdownService = new ResumeMarkdownExportService();
+  const service = new ResumePdfExportService(markdownService);
+
+  it('should render the published resume into a pdf buffer', async () => {
+    const resume = createExampleStandardResume();
+
+    const pdfBuffer = await service.render(resume, 'zh');
+
+    expect(pdfBuffer.byteLength).toBeGreaterThan(100);
+    expect(pdfBuffer.subarray(0, 4).toString('utf8')).toBe('%PDF');
+  });
+});

--- a/apps/server/src/modules/resume/resume-pdf-export.service.ts
+++ b/apps/server/src/modules/resume/resume-pdf-export.service.ts
@@ -1,0 +1,80 @@
+import { Injectable } from '@nestjs/common';
+import PDFDocument from 'pdfkit';
+
+import { ResumeLocale, StandardResume } from './domain/standard-resume';
+import { ResumeMarkdownExportService } from './resume-markdown-export.service';
+
+@Injectable()
+export class ResumePdfExportService {
+  constructor(
+    private readonly resumeMarkdownExportService: ResumeMarkdownExportService,
+  ) {}
+
+  async render(
+    resume: StandardResume,
+    locale: ResumeLocale,
+  ): Promise<Buffer<ArrayBufferLike>> {
+    const markdown = this.resumeMarkdownExportService.render(resume, locale);
+
+    return new Promise((resolve, reject) => {
+      const document = new PDFDocument({
+        margin: 48,
+        size: 'A4',
+      });
+      const chunks: Buffer[] = [];
+
+      document.on('data', (chunk: Buffer | Uint8Array | string) => {
+        chunks.push(
+          Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk as Uint8Array),
+        );
+      });
+      document.on('end', () => resolve(Buffer.concat(chunks)));
+      document.on('error', reject);
+
+      document.fontSize(12);
+
+      markdown.split('\n').forEach((line, index) => {
+        const trimmedLine = line.trim();
+
+        if (!trimmedLine) {
+          document.moveDown(0.4);
+          return;
+        }
+
+        if (trimmedLine.startsWith('# ')) {
+          document.fontSize(20).text(trimmedLine.slice(2));
+          document.moveDown(0.6);
+          document.fontSize(12);
+          return;
+        }
+
+        if (trimmedLine.startsWith('## ')) {
+          document.fontSize(16).text(trimmedLine.slice(3));
+          document.moveDown(0.4);
+          document.fontSize(12);
+          return;
+        }
+
+        if (trimmedLine.startsWith('### ')) {
+          document.fontSize(13).text(trimmedLine.slice(4));
+          document.moveDown(0.2);
+          document.fontSize(12);
+          return;
+        }
+
+        if (trimmedLine.startsWith('- ')) {
+          document.text(`• ${trimmedLine.slice(2)}`);
+          return;
+        }
+
+        document.text(trimmedLine);
+
+        if (index < markdown.length - 1) {
+          document.moveDown(0.2);
+        }
+      });
+
+      document.end();
+    });
+  }
+}

--- a/apps/server/src/modules/resume/resume.controller.ts
+++ b/apps/server/src/modules/resume/resume.controller.ts
@@ -20,6 +20,7 @@ import { RoleCapabilitiesGuard } from '../auth/guards/role-capabilities.guard';
 import { ResumeLocale, validateStandardResume } from './domain/standard-resume';
 import type { StandardResume } from './domain/standard-resume';
 import { ResumeMarkdownExportService } from './resume-markdown-export.service';
+import { ResumePdfExportService } from './resume-pdf-export.service';
 import { ResumePublicationService } from './resume-publication.service';
 
 @Controller('resume')
@@ -27,6 +28,7 @@ export class ResumeController {
   constructor(
     private readonly resumePublicationService: ResumePublicationService,
     private readonly resumeMarkdownExportService: ResumeMarkdownExportService,
+    private readonly resumePdfExportService: ResumePdfExportService,
   ) {}
 
   @Get('published')
@@ -67,6 +69,35 @@ export class ResumeController {
     );
 
     response.status(HttpStatus.OK).send(markdown);
+  }
+
+  @Get('published/export/pdf')
+  async exportPublishedResumePdf(
+    @Query('locale') localeQuery: string | undefined,
+    @Res() response: Response,
+  ) {
+    const published = this.resumePublicationService.getPublished();
+
+    if (!published) {
+      throw new NotFoundException('Published resume is not available');
+    }
+
+    const locale = this.resolveExportLocale(
+      localeQuery,
+      published.resume.meta.defaultLocale,
+    );
+    const pdfBuffer = await this.resumePdfExportService.render(
+      published.resume,
+      locale,
+    );
+
+    response.setHeader('Content-Type', 'application/pdf');
+    response.setHeader(
+      'Content-Disposition',
+      `attachment; filename="${published.resume.meta.slug}-${locale}.pdf"`,
+    );
+
+    response.status(HttpStatus.OK).send(pdfBuffer);
   }
 
   @Get('draft')

--- a/apps/server/src/modules/resume/resume.module.ts
+++ b/apps/server/src/modules/resume/resume.module.ts
@@ -3,12 +3,21 @@ import { Module } from '@nestjs/common';
 import { AuthModule } from '../auth/auth.module';
 import { ResumeController } from './resume.controller';
 import { ResumeMarkdownExportService } from './resume-markdown-export.service';
+import { ResumePdfExportService } from './resume-pdf-export.service';
 import { ResumePublicationService } from './resume-publication.service';
 
 @Module({
   imports: [AuthModule],
   controllers: [ResumeController],
-  providers: [ResumePublicationService, ResumeMarkdownExportService],
-  exports: [ResumePublicationService, ResumeMarkdownExportService],
+  providers: [
+    ResumePublicationService,
+    ResumeMarkdownExportService,
+    ResumePdfExportService,
+  ],
+  exports: [
+    ResumePublicationService,
+    ResumeMarkdownExportService,
+    ResumePdfExportService,
+  ],
 })
 export class ResumeModule {}

--- a/apps/server/test/resume-publication.e2e-spec.ts
+++ b/apps/server/test/resume-publication.e2e-spec.ts
@@ -116,6 +116,15 @@ describe('Resume publication flow (e2e)', () => {
     expect(markdownResponse.text).toContain('# Yinsheng Fu');
     expect(markdownResponse.text).toContain('## Summary');
     expect(markdownResponse.text).toContain('Publish Candidate');
+
+    const pdfResponse = await request(app.getHttpServer())
+      .get('/resume/published/export/pdf?locale=zh')
+      .expect(200);
+
+    expect(pdfResponse.headers['content-type']).toContain('application/pdf');
+    expect(pdfResponse.headers['content-disposition']).toContain(
+      'standard-resume-zh.pdf',
+    );
   });
 
   it('should keep viewer read-only for draft and publish actions', async () => {
@@ -159,6 +168,27 @@ describe('Resume publication flow (e2e)', () => {
 
     await request(app.getHttpServer())
       .get('/resume/published/export/markdown?locale=ja')
+      .expect(400);
+  });
+
+  it('should reject unsupported pdf export locale', async () => {
+    const loginResponse = await request(app.getHttpServer())
+      .post('/auth/login')
+      .send({
+        username: 'admin',
+        password: 'admin123456',
+      })
+      .expect(200);
+
+    const accessToken = loginResponse.body.accessToken as string;
+
+    await request(app.getHttpServer())
+      .post('/resume/publish')
+      .set('Authorization', `Bearer ${accessToken}`)
+      .expect(200);
+
+    await request(app.getHttpServer())
+      .get('/resume/published/export/pdf?locale=ja')
       .expect(400);
   });
 });

--- a/docs/30-开发日志/M5-issue-18-PDF-导出.md
+++ b/docs/30-开发日志/M5-issue-18-PDF-导出.md
@@ -1,0 +1,142 @@
+# M5 / issue-18 PDF 导出
+
+- Issue：`#25`
+- 里程碑：`M5 导出与下载：Markdown / PDF`
+- 分支：`feat/m5-issue-18-pdf-export`
+- 日期：`2026-03-25`
+
+## 背景
+
+在 Markdown 导出已经固定住内容结构后，M5 的第二步就是 PDF。  
+这一轮的目标不是把 PDF 做成复杂排版模板，而是先打通“已发布内容 -> 服务端 PDF 下载”这条主链路。
+
+这样后续无论是做精细样式、打印优化，还是多模板扩展，都有了稳定的服务端出口。
+
+## 本次目标
+
+- 由 `apps/server` 输出标准 PDF 简历
+- 导出内容与已发布版本保持一致
+- 支持 `zh / en` 导出
+- 提供公开下载响应
+- 补齐服务层与 E2E 测试
+
+## 非目标
+
+- 不做复杂排版模板
+- 不做多页精细设计
+- 不接 `web / admin` 下载按钮
+- 不引入浏览器端 PDF 渲染
+
+## TDD / 测试设计
+
+### 服务层单测
+
+新增 `apps/server/src/modules/resume/resume-pdf-export.service.spec.ts`，先锁定：
+
+- 可输出 PDF 二进制内容
+- 结果 buffer 具有 `%PDF` 头部
+
+### E2E
+
+在 `apps/server/test/resume-publication.e2e-spec.ts` 中补充：
+
+- 发布后可访问 `GET /resume/published/export/pdf`
+- 返回 `application/pdf`
+- 返回附件文件名
+- 不支持的 `locale` 返回 `400`
+
+## 首次失败记录
+
+### 1. PDF 导出服务不存在
+
+- `pnpm --filter @my-resume/server exec jest --runInBand src/modules/resume/resume-pdf-export.service.spec.ts`
+- 结果：失败
+- 原因：缺少 `ResumePdfExportService`
+
+### 2. PDF 导出接口不存在
+
+- `pnpm --filter @my-resume/server exec jest --config ./test/jest-e2e.json --runInBand test/resume-publication.e2e-spec.ts`
+- 结果：失败
+- 原因：缺少 `GET /resume/published/export/pdf`
+
+## 实际改动
+
+### `apps/server`
+
+- 新增 `ResumePdfExportService`
+- 在 `ResumeController` 中新增：
+  - `GET /resume/published/export/pdf`
+- PDF 渲染基于 `pdfkit`
+- PDF 内容基于现有 Markdown 导出结果进一步渲染，保证内容来源统一
+- 支持 `locale=zh | en`
+- 设置响应头：
+  - `Content-Type: application/pdf`
+  - `Content-Disposition: attachment; filename="standard-resume-{locale}.pdf"`
+
+## Review 记录
+
+### 是否符合当前 Issue 与里程碑目标
+
+符合。当前只完成了 PDF 导出主链路：
+
+- 只导出已发布内容
+- 只做最小可用 PDF
+- 没有提前进入 web/admin 下载入口
+- 没有提前做复杂样式布局
+
+### 是否存在可继续抽离的点
+
+当前拆分依旧清晰：
+
+- `ResumeMarkdownExportService` 负责内容文本结构
+- `ResumePdfExportService` 负责 PDF 渲染
+- `ResumeController` 只做公开响应输出
+
+后续如果要做更精细的 PDF 模板，可以继续保留同样的职责边界。
+
+### Review 结论
+
+- 通过
+- 可以进入自测与提交阶段
+
+## 自测结果
+
+### 1. Resume 导出单测
+
+- `pnpm --filter @my-resume/server exec jest --runInBand src/modules/resume/resume-pdf-export.service.spec.ts`
+- 结果：通过
+
+### 2. 发布流 E2E
+
+- `pnpm --filter @my-resume/server exec jest --config ./test/jest-e2e.json --runInBand test/resume-publication.e2e-spec.ts`
+- 结果：通过
+
+### 3. `apps/server` 构建
+
+- `pnpm --filter @my-resume/server build`
+- 结果：通过
+
+## 遇到的问题
+
+### 1. PDF 内容如果重新单独拼装，容易和 Markdown / 已发布内容漂移
+
+- 风险：两套导出逻辑越走越远，后续很难保证一致性
+- 处理：当前让 PDF 复用 Markdown 导出内容作为文本来源，再进行 PDF 渲染
+
+### 2. 过早追求 PDF 精美样式会打乱教程节奏
+
+- 风险：一开始就做复杂布局，会把重点从“导出链路”转到“视觉排版”
+- 处理：这一轮只做最小可用 PDF，把接口和服务边界先固定下来
+
+## 可沉淀为教程 / 博客的点
+
+- 为什么 PDF 导出最好放在 Markdown 导出之后做
+- 如何让 PDF 和 Markdown 共用同一份内容来源
+- 服务端 PDF 导出为什么比前端浏览器导出更稳定
+- 如何把“最小可用 PDF”与“复杂模板系统”拆成两阶段
+
+## 后续待办
+
+- 关闭 `issue-18`
+- 继续 `issue-19`：`web/admin` 下载入口
+- 评估 M5 收官时是否补一篇教程大纲

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -191,6 +191,9 @@ importers:
       '@types/node':
         specifier: ^22.10.7
         version: 22.19.15
+      '@types/pdfkit':
+        specifier: ^0.17.5
+        version: 0.17.5
       '@types/supertest':
         specifier: ^6.0.2
         version: 6.0.3
@@ -1667,6 +1670,9 @@ packages:
 
   '@types/node@25.5.0':
     resolution: {integrity: sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==}
+
+  '@types/pdfkit@0.17.5':
+    resolution: {integrity: sha512-T3ZHnvF91HsEco5ClhBCOuBwobZfPcI2jaiSHybkkKYq4KhVIIurod94JVKvDIG0JXT6o3KiERC0X0//m8dyrg==}
 
   '@types/qs@6.15.0':
     resolution: {integrity: sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow==}
@@ -6432,6 +6438,10 @@ snapshots:
   '@types/node@25.5.0':
     dependencies:
       undici-types: 7.18.2
+
+  '@types/pdfkit@0.17.5':
+    dependencies:
+      '@types/node': 22.19.15
 
   '@types/qs@6.15.0': {}
 


### PR DESCRIPTION
## Summary
- add published PDF export in apps/server
- reuse markdown content as the source for minimal PDF rendering
- add service tests, e2e coverage, and issue-18 devlog

## Test
- pnpm --filter @my-resume/server exec jest --runInBand src/modules/resume/resume-pdf-export.service.spec.ts
- pnpm --filter @my-resume/server exec jest --config ./test/jest-e2e.json --runInBand test/resume-publication.e2e-spec.ts
- pnpm --filter @my-resume/server build

Closes #25
