### PR TITLE
[M7][issue-32] 旧版简历内容迁移到标准模型

### DIFF
--- a/apps/server/src/modules/resume/domain/standard-resume.ts
+++ b/apps/server/src/modules/resume/domain/standard-resume.ts
@@ -109,6 +109,13 @@ export function createEmptyLocalizedText(): LocalizedText {
   };
 }
 
+export function createLocalizedText(zh: string, en: string): LocalizedText {
+  return {
+    zh,
+    en,
+  };
+}
+
 export function isLocalizedText(value: unknown): value is LocalizedText {
   if (!value || typeof value !== 'object') {
     return false;
@@ -162,147 +169,412 @@ export function createExampleStandardResume(): StandardResume {
       locales: ['zh', 'en'],
     },
     profile: {
-      fullName: {
-        zh: '付寅生',
-        en: 'Yinsheng Fu',
-      },
-      headline: {
-        zh: '全栈开发工程师',
-        en: 'Full-Stack Engineer',
-      },
-      summary: {
-        zh: '专注于前端工程化、Node.js 后端与 AI 工具链落地。',
-        en: 'Focused on frontend engineering, Node.js backend development, and AI workflow integration.',
-      },
-      location: {
-        zh: '中国 上海',
-        en: 'Shanghai, China',
-      },
-      email: 'demo@example.com',
-      phone: '+86 13800000000',
-      website: 'https://example.com',
+      fullName: createLocalizedText('付寅生', 'Yinsheng Fu'),
+      headline: createLocalizedText('前端工程师 / 前端负责人', 'Frontend Engineer / Frontend Lead'),
+      summary: createLocalizedText(
+        '8 年前端开发经验，经历 ToB 安全平台、综合管理后台、SaaS 与小程序项目，擅长 Vue3、TypeScript、前端工程化与团队协作，也在持续补齐 React、Next.js、NestJS 与 AI 工具链能力。',
+        'Frontend engineer with 8 years of experience across ToB security platforms, integrated admin systems, SaaS products, and mini-program projects. Strong in Vue 3, TypeScript, frontend engineering, and team collaboration, while actively expanding into React, Next.js, NestJS, and AI workflows.',
+      ),
+      location: createLocalizedText('中国 成都', 'Chengdu, China'),
+      email: '249121486@qq.com',
+      phone: '16602835945',
+      website: 'https://resume.fridolph.top',
       links: [
         {
-          label: {
-            zh: 'GitHub',
-            en: 'GitHub',
-          },
+          label: createLocalizedText('GitHub', 'GitHub'),
           url: 'https://github.com/Fridolph',
+        },
+        {
+          label: createLocalizedText('技术博客', 'Tech Blog'),
+          url: 'https://blog.fridolph.top',
+        },
+        {
+          label: createLocalizedText('掘金', 'Juejin'),
+          url: 'https://juejin.cn/user/3984288320609918',
         },
       ],
       interests: [
-        {
-          zh: '开源项目',
-          en: 'Open Source',
-        },
+        createLocalizedText('羽毛球', 'Badminton'),
+        createLocalizedText('动漫', 'Anime'),
+        createLocalizedText('音乐', 'Music'),
+        createLocalizedText('开源', 'Open Source'),
       ],
     },
     education: [
       {
-        schoolName: {
-          zh: '示例大学',
-          en: 'Example University',
-        },
-        degree: {
-          zh: '本科',
-          en: 'Bachelor',
-        },
-        fieldOfStudy: {
-          zh: '软件工程',
-          en: 'Software Engineering',
-        },
-        startDate: '2016-09',
-        endDate: '2020-06',
-        location: {
-          zh: '中国',
-          en: 'China',
-        },
+        schoolName: createLocalizedText(
+          '四川大学锦江学院',
+          'Sichuan University Jinjiang College',
+        ),
+        degree: createLocalizedText('本科', 'Bachelor'),
+        fieldOfStudy: createLocalizedText('通信工程', 'Communication Engineering'),
+        startDate: '2012-09',
+        endDate: '2016-06',
+        location: createLocalizedText('四川 眉山', 'Meishan, Sichuan'),
         highlights: [
-          {
-            zh: '主修软件工程与分布式系统',
-            en: 'Focused on software engineering and distributed systems.',
-          },
+          createLocalizedText(
+            '完成通信工程本科学习，系统接触通信原理、计算机基础与工程实践。',
+            'Completed undergraduate study in Communication Engineering with systematic exposure to communication principles, computer fundamentals, and engineering practice.',
+          ),
         ],
       },
     ],
     experiences: [
       {
-        companyName: {
-          zh: '示例科技',
-          en: 'Example Tech',
-        },
-        role: {
-          zh: '前端负责人',
-          en: 'Frontend Lead',
-        },
-        employmentType: {
-          zh: '全职',
-          en: 'Full-time',
-        },
-        startDate: '2022-01',
-        endDate: '至今',
-        location: {
-          zh: '上海',
-          en: 'Shanghai',
-        },
-        summary: {
-          zh: '负责中后台平台前端架构与研发规范建设。',
-          en: 'Led frontend architecture and engineering standards for internal platforms.',
-        },
+        companyName: createLocalizedText(
+          '成都一蟹科技有限公司',
+          'Chengdu Yixie Technology Co., Ltd.',
+        ),
+        role: createLocalizedText('前端主管', 'Frontend Lead'),
+        employmentType: createLocalizedText('全职', 'Full-time'),
+        startDate: '2024-03',
+        endDate: '2024-08',
+        location: createLocalizedText('成都', 'Chengdu'),
+        summary: createLocalizedText(
+          '负责需求规划、团队协作、技术升级与质量建设，推动前端体系化建设和知识沉淀。',
+          'Led requirement planning, team collaboration, technical upgrades, and quality practices, while promoting a more systematic frontend engineering workflow and knowledge sharing.',
+        ),
         highlights: [
-          {
-            zh: '推动 monorepo 与组件标准化',
-            en: 'Promoted monorepo adoption and UI component standardization.',
-          },
+          createLocalizedText(
+            '规划并实施 2024 年二、三季度计划，推动团队整体绩效提升。',
+            'Planned and executed Q2 and Q3 goals for 2024, improving overall team effectiveness.',
+          ),
+          createLocalizedText(
+            '建立并丰富语雀知识库，沉淀团队协作、规范与复盘材料。',
+            'Built and enriched the internal knowledge base to capture collaboration rules, standards, and project learnings.',
+          ),
+          createLocalizedText(
+            '定期组织 Code Review 和技术分享，改善质量保障与团队交流氛围。',
+            'Organized regular code reviews and sharing sessions to improve code quality and team communication.',
+          ),
         ],
-        technologies: ['Vue 3', 'React', 'TypeScript', 'NestJS'],
+        technologies: ['Vue 3', 'TypeScript', 'uni-app', 'pnpm', 'Monorepo'],
+      },
+      {
+        companyName: createLocalizedText(
+          '成都网思科平科技有限公司',
+          'OneScorpion Technology Co., Ltd.',
+        ),
+        role: createLocalizedText('前端组长', 'Frontend Team Lead'),
+        employmentType: createLocalizedText('全职', 'Full-time'),
+        startDate: '2017-07',
+        endDate: '2024-01',
+        location: createLocalizedText('成都', 'Chengdu'),
+        summary: createLocalizedText(
+          '负责多个 ToB 安全与管理平台的前端架构、规范建设、跨端协作和重点模块交付。',
+          'Led frontend architecture, engineering standards, cross-team collaboration, and key feature delivery across multiple ToB security and management platforms.',
+        ),
+        highlights: [
+          createLocalizedText(
+            '主导前端架构搭建、技术选型与开发规范落地，推动团队形成稳定协作方式。',
+            'Led frontend architecture, technical choices, and engineering conventions, helping the team build a stable collaboration model.',
+          ),
+          createLocalizedText(
+            '参与需求梳理、接口约定、单元测试与 Code Review，持续优化交付质量。',
+            'Participated in requirement refinement, API contracts, unit testing, and code review to continuously improve delivery quality.',
+          ),
+          createLocalizedText(
+            '承担团队 Leader 角色，推动资源共享、知识沉淀和新人支持。',
+            'Acted as team lead to promote shared resources, knowledge accumulation, and onboarding support.',
+          ),
+        ],
+        technologies: [
+          'Vue',
+          'Vue 3',
+          'TypeScript',
+          'ECharts',
+          'WebSocket',
+          'vxe-table',
+        ],
+      },
+      {
+        companyName: createLocalizedText(
+          '四川爱礼科技有限公司',
+          'Sichuan Aili Technology Co., Ltd.',
+        ),
+        role: createLocalizedText('Web 开发 / 移动端 WebView', 'Web Developer / Mobile WebView Developer'),
+        employmentType: createLocalizedText('全职', 'Full-time'),
+        startDate: '2016-01',
+        endDate: '2017-07',
+        location: createLocalizedText('成都', 'Chengdu'),
+        summary: createLocalizedText(
+          '参与官网与主项目页面开发，负责高精度还原、组件拆分、响应式适配与前后端联调。',
+          'Worked on the company website and core product pages, focusing on precise implementation, componentization, responsive adaptation, and frontend-backend integration.',
+        ),
+        highlights: [
+          createLocalizedText(
+            '完成页面模块拆分与复用，提升开发效率和维护性。',
+            'Split pages into reusable modules to improve development efficiency and maintainability.',
+          ),
+          createLocalizedText(
+            '适配主流移动设备与浏览器，保障一致的浏览体验。',
+            'Adapted pages for mainstream mobile devices and browsers to ensure a consistent browsing experience.',
+          ),
+          createLocalizedText(
+            '在架构升级阶段接触 React、Webpack 与工程化开发模式。',
+            'Got hands-on experience with React, Webpack, and an early frontend engineering workflow during the architecture upgrade.',
+          ),
+        ],
+        technologies: ['React', 'Webpack', 'Redux', 'jQuery', 'Bootstrap'],
       },
     ],
     projects: [
       {
-        name: {
-          zh: '个人简历 Monorepo',
-          en: 'Personal Resume Monorepo',
-        },
-        role: {
-          zh: '作者 / 维护者',
-          en: 'Author / Maintainer',
-        },
-        startDate: '2026-03',
-        endDate: '进行中',
-        summary: {
-          zh: '以教程型方式逐步构建 admin / web / server 三端项目。',
-          en: 'Building an admin / web / server monorepo incrementally as a tutorial-driven project.',
-        },
+        name: createLocalizedText('云药客 SaaS 系统', 'YYK SaaS Platform'),
+        role: createLocalizedText('核心前端开发', 'Core Frontend Engineer'),
+        startDate: '2024-03',
+        endDate: '2024-08',
+        summary: createLocalizedText(
+          '为药械企业提供推广与结算管理的 SaaS 方案，支持多组织、多任务与合规流程。',
+          'A SaaS solution for pharmaceutical and medical device companies, supporting multi-organization task settlement and compliance workflows.',
+        ),
         highlights: [
+          createLocalizedText(
+            '将系统中的 Vue2 代码和组件重构到 Vue3 + TypeScript，并升级 antdVue 版本。',
+            'Refactored legacy Vue 2 code and components to Vue 3 + TypeScript and upgraded antdVue.',
+          ),
+          createLocalizedText(
+            '引入 pnpm 与 monorepo 思路，改善分支与依赖管理效率。',
+            'Introduced pnpm and monorepo practices to improve dependency and branch management.',
+          ),
+          createLocalizedText(
+            '设计组合式卡片、模式入口、组合搜索等可复用业务组件。',
+            'Designed reusable business components such as composite cards, mode entry points, and combined search.',
+          ),
+        ],
+        technologies: ['Vue 3', 'TypeScript', 'Ant Design Vue', 'Pinia', 'pnpm'],
+        links: [],
+      },
+      {
+        name: createLocalizedText('悬壶医讯', 'XuanHu News'),
+        role: createLocalizedText('小程序前端开发', 'Mini Program Frontend Engineer'),
+        startDate: '2024-03',
+        endDate: '2024-08',
+        summary: createLocalizedText(
+          '面向医生的互动交流平台，负责真实世界 RWS、抽奖活动等模块迭代，并推进 uni-app 重构方案。',
+          'An interaction platform for doctors, where I worked on RWS, lottery modules, and the uni-app migration plan.',
+        ),
+        highlights: [
+          createLocalizedText(
+            '负责真实世界 RWS 和抽奖活动模块的开发与优化。',
+            'Developed and optimized the RWS and lottery modules in the mini program.',
+          ),
+          createLocalizedText(
+            '参与 Vue3 + TypeScript + Tailwind + uView UI 的 uni-app 重构调研与推进。',
+            'Participated in researching and promoting a uni-app refactor based on Vue 3, TypeScript, Tailwind, and uView UI.',
+          ),
+        ],
+        technologies: ['uni-app', 'Vue 3', 'TypeScript', 'Tailwind CSS', 'uView UI'],
+        links: [],
+      },
+      {
+        name: createLocalizedText(
+          'EDR - 终端威胁侦测与响应平台',
+          'EDR - Endpoint Detection and Response Platform',
+        ),
+        role: createLocalizedText('前端负责人', 'Frontend Lead'),
+        startDate: '2019-01',
+        endDate: '2024-01',
+        summary: createLocalizedText(
+          '面向政企安全场景的终端侦测与响应平台，聚焦资产、告警、终端与进程的可视化管理与实时响应。',
+          'A security platform for enterprise environments that visualizes assets, alerts, terminals, and processes for real-time response.',
+        ),
+        highlights: [
+          createLocalizedText(
+            '主导前端架构、基础模块和示例文档建设，引导团队遵循最佳实践。',
+            'Led frontend architecture, base modules, and example documentation to guide the team toward best practices.',
+          ),
+          createLocalizedText(
+            '完成安全概览、资产详情、WebSocket 实时展示及多类业务组件封装。',
+            'Delivered the security overview, asset detail pages, WebSocket-based realtime views, and several reusable business components.',
+          ),
+          createLocalizedText(
+            '为大数据量场景设计前端过滤、预缓存与 Web Worker 方案，优化加载性能。',
+            'Designed client-side filtering, pre-caching, and Web Worker strategies for heavy data scenarios to improve performance.',
+          ),
+        ],
+        technologies: ['Vue', 'iView', 'vxe-table', 'ECharts', 'D3.js', 'WebSocket'],
+        links: [],
+      },
+      {
+        name: createLocalizedText('Admin - 综合管理后台', 'Admin - Integrated Management System'),
+        role: createLocalizedText('核心前端开发 / 架构升级', 'Core Frontend Engineer / Architecture Upgrade'),
+        startDate: '2022-01',
+        endDate: '2024-01',
+        summary: createLocalizedText(
+          '公司核心综合管理后台，用于统一管理用户权限、子系统入口与定制模块展示。',
+          'The company’s integrated admin platform used to manage user permissions, subsystem access, and customized module visibility.',
+        ),
+        highlights: [
+          createLocalizedText(
+            '主导项目升级到 Vue3，完善构建配置和开发规范。',
+            'Led the upgrade to Vue 3 and improved the build configuration and development conventions.',
+          ),
+          createLocalizedText(
+            '定义主题变量和组件规范，封装通用表单、上传、高级搜索等能力。',
+            'Defined theme variables and component conventions, and encapsulated common forms, uploads, and advanced search.',
+          ),
+          createLocalizedText(
+            '设计并开发路由权限、菜单权限与多角色能力边界。',
+            'Designed and implemented route permissions, menu permissions, and multi-role capability boundaries.',
+          ),
+        ],
+        technologies: ['Vue 3', 'TypeScript', 'Naive UI', 'ECharts', 'vue-i18n'],
+        links: [],
+      },
+      {
+        name: createLocalizedText('LC 安全分析大屏', 'LC Security Analytics Dashboard'),
+        role: createLocalizedText('前端开发', 'Frontend Engineer'),
+        startDate: '2021-01',
+        endDate: '2024-01',
+        summary: createLocalizedText(
+          '结合安全数据做态势感知与可视化展示，帮助用户快速理解整体安全状态。',
+          'A security visualization dashboard built on top of platform data to help users quickly understand the overall security situation.',
+        ),
+        highlights: [
+          createLocalizedText(
+            '通过 CSS、SVG、响应式布局和 ATT&CK 热力图优化大屏体验。',
+            'Improved the large-screen experience through CSS, SVG, responsive layout, and ATT&CK heatmap visualizations.',
+          ),
+          createLocalizedText(
+            '针对首屏白屏、图表更新与多尺寸设备展示做性能优化。',
+            'Optimized first-screen loading, chart updates, and display across multiple screen sizes.',
+          ),
+        ],
+        technologies: ['Vue 3', 'TypeScript', 'ECharts', 'D3.js'],
+        links: [],
+      },
+      {
+        name: createLocalizedText('环球礼仪知识平台', 'Global Etiquette Knowledge Platform'),
+        role: createLocalizedText('Web 开发', 'Web Developer'),
+        startDate: '2016-01',
+        endDate: '2017-07',
+        summary: createLocalizedText(
+          '传统内容社区网站，在平台升级阶段从多页面模式过渡到 Webpack + React + Redux 的工程化模式。',
+          'A traditional content community website that evolved from a multi-page setup to a Webpack + React + Redux engineering workflow.',
+        ),
+        highlights: [
+          createLocalizedText(
+            '负责静态页面与样式编码，兼顾视觉还原和用户体验。',
+            'Implemented static pages and styles with a strong focus on design fidelity and user experience.',
+          ),
+          createLocalizedText(
+            '封装滚动、全屏特效、工具栏与动画等工具模块，提升页面复用度。',
+            'Encapsulated utility modules for scrolling, fullscreen effects, toolbars, and animations to improve reuse.',
+          ),
+          createLocalizedText(
+            '完成多端适配和兼容性处理，适应早期前端工程化转型。',
+            'Handled responsive adaptation and browser compatibility during the team’s transition to frontend engineering.',
+          ),
+        ],
+        technologies: ['React', 'Webpack', 'Redux', 'jQuery', 'Bootstrap'],
+        links: [],
+      },
+      {
+        name: createLocalizedText('my-resume 在线简历', 'my-resume Online Resume'),
+        role: createLocalizedText('作者 / 维护者', 'Author / Maintainer'),
+        startDate: '2024-02',
+        endDate: '至今',
+        summary: createLocalizedText(
+          '使用 Vite、Vue3、TypeScript 与 TailwindCSS 搭建的在线简历项目，并持续以教程和开源形式迭代。',
+          'An online resume project built with Vite, Vue 3, TypeScript, and Tailwind CSS, iterated publicly through tutorials and open source.',
+        ),
+        highlights: [
+          createLocalizedText(
+            '完整记录从开发到上线的过程，并沉淀为文章与可复用模板。',
+            'Documented the full path from development to deployment and turned it into articles and reusable templates.',
+          ),
+          createLocalizedText(
+            '作为当前 monorepo 重构的内容来源与迁移基线。',
+            'Serves as the source content and migration baseline for the current monorepo refactor.',
+          ),
+        ],
+        technologies: ['Vite', 'Vue 3', 'TypeScript', 'Tailwind CSS'],
+        links: [
           {
-            zh: '落地鉴权、AI Provider 适配器与内容建模',
-            en: 'Implemented authentication, AI provider adapters, and content modeling.',
+            label: createLocalizedText('GitHub 仓库', 'GitHub Repository'),
+            url: 'https://github.com/Fridolph/my-resume',
+          },
+          {
+            label: createLocalizedText('在线简历', 'Online Resume'),
+            url: 'https://resume.fridolph.top',
           },
         ],
-        technologies: ['Next.js', 'NestJS', 'pnpm workspace', 'Turborepo'],
-        links: [],
       },
     ],
     skills: [
       {
-        name: {
-          zh: '前端工程化',
-          en: 'Frontend Engineering',
-        },
-        keywords: ['Vue 3', 'React', 'TypeScript', 'Vite'],
+        name: createLocalizedText('前端基础与框架', 'Frontend Fundamentals & Frameworks'),
+        keywords: [
+          'HTML',
+          'CSS',
+          'JavaScript',
+          'TypeScript',
+          'Vue',
+          'Vue 3',
+          'React',
+          'uni-app',
+        ],
+      },
+      {
+        name: createLocalizedText('工程化与质量', 'Engineering & Quality'),
+        keywords: [
+          'Vite',
+          'Webpack',
+          'pnpm',
+          'Monorepo',
+          'JSDoc',
+          'Unit Testing',
+          'GitLab CI',
+          'Jenkins',
+        ],
+      },
+      {
+        name: createLocalizedText('UI 与可视化', 'UI & Visualization'),
+        keywords: [
+          'Tailwind CSS',
+          'Naive UI',
+          'Ant Design Vue',
+          'Element UI',
+          'ECharts',
+          'D3.js',
+          'vxe-table',
+        ],
+      },
+      {
+        name: createLocalizedText('服务端与安全', 'Backend & Security'),
+        keywords: [
+          'Node.js',
+          'Koa',
+          'NestJS',
+          'Linux',
+          'Web Security',
+          'WebSocket',
+          'Responsive Design',
+        ],
       },
     ],
     highlights: [
       {
-        title: {
-          zh: '教程型开源实践',
-          en: 'Tutorial-driven Open Source Practice',
-        },
-        description: {
-          zh: '强调小步提交、开发日志与里程碑教程沉淀。',
-          en: 'Focused on small commits, dev logs, and milestone-based tutorial outputs.',
-        },
+        title: createLocalizedText('个人项目与知识沉淀', 'Personal Projects & Knowledge Sharing'),
+        description: createLocalizedText(
+          '长期维护 `my-element-plus`、`my-program`、`FE-prepare-interview`、`fridolph` 等仓库，持续整理前端学习资料、项目经验与教程输出。',
+          'Maintains repositories such as `my-element-plus`, `my-program`, `FE-prepare-interview`, and `fridolph`, continuously organizing frontend learning materials, project experience, and tutorial content.',
+        ),
+      },
+      {
+        title: createLocalizedText('开源参与', 'Open Source Contributions'),
+        description: createLocalizedText(
+          '参与 MDN 感知性能文章翻译、`hexo-theme-butterfly` 优化以及简历项目开源分享，强调可复用与可传播。',
+          'Contributed to MDN perceived performance translation, improvements in `hexo-theme-butterfly`, and open-sourced the resume project with a focus on reusability and knowledge sharing.',
+        ),
+      },
+      {
+        title: createLocalizedText('团队建设与规范实践', 'Team Building & Engineering Standards'),
+        description: createLocalizedText(
+          '通过团队文档、UI 规范、代码规范、Code Review 与技术分享，持续提升协作效率与项目可维护性。',
+          'Improved collaboration efficiency and maintainability through team documentation, UI standards, coding conventions, code reviews, and technical sharing.',
+        ),
       },
     ],
   };

--- a/apps/server/src/modules/resume/resume-markdown-export.service.spec.ts
+++ b/apps/server/src/modules/resume/resume-markdown-export.service.spec.ts
@@ -13,9 +13,10 @@ describe('ResumeMarkdownExportService', () => {
 
     expect(markdown).toContain('# 付寅生');
     expect(markdown).toContain('## 个人简介');
-    expect(markdown).toContain('全栈开发工程师');
-    expect(markdown).toContain('### 示例科技');
-    expect(markdown).toContain('Vue 3 / React / TypeScript / NestJS');
+    expect(markdown).toContain('前端工程师 / 前端负责人');
+    expect(markdown).toContain('### 成都一蟹科技有限公司');
+    expect(markdown).toContain('### 云药客 SaaS 系统');
+    expect(markdown).toContain('Vite / Webpack / pnpm / Monorepo');
   });
 
   it('should render english markdown when locale is en', () => {
@@ -25,8 +26,9 @@ describe('ResumeMarkdownExportService', () => {
 
     expect(markdown).toContain('# Yinsheng Fu');
     expect(markdown).toContain('## Summary');
-    expect(markdown).toContain('Full-Stack Engineer');
-    expect(markdown).toContain('### Example Tech');
-    expect(markdown).toContain('Focused on frontend engineering');
+    expect(markdown).toContain('Frontend Engineer / Frontend Lead');
+    expect(markdown).toContain('### Chengdu Yixie Technology Co., Ltd.');
+    expect(markdown).toContain('### YYK SaaS Platform');
+    expect(markdown).toContain('frontend engineering');
   });
 });

--- a/docs/30-开发日志/M7-issue-32-旧版简历内容迁移到标准模型.md
+++ b/docs/30-开发日志/M7-issue-32-旧版简历内容迁移到标准模型.md
@@ -1,0 +1,155 @@
+# M7 / issue-32 开发日志：旧版简历内容迁移到标准模型
+
+- Issue：#56
+- 里程碑：M7 展示层与内容接入：从联调壳到真实页面
+- 分支：`feat/m7-issue-32-legacy-resume-migration`
+- 日期：2026-03-25
+
+## 背景
+
+当前三端虽然已经能跑通，但 `apps/server` 中的示例简历仍然只是占位内容。只要这一点不改，整个项目就还停留在“脚手架演示”，没有真正进入“我的简历重构”阶段。
+
+本次任务的重点不是引入数据库、后台复杂迁移工具或商业版变体能力，而是把旧版 Vue 简历中的真实内容，安全迁移到当前的 `StandardResume` 双语模型里，让后续 `admin / web / export` 读到的是同一份真实简历数据。
+
+## 本次目标
+
+- 盘点旧版 Vue 简历内容来源
+- 将旧版内容映射到 `StandardResume`
+- 替换后端内置示例简历为真实个人简历
+- 保持导出与既有测试链路仍然可用
+
+## 非目标
+
+- 不引入数据库持久化
+- 不做 JD 多版本定制
+- 不新增商业版字段模型
+- 不在本次实现页面视觉升级
+
+## TDD / 测试设计
+
+本次不是新增接口，而是替换“标准样例内容”，所以测试重点放在：
+
+- `standard-resume` 领域模型仍然合法
+- Markdown 导出仍能正确渲染真实迁移后的内容
+- PDF 导出仍然可生成有效文件
+
+对应执行：
+
+- `apps/server/src/modules/resume/domain/standard-resume.spec.ts`
+- `apps/server/src/modules/resume/resume-markdown-export.service.spec.ts`
+- `apps/server/src/modules/resume/resume-pdf-export.service.spec.ts`
+
+并同步更新了 Markdown 导出断言，使其不再依赖旧的占位示例公司与描述。
+
+## 实际改动
+
+### 1. 盘点旧版内容来源
+
+本次主要以两个来源作为迁移依据：
+
+- `public/web_fuyinsheng_8y.md`
+- `src/locales/zh/index.ts` / `src/locales/en/index.ts`
+
+前者提供了较完整的中文简历内容和模块顺序，后者提供了旧版站点已经存在的一部分英文映射。这样可以避免完全重新编写英文文案，尽可能保留旧项目中的原始表达。
+
+### 2. 将内容映射到标准模型
+
+更新：
+
+- `apps/server/src/modules/resume/domain/standard-resume.ts`
+
+主要完成：
+
+- profile：姓名、标题、摘要、位置、邮箱、电话、站点、外链、兴趣
+- education：四川大学锦江学院 / 通信工程
+- experiences：一蟹科技、网思科平、爱礼科技三段经历
+- projects：云药客 SaaS、悬壶医讯、EDR、综合管理后台、安全分析大屏、环球礼仪知识平台、my-resume
+- skills：前端基础与框架、工程化与质量、UI 与可视化、服务端与安全
+- highlights：个人项目与知识沉淀、开源参与、团队建设与规范实践
+
+为了减少重复书写，本次顺手补了 `createLocalizedText()`，让双语字段构造更清晰。
+
+### 3. 更新导出测试断言
+
+更新：
+
+- `apps/server/src/modules/resume/resume-markdown-export.service.spec.ts`
+
+测试从原先依赖“示例科技 / Example Tech”这类占位内容，改为断言真实迁移后的公司、项目与技能片段，确保迁移结果能被导出链路真实消费。
+
+## Review 记录
+
+### 是否符合当前 Issue 与里程碑目标
+
+符合。
+
+本次只处理了旧版简历内容到 `StandardResume` 的迁移，没有扩展到：
+
+- 数据库存储
+- 后台批量迁移工具
+- JD 多版本简历
+- 页面样式重设计
+
+### 是否可抽离组件、公共函数、skills 或其他复用能力
+
+已做的最小抽离：
+
+- 在领域模型中新增 `createLocalizedText()`，简化双语字段构造
+
+当前不需要再抽独立“迁移脚本”或“legacy parser”，因为 v1 只做一份标准通用版简历，现阶段把迁移逻辑清楚地写在领域样例中，更适合教程阅读和维护。
+
+### 本次最关键的设计判断
+
+旧版内容迁移的目标，是让“标准模型承载真实内容”，而不是把旧 Vue 站的结构原样复制过来。
+
+也就是说：
+
+- 旧版是页面组织方式
+- 新版是领域数据模型
+- 迁移时要做结构映射，而不是字段照搬
+
+这一步做对了，后续 `admin`、`web`、`export` 才能围绕同一份稳定数据继续演进。
+
+## 自测结果
+
+已执行：
+
+- `pnpm --filter @my-resume/server test -- --runInBand src/modules/resume/domain/standard-resume.spec.ts src/modules/resume/resume-markdown-export.service.spec.ts src/modules/resume/resume-pdf-export.service.spec.ts`
+- `pnpm --filter @my-resume/server typecheck`
+- `pnpm --filter @my-resume/server build`
+
+结果：全部通过。
+
+## 遇到的问题
+
+### 1. 旧版内容来源分散
+
+问题：旧版中文主内容在 Markdown，英文内容与部分补充语义在 `src/locales` 中，信息不是单一来源。
+
+处理：
+
+- 以 Markdown 为中文主基线
+- 以 `src/locales/en` 作为英文补充来源
+- 对个别缺失的英文描述做最小补齐，但不额外扩展商业版字段
+
+### 2. 标准模型与旧版页面结构并不一一对应
+
+问题：旧版有“个人项目 / 参与开源 / 最近文章”等页面表达，而标准模型更偏向统一的数据块。
+
+处理：
+
+- 工作项目进入 `projects`
+- 个人项目与开源沉淀进入 `highlights`
+- 不额外新增模型字段，避免破坏 v1 结构稳定性
+
+## 可沉淀为教程/博客的点
+
+- 如何从旧前端页面内容反推标准数据模型
+- 内容迁移时为什么更应该“映射结构”，而不是“照搬页面”
+- 双语简历项目如何利用旧版 i18n 文案为新模型服务
+
+## 后续待办
+
+- 继续 `M7 / issue-33`：web 公开简历页面模块化渲染
+- 再推进 `M7 / issue-34`：展示层整理，为 UI 升级预留边界
+- M7 收尾时补里程碑教程大纲


### PR DESCRIPTION
## Summary
- 将旧版 Vue 简历内容迁移到 `StandardResume`
- 用真实个人简历替换后端内置占位示例
- 同步更新 Markdown 导出断言与本次开发日志

## Testing
- pnpm --filter @my-resume/server test -- --runInBand src/modules/resume/domain/standard-resume.spec.ts src/modules/resume/resume-markdown-export.service.spec.ts src/modules/resume/resume-pdf-export.service.spec.ts
- pnpm --filter @my-resume/server typecheck
- pnpm --filter @my-resume/server build

## Logs
- docs/30-开发日志/M7-issue-32-旧版简历内容迁移到标准模型.md

Closes #56
