### PR TITLE
[M7][issue-33] web 公开简历页面模块化渲染

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -175,9 +175,14 @@ button {
   gap: 0.75rem;
 }
 
-.section-grid {
+.content-grid {
   display: grid;
   grid-template-columns: 1.2fr 0.8fr;
+  gap: 1.25rem;
+}
+
+.section-stack {
+  display: grid;
   gap: 1.25rem;
 }
 
@@ -187,9 +192,23 @@ button {
   gap: 1rem;
 }
 
+.section-header {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.section-header.compact {
+  gap: 0.2rem;
+}
+
 .section-title {
   margin: 0;
   font-size: 1.25rem;
+}
+
+.hero-block {
+  display: grid;
+  gap: 0.75rem;
 }
 
 .timeline {
@@ -256,7 +275,7 @@ button {
     justify-content: flex-start;
   }
 
-  .section-grid {
+  .content-grid {
     grid-template-columns: 1fr;
   }
 }

--- a/apps/web/components/published-resume-shell.spec.tsx
+++ b/apps/web/components/published-resume-shell.spec.tsx
@@ -31,27 +31,86 @@ const publishedResume = {
       links: [],
       interests: [],
     },
-    education: [],
-    experiences: [],
     projects: [
       {
         name: {
-          zh: '个人简历 Monorepo',
-          en: 'Personal Resume Monorepo',
+          zh: 'my-resume 在线简历',
+          en: 'my-resume Online Resume',
         },
         role: {
-          zh: '作者',
-          en: 'Author',
+          zh: '作者 / 维护者',
+          en: 'Author / Maintainer',
         },
-        startDate: '2026-03',
-        endDate: '进行中',
+        startDate: '2024-02',
+        endDate: '至今',
         summary: {
-          zh: '逐步构建三端项目。',
-          en: 'Incrementally building a three-surface project.',
+          zh: '使用 Vite、Vue3、TypeScript 与 TailwindCSS 搭建的在线简历项目。',
+          en: 'An online resume project built with Vite, Vue 3, TypeScript, and Tailwind CSS.',
         },
-        highlights: [],
+        highlights: [
+          {
+            zh: '持续以教程和开源形式迭代。',
+            en: 'Iterated publicly through tutorials and open source.',
+          },
+        ],
         technologies: ['Next.js', 'NestJS'],
         links: [],
+      },
+    ],
+    education: [
+      {
+        schoolName: {
+          zh: '四川大学锦江学院',
+          en: 'Sichuan University Jinjiang College',
+        },
+        degree: {
+          zh: '本科',
+          en: 'Bachelor',
+        },
+        fieldOfStudy: {
+          zh: '通信工程',
+          en: 'Communication Engineering',
+        },
+        startDate: '2012-09',
+        endDate: '2016-06',
+        location: {
+          zh: '四川 眉山',
+          en: 'Meishan, Sichuan',
+        },
+        highlights: [],
+      },
+    ],
+    experiences: [
+      {
+        companyName: {
+          zh: '成都一蟹科技有限公司',
+          en: 'Chengdu Yixie Technology Co., Ltd.',
+        },
+        role: {
+          zh: '前端主管',
+          en: 'Frontend Lead',
+        },
+        employmentType: {
+          zh: '全职',
+          en: 'Full-time',
+        },
+        startDate: '2024-03',
+        endDate: '2024-08',
+        location: {
+          zh: '成都',
+          en: 'Chengdu',
+        },
+        summary: {
+          zh: '负责需求规划、团队协作、技术升级与质量建设。',
+          en: 'Led requirement planning, team collaboration, technical upgrades, and quality practices.',
+        },
+        highlights: [
+          {
+            zh: '定期组织 Code Review 和技术分享。',
+            en: 'Organized regular code reviews and technical sharing sessions.',
+          },
+        ],
+        technologies: ['Vue 3', 'TypeScript'],
       },
     ],
     skills: [
@@ -63,12 +122,23 @@ const publishedResume = {
         keywords: ['TypeScript', 'React'],
       },
     ],
-    highlights: [],
+    highlights: [
+      {
+        title: {
+          zh: '开源参与',
+          en: 'Open Source Contributions',
+        },
+        description: {
+          zh: '持续沉淀文章、开源和知识文档。',
+          en: 'Continuously shares articles, open-source work, and knowledge docs.',
+        },
+      },
+    ],
   },
 };
 
 describe('PublishedResumeShell', () => {
-  it('should render zh content by default and switch to en', async () => {
+  it('should render modular zh sections by default and switch to en', async () => {
     const user = userEvent.setup();
 
     render(<PublishedResumeShell publishedResume={publishedResume} />);
@@ -77,6 +147,13 @@ describe('PublishedResumeShell', () => {
     expect(
       screen.getByText('专注前端工程化与 Node.js 后端。'),
     ).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: '职业经历' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: '代表项目' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: '教育背景' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: '技能结构' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: '补充亮点' })).toBeInTheDocument();
+    expect(screen.getByText('成都一蟹科技有限公司')).toBeInTheDocument();
+    expect(screen.getByText('四川大学锦江学院')).toBeInTheDocument();
 
     await user.click(screen.getByRole('button', { name: 'EN' }));
 
@@ -86,6 +163,11 @@ describe('PublishedResumeShell', () => {
     expect(
       screen.getByText('Focused on frontend engineering and Node.js backend development.'),
     ).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Work Experience' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Selected Projects' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Education' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Skill Structure' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Additional Highlights' })).toBeInTheDocument();
   });
 
   it('should toggle light and dark theme on the document element', async () => {

--- a/apps/web/components/published-resume-shell.tsx
+++ b/apps/web/components/published-resume-shell.tsx
@@ -1,39 +1,17 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { DEFAULT_API_BASE_URL } from '../lib/env';
-import {
-  LocalizedText,
-  ResumeLocale,
-  ResumeProjectItem,
-  ResumePublishedSnapshot,
-  ResumeSkillGroup,
-} from '../lib/published-resume-types';
-
-type ThemeMode = 'light' | 'dark';
-
-function readLocalizedText(value: LocalizedText, locale: ResumeLocale): string {
-  return value[locale];
-}
-
-function formatProjectPeriod(
-  project: ResumeProjectItem,
-  locale: ResumeLocale,
-): string {
-  if (locale === 'zh') {
-    return `${project.startDate} - ${project.endDate}`;
-  }
-
-  return `${project.startDate} - ${project.endDate}`;
-}
-
-function renderSkillGroup(
-  skillGroup: ResumeSkillGroup,
-  locale: ResumeLocale,
-): string {
-  return `${readLocalizedText(skillGroup.name, locale)} · ${skillGroup.keywords.join(', ')}`;
-}
+import { ResumeLocale, ResumePublishedSnapshot } from '../lib/published-resume-types';
+import { PublishedResumeEducationSection } from './published-resume/published-resume-education-section';
+import { PublishedResumeEmptyState } from './published-resume/published-resume-empty-state';
+import { PublishedResumeExperienceSection } from './published-resume/published-resume-experience-section';
+import { PublishedResumeHero } from './published-resume/published-resume-hero';
+import { PublishedResumeHighlightsSection } from './published-resume/published-resume-highlights-section';
+import { PublishedResumeProjectsSection } from './published-resume/published-resume-projects-section';
+import { PublishedResumeSkillsSection } from './published-resume/published-resume-skills-section';
+import { ThemeMode } from './published-resume/published-resume-utils';
 
 export function PublishedResumeShell({
   apiBaseUrl = DEFAULT_API_BASE_URL,
@@ -49,227 +27,44 @@ export function PublishedResumeShell({
     document.documentElement.dataset.theme = theme;
   }, [theme]);
 
-  const rawProfile = publishedResume?.resume.profile;
-  const skills = publishedResume?.resume.skills ?? [];
-  const projects = publishedResume?.resume.projects ?? [];
-
-  const localizedProfile = useMemo(() => {
-    if (!rawProfile) {
-      return null;
-    }
-
-    return {
-      fullName: readLocalizedText(rawProfile.fullName, locale),
-      headline: readLocalizedText(rawProfile.headline, locale),
-      summary: readLocalizedText(rawProfile.summary, locale),
-      location: readLocalizedText(rawProfile.location, locale),
-      interests: rawProfile.interests.map((item) =>
-        readLocalizedText(item, locale),
-      ),
-      links: rawProfile.links.map((link) => ({
-        label: readLocalizedText(link.label, locale),
-        url: link.url,
-      })),
-    };
-  }, [locale, rawProfile]);
-
-  if (!publishedResume || !localizedProfile || !rawProfile) {
-    return (
-      <main className="page-shell">
-        <section className="empty-card">
-          <p className="eyebrow">公开简历</p>
-          <h1>当前还没有已发布的公开简历内容。</h1>
-          <p className="muted">
-            请先通过后台更新草稿并执行发布动作，公开站才会读取到最新已发布版本。
-          </p>
-        </section>
-      </main>
-    );
+  if (!publishedResume) {
+    return <PublishedResumeEmptyState />;
   }
 
-  const profile = rawProfile;
-  const markdownExportUrl = `${apiBaseUrl.replace(/\/$/, '')}/resume/published/export/markdown?locale=${locale}`;
-  const pdfExportUrl = `${apiBaseUrl.replace(/\/$/, '')}/resume/published/export/pdf?locale=${locale}`;
+  const { education, experiences, highlights, projects, skills } =
+    publishedResume.resume;
 
   return (
-    <main className="page-shell">
-      <section className="hero-card">
-        <div className="hero-header">
-          <div className="hero-copy">
-            <p className="eyebrow">公开简历</p>
-            <h1 className="headline">{localizedProfile.fullName}</h1>
-            <p className="subtitle">{localizedProfile.headline}</p>
-            <p className="subtitle">{localizedProfile.summary}</p>
-          </div>
+    <main className="page-shell" data-template="standard">
+      <PublishedResumeHero
+        apiBaseUrl={apiBaseUrl}
+        locale={locale}
+        onChangeLocale={setLocale}
+        onChangeTheme={setTheme}
+        publishedResume={publishedResume}
+        theme={theme}
+      />
 
-          <div className="toolbar">
-            <div aria-label="语言切换" className="toolbar-group" role="group">
-              <button
-                className={`toggle-button ${locale === 'zh' ? 'is-active' : ''}`}
-                onClick={() => setLocale('zh')}
-                type="button"
-              >
-                中文
-              </button>
-              <button
-                className={`toggle-button ${locale === 'en' ? 'is-active' : ''}`}
-                onClick={() => setLocale('en')}
-                type="button"
-              >
-                EN
-              </button>
-            </div>
-
-            <div aria-label="主题切换" className="toolbar-group" role="group">
-              <button
-                className={`toggle-button ${theme === 'light' ? 'is-active' : ''}`}
-                onClick={() => setTheme('light')}
-                type="button"
-              >
-                Light
-              </button>
-              <button
-                className={`toggle-button ${theme === 'dark' ? 'is-active' : ''}`}
-                onClick={() => setTheme('dark')}
-                type="button"
-              >
-                Dark
-              </button>
-            </div>
-          </div>
+      <section className="content-grid">
+        <div className="section-stack">
+          <PublishedResumeExperienceSection
+            experiences={experiences}
+            locale={locale}
+          />
+          <PublishedResumeProjectsSection locale={locale} projects={projects} />
         </div>
 
-        <div className="hero-meta">
-          <span className="meta-pill">{localizedProfile.location}</span>
-          <span className="meta-pill">{profile.email}</span>
-          <span className="meta-pill">{profile.website}</span>
-          <span className="meta-pill">
-            {locale === 'zh' ? '已发布于' : 'Published at'}{' '}
-            <span className="meta-text">{publishedResume.publishedAt}</span>
-          </span>
+        <div className="section-stack">
+          <PublishedResumeEducationSection
+            education={education}
+            locale={locale}
+          />
+          <PublishedResumeSkillsSection locale={locale} skills={skills} />
+          <PublishedResumeHighlightsSection
+            highlights={highlights}
+            locale={locale}
+          />
         </div>
-
-        <div className="link-grid">
-          <a className="link-pill" href={markdownExportUrl}>
-            {locale === 'zh' ? '导出 Markdown' : 'Export Markdown'}
-          </a>
-          <a className="link-pill" href={pdfExportUrl}>
-            {locale === 'zh' ? '导出 PDF' : 'Export PDF'}
-          </a>
-        </div>
-
-        {localizedProfile.links.length > 0 ? (
-          <div className="link-grid">
-            {localizedProfile.links.map((link) => (
-              <a
-                className="link-pill"
-                href={link.url}
-                key={link.url}
-                rel="noreferrer"
-                target="_blank"
-              >
-                {link.label}
-              </a>
-            ))}
-          </div>
-        ) : null}
-      </section>
-
-      <section className="section-grid">
-        <section className="section-card">
-          <div>
-            <p className="eyebrow">
-              {locale === 'zh' ? '项目经历' : 'Projects'}
-            </p>
-            <h2 className="section-title">
-              {locale === 'zh' ? '已发布项目内容' : 'Published project content'}
-            </h2>
-            <p className="section-subtitle">
-              {locale === 'zh'
-                ? '公开站只读取已发布内容，不会直接暴露后台草稿。'
-                : 'The public site only reads published content and never exposes draft data directly.'}
-            </p>
-          </div>
-
-          <div className="timeline">
-            {projects.map((project) => (
-              <article className="timeline-item" key={project.name.en}>
-                <div className="item-header">
-                  <div>
-                    <h3 className="item-title">
-                      {readLocalizedText(project.name, locale)}
-                    </h3>
-                    <p className="item-subtitle">
-                      {readLocalizedText(project.role, locale)}
-                    </p>
-                  </div>
-                  <span className="meta-text">
-                    {formatProjectPeriod(project, locale)}
-                  </span>
-                </div>
-
-                <p className="item-summary">
-                  {readLocalizedText(project.summary, locale)}
-                </p>
-
-                {project.technologies.length > 0 ? (
-                  <div className="tag-grid">
-                    {project.technologies.map((tech) => (
-                      <span className="meta-pill" key={tech}>
-                        {tech}
-                      </span>
-                    ))}
-                  </div>
-                ) : null}
-              </article>
-            ))}
-          </div>
-        </section>
-
-        <section className="section-card">
-          <div>
-            <p className="eyebrow">{locale === 'zh' ? '技能' : 'Skills'}</p>
-            <h2 className="section-title">
-              {locale === 'zh' ? '公开技能摘要' : 'Published skill summary'}
-            </h2>
-          </div>
-
-          <div className="timeline">
-            {skills.map((skillGroup) => (
-              <article
-                className="timeline-item"
-                key={`${skillGroup.name.en}-${skillGroup.keywords.join('-')}`}
-              >
-                <h3 className="item-title">
-                  {readLocalizedText(skillGroup.name, locale)}
-                </h3>
-                <p className="item-summary">
-                  {renderSkillGroup(skillGroup, locale)}
-                </p>
-              </article>
-            ))}
-          </div>
-
-          {localizedProfile.interests.length > 0 ? (
-            <>
-              <div>
-                <p className="eyebrow">
-                  {locale === 'zh' ? '兴趣' : 'Interests'}
-                </p>
-                <h2 className="section-title">
-                  {locale === 'zh' ? '个人兴趣' : 'Personal interests'}
-                </h2>
-              </div>
-              <div className="tag-grid">
-                {localizedProfile.interests.map((interest) => (
-                  <span className="meta-pill" key={interest}>
-                    {interest}
-                  </span>
-                ))}
-              </div>
-            </>
-          ) : null}
-        </section>
       </section>
     </main>
   );

--- a/apps/web/components/published-resume/published-resume-education-section.tsx
+++ b/apps/web/components/published-resume/published-resume-education-section.tsx
@@ -1,0 +1,63 @@
+import {
+  ResumeEducationItem,
+  ResumeLocale,
+} from '../../lib/published-resume-types';
+import {
+  formatPeriod,
+  readLocalizedText,
+  resumeLabels,
+} from './published-resume-utils';
+import { PublishedResumeSectionCard } from './published-resume-section-card';
+
+interface PublishedResumeEducationSectionProps {
+  locale: ResumeLocale;
+  education: ResumeEducationItem[];
+}
+
+export function PublishedResumeEducationSection({
+  locale,
+  education,
+}: PublishedResumeEducationSectionProps) {
+  const labels = resumeLabels[locale];
+
+  if (education.length === 0) {
+    return null;
+  }
+
+  return (
+    <PublishedResumeSectionCard
+      description={labels.educationDescription}
+      eyebrow={labels.educationEyebrow}
+      title={labels.educationTitle}
+    >
+      <div className="timeline">
+        {education.map((item) => (
+          <article className="timeline-item" key={`${item.schoolName.en}-${item.startDate}`}>
+            <div className="item-header">
+              <div>
+                <h3 className="item-title">{readLocalizedText(item.schoolName, locale)}</h3>
+                <p className="item-subtitle">
+                  {readLocalizedText(item.degree, locale)} ·{' '}
+                  {readLocalizedText(item.fieldOfStudy, locale)}
+                </p>
+              </div>
+              <span className="meta-text">{formatPeriod(item)}</span>
+            </div>
+
+            <p className="meta-text">{readLocalizedText(item.location, locale)}</p>
+
+            {item.highlights.length > 0 ? (
+              <ul className="bullet-list">
+                {item.highlights.map((highlight) => (
+                  <li key={`${item.schoolName.en}-${highlight.en}`}>
+                    {readLocalizedText(highlight, locale)}
+                  </li>
+                ))}
+              </ul>
+            ) : null}
+          </article>
+        ))}
+      </div>
+    </PublishedResumeSectionCard>
+  );
+}

--- a/apps/web/components/published-resume/published-resume-empty-state.tsx
+++ b/apps/web/components/published-resume/published-resume-empty-state.tsx
@@ -1,0 +1,15 @@
+import { resumeLabels } from './published-resume-utils';
+
+export function PublishedResumeEmptyState() {
+  const labels = resumeLabels.zh;
+
+  return (
+    <main className="page-shell">
+      <section className="empty-card">
+        <p className="eyebrow">{labels.pageEyebrow}</p>
+        <h1>{labels.emptyTitle}</h1>
+        <p className="muted">{labels.emptyDescription}</p>
+      </section>
+    </main>
+  );
+}

--- a/apps/web/components/published-resume/published-resume-experience-section.tsx
+++ b/apps/web/components/published-resume/published-resume-experience-section.tsx
@@ -1,0 +1,83 @@
+import {
+  ResumeExperienceItem,
+  ResumeLocale,
+} from '../../lib/published-resume-types';
+import {
+  formatPeriod,
+  readLocalizedText,
+  resumeLabels,
+} from './published-resume-utils';
+import { PublishedResumeSectionCard } from './published-resume-section-card';
+
+interface PublishedResumeExperienceSectionProps {
+  locale: ResumeLocale;
+  experiences: ResumeExperienceItem[];
+}
+
+export function PublishedResumeExperienceSection({
+  locale,
+  experiences,
+}: PublishedResumeExperienceSectionProps) {
+  const labels = resumeLabels[locale];
+
+  if (experiences.length === 0) {
+    return null;
+  }
+
+  return (
+    <PublishedResumeSectionCard
+      description={labels.experienceDescription}
+      eyebrow={labels.experienceEyebrow}
+      title={labels.experienceTitle}
+    >
+      <div className="timeline">
+        {experiences.map((experience) => (
+          <article
+            className="timeline-item"
+            key={`${experience.companyName.en}-${experience.startDate}`}
+          >
+            <div className="item-header">
+              <div>
+                <h3 className="item-title">
+                  {readLocalizedText(experience.companyName, locale)}
+                </h3>
+                <p className="item-subtitle">
+                  {readLocalizedText(experience.role, locale)} ·{' '}
+                  {readLocalizedText(experience.employmentType, locale)}
+                </p>
+              </div>
+              <span className="meta-text">{formatPeriod(experience)}</span>
+            </div>
+
+            <p className="item-summary">
+              {readLocalizedText(experience.summary, locale)}
+            </p>
+            <p className="meta-text">
+              {readLocalizedText(experience.location, locale)}
+            </p>
+
+            {experience.highlights.length > 0 ? (
+              <ul className="bullet-list">
+                {experience.highlights.map((highlight) => (
+                  <li key={`${experience.companyName.en}-${highlight.en}`}>
+                    {readLocalizedText(highlight, locale)}
+                  </li>
+                ))}
+              </ul>
+            ) : null}
+
+            {experience.technologies.length > 0 ? (
+              <div className="tag-grid">
+                {experience.technologies.map((tech) => (
+                  <span className="meta-pill" key={tech}>
+                    {tech}
+                  </span>
+                ))}
+              </div>
+            ) : null}
+          </article>
+        ))}
+      </div>
+    </PublishedResumeSectionCard>
+  );
+}

--- a/apps/web/components/published-resume/published-resume-hero.tsx
+++ b/apps/web/components/published-resume/published-resume-hero.tsx
@@ -1,0 +1,136 @@
+import { ResumeLocale, ResumePublishedSnapshot } from '../../lib/published-resume-types';
+import {
+  formatPublishedAt,
+  readLocalizedText,
+  resumeLabels,
+  ThemeMode,
+} from './published-resume-utils';
+
+interface PublishedResumeHeroProps {
+  apiBaseUrl: string;
+  locale: ResumeLocale;
+  publishedResume: ResumePublishedSnapshot;
+  theme: ThemeMode;
+  onChangeLocale: (locale: ResumeLocale) => void;
+  onChangeTheme: (theme: ThemeMode) => void;
+}
+
+export function PublishedResumeHero({
+  apiBaseUrl,
+  locale,
+  publishedResume,
+  theme,
+  onChangeLocale,
+  onChangeTheme,
+}: PublishedResumeHeroProps) {
+  const labels = resumeLabels[locale];
+  const profile = publishedResume.resume.profile;
+  const markdownExportUrl = `${apiBaseUrl.replace(/\/$/, '')}/resume/published/export/markdown?locale=${locale}`;
+  const pdfExportUrl = `${apiBaseUrl.replace(/\/$/, '')}/resume/published/export/pdf?locale=${locale}`;
+  const localizedInterests = profile.interests.map((item) =>
+    readLocalizedText(item, locale),
+  );
+
+  return (
+    <section className="hero-card">
+      <div className="hero-header">
+        <div className="hero-copy">
+          <p className="eyebrow">{labels.pageEyebrow}</p>
+          <h1 className="headline">{readLocalizedText(profile.fullName, locale)}</h1>
+          <p className="subtitle">{readLocalizedText(profile.headline, locale)}</p>
+          <p className="subtitle">{readLocalizedText(profile.summary, locale)}</p>
+        </div>
+
+        <div className="toolbar">
+          <div aria-label="语言切换" className="toolbar-group" role="group">
+            <button
+              className={`toggle-button ${locale === 'zh' ? 'is-active' : ''}`}
+              onClick={() => onChangeLocale('zh')}
+              type="button"
+            >
+              中文
+            </button>
+            <button
+              className={`toggle-button ${locale === 'en' ? 'is-active' : ''}`}
+              onClick={() => onChangeLocale('en')}
+              type="button"
+            >
+              EN
+            </button>
+          </div>
+
+          <div aria-label="主题切换" className="toolbar-group" role="group">
+            <button
+              className={`toggle-button ${theme === 'light' ? 'is-active' : ''}`}
+              onClick={() => onChangeTheme('light')}
+              type="button"
+            >
+              Light
+            </button>
+            <button
+              className={`toggle-button ${theme === 'dark' ? 'is-active' : ''}`}
+              onClick={() => onChangeTheme('dark')}
+              type="button"
+            >
+              Dark
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <div className="hero-meta">
+        <span className="meta-pill">{readLocalizedText(profile.location, locale)}</span>
+        <span className="meta-pill">{profile.email}</span>
+        <span className="meta-pill">{profile.phone}</span>
+        <span className="meta-pill">{profile.website}</span>
+        <span className="meta-pill">
+          {labels.publishedAt}{' '}
+          <span className="meta-text">
+            {formatPublishedAt(publishedResume.publishedAt, locale)}
+          </span>
+        </span>
+      </div>
+
+      <div className="link-grid">
+        <a className="link-pill" href={markdownExportUrl}>
+          {labels.exportMarkdown}
+        </a>
+        <a className="link-pill" href={pdfExportUrl}>
+          {labels.exportPdf}
+        </a>
+      </div>
+
+      {profile.links.length > 0 ? (
+        <div className="link-grid">
+          {profile.links.map((link) => (
+            <a
+              className="link-pill"
+              href={link.url}
+              key={link.url}
+              rel="noreferrer"
+              target="_blank"
+            >
+              {readLocalizedText(link.label, locale)}
+            </a>
+          ))}
+        </div>
+      ) : null}
+
+      {localizedInterests.length > 0 ? (
+        <div className="hero-block">
+          <div className="section-header compact">
+            <p className="eyebrow">{labels.interestsEyebrow}</p>
+            <h2 className="section-title">{labels.interestsTitle}</h2>
+          </div>
+          <div className="tag-grid">
+            {localizedInterests.map((interest) => (
+              <span className="meta-pill" key={interest}>
+                {interest}
+              </span>
+            ))}
+          </div>
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/web/components/published-resume/published-resume-highlights-section.tsx
+++ b/apps/web/components/published-resume/published-resume-highlights-section.tsx
@@ -1,0 +1,39 @@
+import {
+  ResumeHighlightItem,
+  ResumeLocale,
+} from '../../lib/published-resume-types';
+import { readLocalizedText, resumeLabels } from './published-resume-utils';
+import { PublishedResumeSectionCard } from './published-resume-section-card';
+
+interface PublishedResumeHighlightsSectionProps {
+  locale: ResumeLocale;
+  highlights: ResumeHighlightItem[];
+}
+
+export function PublishedResumeHighlightsSection({
+  locale,
+  highlights,
+}: PublishedResumeHighlightsSectionProps) {
+  const labels = resumeLabels[locale];
+
+  if (highlights.length === 0) {
+    return null;
+  }
+
+  return (
+    <PublishedResumeSectionCard
+      description={labels.highlightsDescription}
+      eyebrow={labels.highlightsEyebrow}
+      title={labels.highlightsTitle}
+    >
+      <div className="timeline">
+        {highlights.map((item) => (
+          <article className="timeline-item" key={`${item.title.en}-${item.description.en}`}>
+            <h3 className="item-title">{readLocalizedText(item.title, locale)}</h3>
+            <p className="item-summary">{readLocalizedText(item.description, locale)}</p>
+          </article>
+        ))}
+      </div>
+    </PublishedResumeSectionCard>
+  );
+}

--- a/apps/web/components/published-resume/published-resume-projects-section.tsx
+++ b/apps/web/components/published-resume/published-resume-projects-section.tsx
@@ -1,0 +1,86 @@
+import {
+  ResumeLocale,
+  ResumeProjectItem,
+} from '../../lib/published-resume-types';
+import {
+  formatPeriod,
+  readLocalizedText,
+  resumeLabels,
+} from './published-resume-utils';
+import { PublishedResumeSectionCard } from './published-resume-section-card';
+
+interface PublishedResumeProjectsSectionProps {
+  locale: ResumeLocale;
+  projects: ResumeProjectItem[];
+}
+
+export function PublishedResumeProjectsSection({
+  locale,
+  projects,
+}: PublishedResumeProjectsSectionProps) {
+  const labels = resumeLabels[locale];
+
+  if (projects.length === 0) {
+    return null;
+  }
+
+  return (
+    <PublishedResumeSectionCard
+      description={labels.projectsDescription}
+      eyebrow={labels.projectsEyebrow}
+      title={labels.projectsTitle}
+    >
+      <div className="timeline">
+        {projects.map((project) => (
+          <article className="timeline-item" key={`${project.name.en}-${project.startDate}`}>
+            <div className="item-header">
+              <div>
+                <h3 className="item-title">{readLocalizedText(project.name, locale)}</h3>
+                <p className="item-subtitle">{readLocalizedText(project.role, locale)}</p>
+              </div>
+              <span className="meta-text">{formatPeriod(project)}</span>
+            </div>
+
+            <p className="item-summary">{readLocalizedText(project.summary, locale)}</p>
+
+            {project.highlights.length > 0 ? (
+              <ul className="bullet-list">
+                {project.highlights.map((highlight) => (
+                  <li key={`${project.name.en}-${highlight.en}`}>
+                    {readLocalizedText(highlight, locale)}
+                  </li>
+                ))}
+              </ul>
+            ) : null}
+
+            {project.technologies.length > 0 ? (
+              <div className="tag-grid">
+                {project.technologies.map((tech) => (
+                  <span className="meta-pill" key={tech}>
+                    {tech}
+                  </span>
+                ))}
+              </div>
+            ) : null}
+
+            {project.links.length > 0 ? (
+              <div className="link-grid">
+                {project.links.map((link) => (
+                  <a
+                    className="link-pill"
+                    href={link.url}
+                    key={link.url}
+                    rel="noreferrer"
+                    target="_blank"
+                  >
+                    {readLocalizedText(link.label, locale)}
+                  </a>
+                ))}
+              </div>
+            ) : null}
+          </article>
+        ))}
+      </div>
+    </PublishedResumeSectionCard>
+  );
+}

--- a/apps/web/components/published-resume/published-resume-section-card.tsx
+++ b/apps/web/components/published-resume/published-resume-section-card.tsx
@@ -1,0 +1,26 @@
+import { ReactNode } from 'react';
+
+interface PublishedResumeSectionCardProps {
+  eyebrow: string;
+  title: string;
+  description?: string;
+  children: ReactNode;
+}
+
+export function PublishedResumeSectionCard({
+  eyebrow,
+  title,
+  description,
+  children,
+}: PublishedResumeSectionCardProps) {
+  return (
+    <section className="section-card">
+      <div className="section-header">
+        <p className="eyebrow">{eyebrow}</p>
+        <h2 className="section-title">{title}</h2>
+        {description ? <p className="section-subtitle">{description}</p> : null}
+      </div>
+      {children}
+    </section>
+  );
+}

--- a/apps/web/components/published-resume/published-resume-skills-section.tsx
+++ b/apps/web/components/published-resume/published-resume-skills-section.tsx
@@ -1,0 +1,48 @@
+import {
+  ResumeLocale,
+  ResumeSkillGroup,
+} from '../../lib/published-resume-types';
+import { readLocalizedText, resumeLabels } from './published-resume-utils';
+import { PublishedResumeSectionCard } from './published-resume-section-card';
+
+interface PublishedResumeSkillsSectionProps {
+  locale: ResumeLocale;
+  skills: ResumeSkillGroup[];
+}
+
+export function PublishedResumeSkillsSection({
+  locale,
+  skills,
+}: PublishedResumeSkillsSectionProps) {
+  const labels = resumeLabels[locale];
+
+  if (skills.length === 0) {
+    return null;
+  }
+
+  return (
+    <PublishedResumeSectionCard
+      description={labels.skillsDescription}
+      eyebrow={labels.skillsEyebrow}
+      title={labels.skillsTitle}
+    >
+      <div className="timeline">
+        {skills.map((group) => (
+          <article
+            className="timeline-item"
+            key={`${group.name.en}-${group.keywords.join('-')}`}
+          >
+            <h3 className="item-title">{readLocalizedText(group.name, locale)}</h3>
+            <div className="tag-grid">
+              {group.keywords.map((keyword) => (
+                <span className="meta-pill" key={`${group.name.en}-${keyword}`}>
+                  {keyword}
+                </span>
+              ))}
+            </div>
+          </article>
+        ))}
+      </div>
+    </PublishedResumeSectionCard>
+  );
+}

--- a/apps/web/components/published-resume/published-resume-utils.ts
+++ b/apps/web/components/published-resume/published-resume-utils.ts
@@ -1,0 +1,94 @@
+import {
+  LocalizedText,
+  ResumeEducationItem,
+  ResumeExperienceItem,
+  ResumeLocale,
+  ResumeProjectItem,
+} from '../../lib/published-resume-types';
+
+export type ThemeMode = 'light' | 'dark';
+
+export function readLocalizedText(
+  value: LocalizedText,
+  locale: ResumeLocale,
+): string {
+  return value[locale];
+}
+
+export function formatPeriod(
+  item: ResumeProjectItem | ResumeExperienceItem | ResumeEducationItem,
+): string {
+  return `${item.startDate} - ${item.endDate}`;
+}
+
+export function formatPublishedAt(
+  publishedAt: string,
+  locale: ResumeLocale,
+): string {
+  return new Date(publishedAt).toLocaleString(
+    locale === 'zh' ? 'zh-CN' : 'en-US',
+    {
+      hour12: false,
+    },
+  );
+}
+
+export const resumeLabels = {
+  zh: {
+    pageEyebrow: '公开简历',
+    emptyTitle: '当前还没有已发布的公开简历内容。',
+    emptyDescription:
+      '请先通过后台更新草稿并执行发布动作，公开站才会读取到最新已发布版本。',
+    publishedAt: '已发布于',
+    exportMarkdown: '导出 Markdown',
+    exportPdf: '导出 PDF',
+    experienceEyebrow: '工作经历',
+    experienceTitle: '职业经历',
+    experienceDescription: '聚焦过往公司的职责范围、业务场景与关键成果。',
+    projectsEyebrow: '项目经历',
+    projectsTitle: '代表项目',
+    projectsDescription: '按标准模型展示项目背景、职责、亮点与技术栈。',
+    educationEyebrow: '教育经历',
+    educationTitle: '教育背景',
+    educationDescription: '保留稳定学历信息，避免和项目型内容混排。',
+    skillsEyebrow: '技能清单',
+    skillsTitle: '技能结构',
+    skillsDescription: '按类别聚合技术关键词，便于后续主题化展示。',
+    highlightsEyebrow: '亮点',
+    highlightsTitle: '补充亮点',
+    highlightsDescription: '沉淀个人项目、开源参与与团队建设等补充信息。',
+    interestsEyebrow: '兴趣方向',
+    interestsTitle: '个人兴趣',
+  },
+  en: {
+    pageEyebrow: 'Published Resume',
+    emptyTitle: 'There is no published resume content yet.',
+    emptyDescription:
+      'Please update the draft and publish it from the admin dashboard before the public site can read the latest version.',
+    publishedAt: 'Published at',
+    exportMarkdown: 'Export Markdown',
+    exportPdf: 'Export PDF',
+    experienceEyebrow: 'Experience',
+    experienceTitle: 'Work Experience',
+    experienceDescription:
+      'Highlights company scope, responsibilities, delivery context, and key outcomes.',
+    projectsEyebrow: 'Projects',
+    projectsTitle: 'Selected Projects',
+    projectsDescription:
+      'Shows project background, role, highlights, and technology stack from the standard model.',
+    educationEyebrow: 'Education',
+    educationTitle: 'Education',
+    educationDescription:
+      'Keeps stable academic information separated from project-focused content.',
+    skillsEyebrow: 'Skills',
+    skillsTitle: 'Skill Structure',
+    skillsDescription:
+      'Groups technical keywords by category for future theme and template expansion.',
+    highlightsEyebrow: 'Highlights',
+    highlightsTitle: 'Additional Highlights',
+    highlightsDescription:
+      'Captures personal projects, open-source work, and team-building achievements.',
+    interestsEyebrow: 'Interests',
+    interestsTitle: 'Personal Interests',
+  },
+} as const;

--- a/docs/30-开发日志/M7-issue-33-web-公开简历页面模块化渲染.md
+++ b/docs/30-开发日志/M7-issue-33-web-公开简历页面模块化渲染.md
@@ -1,0 +1,190 @@
+# M7 / issue-33 开发日志：web 公开简历页面模块化渲染
+
+- Issue：#54
+- 里程碑：M7 展示层与内容接入：从联调壳到真实页面
+- 分支：`feat/m7-issue-33-web-modular-render`
+- 日期：2026-03-25
+
+## 背景
+
+在 `issue-32` 完成后，公开站已经可以读到真实迁移后的个人简历内容，但页面仍然主要由一个 `PublishedResumeShell` 粗粒度组件承担全部展示职责。只要结构还集中在一个文件里，后续一旦进入 UI 升级、主题整理或模板扩展，就会很快失控。
+
+因此这一步先不追求完整视觉重设计，而是先把公开简历拆成稳定的展示模块，让页面结构先“能维护、能讲清、能继续长”。
+
+## 本次目标
+
+- 将公开简历按模块拆分渲染
+- 覆盖 `profile / experiences / projects / education / skills / highlights`
+- 保持 `zh / en` 与 `light / dark` 仍然可用
+- 为后续展示层整理和 UI 升级保留清晰边界
+
+## 非目标
+
+- 不接 Figma 精修稿
+- 不做多模板切换
+- 不进入完整视觉重设计
+- 不在本次跨到 `packages/ui` 做共享设计系统
+
+## TDD / 测试设计
+
+本次重点不在接口，而在页面结构稳定性，因此测试放在 `PublishedResumeShell` 组件行为上：
+
+- 默认中文能展示模块化 section
+- 切到英文后，各 section 标题和内容同步切换
+- `light / dark` 主题切换仍影响 `documentElement`
+- 导出链接仍会随语言切换更新参数
+- 未发布时的空态不受影响
+
+对应执行：
+
+- `pnpm --filter @my-resume/web test -- published-resume-shell.spec.tsx`
+- `pnpm --filter @my-resume/web typecheck`
+- `pnpm --filter @my-resume/web build`
+
+## 实际改动
+
+### 1. 将公开页拆成模块组件
+
+新增目录：
+
+- `apps/web/components/published-resume/`
+
+新增组件：
+
+- `published-resume-empty-state.tsx`
+- `published-resume-hero.tsx`
+- `published-resume-section-card.tsx`
+- `published-resume-experience-section.tsx`
+- `published-resume-projects-section.tsx`
+- `published-resume-education-section.tsx`
+- `published-resume-skills-section.tsx`
+- `published-resume-highlights-section.tsx`
+- `published-resume-utils.ts`
+
+这样拆分后，每个模块只关注自己的展示职责，而 `PublishedResumeShell` 只负责：
+
+- 已发布 / 空态判断
+- 语言切换状态
+- 主题切换状态
+- 页面整体编排
+
+### 2. 公开页开始完整消费标准模型模块
+
+更新后的页面不再只展示项目和技能，而是正式接入：
+
+- `profile`：hero 区域与基础信息
+- `experiences`：工作经历模块
+- `projects`：项目经历模块
+- `education`：教育模块
+- `skills`：技能模块
+- `highlights`：亮点模块
+
+这一步非常关键，因为它意味着 `web` 首次以“完整标准简历”的视角组织页面，而不是零散读取部分字段。
+
+### 3. 保留主题与模板扩展钩子
+
+更新：
+
+- `apps/web/components/published-resume-shell.tsx`
+- `apps/web/app/globals.css`
+
+本次保留了：
+
+- `light / dark` 主题切换
+- `data-template="standard"` 作为标准模板标识
+- 模块级 `section-card / section-stack / content-grid` 布局边界
+
+这意味着后续要做视觉升级时，可以在当前模块结构上演进，而不需要重新从单文件大组件中硬拆。
+
+### 4. 更新模块化测试断言
+
+更新：
+
+- `apps/web/components/published-resume-shell.spec.tsx`
+
+测试不再只验证 hero 与导出链接，而是新增断言：
+
+- 职业经历 / 代表项目 / 教育背景 / 技能结构 / 补充亮点
+- 中英文切换后的 section 标题同步
+
+这样可以保证“模块化”不是主观感觉，而是有自动化断言兜底。
+
+## Review 记录
+
+### 是否符合当前 Issue 与里程碑目标
+
+符合。
+
+本次专注于 `apps/web` 的模块化渲染，没有扩展到：
+
+- admin 展示层共性整理
+- packages/ui 共享设计系统
+- 视觉精修与品牌化表达
+- 多模板切换机制
+
+### 是否可抽离组件、公共函数、skills 或其他复用能力
+
+已做的最小抽离：
+
+- section 基础卡片：`published-resume-section-card.tsx`
+- 展示层工具：`published-resume-utils.ts`
+- 各模块单独组件化
+
+但当前仍然只在 `apps/web` 内部抽离，没有直接升级为跨应用共享能力。这是有意控制范围：本次先让“模块边界”成立，下一步再做“共享边界”整理。
+
+### 为什么现在先模块化，而不是直接重设计
+
+因为视觉稿可以反复调整，但页面结构一旦混乱，后续每次改版都会成本很高。
+
+先模块化的价值在于：
+
+- 先把领域内容和显示边界对齐
+- 先让测试知道“页面有哪些稳定模块”
+- 再进入样式升级时，改动范围更可控
+
+这比直接重设计更适合教程型项目的节奏。
+
+## 自测结果
+
+已执行：
+
+- `pnpm --filter @my-resume/web test -- published-resume-shell.spec.tsx`
+- `pnpm --filter @my-resume/web typecheck`
+- `pnpm --filter @my-resume/web build`
+
+结果：全部通过。
+
+补充说明：构建时仍出现现有 Tailwind `content` 配置告警，但不影响本次构建与功能闭环；该问题会在后续展示层整理中一并考虑。
+
+## 遇到的问题
+
+### 1. 模块化后要避免“拆而不清”
+
+问题：如果只是把 JSX 挪到不同文件，但职责仍然混乱，后续维护收益会很有限。
+
+处理：
+
+- 明确让 `shell` 只管状态与编排
+- 各 section 只负责对应简历模块展示
+- 共用的文本读取、标签和日期格式统一放到 `published-resume-utils.ts`
+
+### 2. 当前还不是共享设计系统
+
+问题：模块组件拆出来后，很容易冲动继续抽到 `packages/ui`。
+
+处理：
+
+- 本次先停在 `apps/web` 内部模块化
+- 把“跨应用共享边界整理”留给 `issue-34`
+- 避免在同一个 issue 同时做页面模块化和共享层抽象
+
+## 可沉淀为教程/博客的点
+
+- 为什么公开页先做模块化，比先做视觉重设计更重要
+- 如何把简历标准模型映射成稳定的页面 section
+- 单文件展示壳如何渐进演进到可维护的模块化页面
+
+## 后续待办
+
+- 继续 `M7 / issue-34`：展示层整理，为后续 UI 升级预留边界
+- `issue-34` 完成后整理 M7 教程大纲并关闭里程碑


### PR DESCRIPTION
## Summary
- 将 `PublishedResumeShell` 拆成 hero、section card 和各简历模块组件
- 让公开站完整消费 `profile / experiences / projects / education / skills / highlights`
- 保留 `zh / en`、`light / dark` 与下载入口
- 补齐模块化页面测试与开发日志

## Testing
- pnpm --filter @my-resume/web test -- published-resume-shell.spec.tsx
- pnpm --filter @my-resume/web typecheck
- pnpm --filter @my-resume/web build
- pnpm --filter @my-resume/web test

## Logs
- docs/30-开发日志/M7-issue-33-web-公开简历页面模块化渲染.md

Closes #54
