### PR TITLE
feat(m8): persist resume publication service

### DIFF
--- a/apps/server/src/modules/resume/resume-publication.repository.ts
+++ b/apps/server/src/modules/resume/resume-publication.repository.ts
@@ -1,0 +1,70 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { desc, eq } from 'drizzle-orm';
+
+import { DATABASE_INSTANCE } from '../../database/database.tokens';
+import type { DatabaseInstance } from '../../database/database.client';
+import {
+  createResumeDraftRecord,
+  createResumePublicationSnapshotRecord,
+  STANDARD_RESUME_KEY,
+} from '../../database/resume-records';
+import {
+  resumeDrafts,
+  resumePublicationSnapshots,
+} from '../../database/schema';
+import type { StandardResume } from './domain/standard-resume';
+
+@Injectable()
+export class ResumePublicationRepository {
+  constructor(
+    @Inject(DATABASE_INSTANCE)
+    private readonly database: DatabaseInstance,
+  ) {}
+
+  async findDraft() {
+    const [record] = await this.database
+      .select()
+      .from(resumeDrafts)
+      .where(eq(resumeDrafts.resumeKey, STANDARD_RESUME_KEY))
+      .limit(1);
+
+    return record ?? null;
+  }
+
+  async saveDraft(resume: StandardResume, updatedAt = new Date()) {
+    const draftRecord = createResumeDraftRecord(resume, updatedAt);
+
+    await this.database
+      .insert(resumeDrafts)
+      .values(draftRecord)
+      .onConflictDoUpdate({
+        target: resumeDrafts.resumeKey,
+        set: {
+          schemaVersion: draftRecord.schemaVersion,
+          resumeJson: draftRecord.resumeJson,
+          updatedAt: draftRecord.updatedAt,
+        },
+      });
+
+    return (await this.findDraft())!;
+  }
+
+  async findLatestPublishedSnapshot() {
+    const [record] = await this.database
+      .select()
+      .from(resumePublicationSnapshots)
+      .where(eq(resumePublicationSnapshots.resumeKey, STANDARD_RESUME_KEY))
+      .orderBy(desc(resumePublicationSnapshots.publishedAt))
+      .limit(1);
+
+    return record ?? null;
+  }
+
+  async createPublishedSnapshot(resume: StandardResume, publishedAt = new Date()) {
+    const snapshotRecord = createResumePublicationSnapshotRecord(resume, publishedAt);
+
+    await this.database.insert(resumePublicationSnapshots).values(snapshotRecord);
+
+    return snapshotRecord;
+  }
+}

--- a/apps/server/src/modules/resume/resume-publication.service.spec.ts
+++ b/apps/server/src/modules/resume/resume-publication.service.spec.ts
@@ -1,11 +1,98 @@
-import { describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
 
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  createDatabase,
+  createDatabaseClient,
+} from '../../database/database.client';
+import type { DatabaseClient } from '../../database/database.client';
+import { ResumePublicationRepository } from './resume-publication.repository';
 import { createExampleStandardResume } from './domain/standard-resume';
 import { ResumePublicationService } from './resume-publication.service';
 
+interface ServiceHarness {
+  client: DatabaseClient;
+  databaseFilePath: string;
+  service: ResumePublicationService;
+}
+
+const tempDirectories: string[] = [];
+
+async function prepareTables(client: DatabaseClient) {
+  await client.execute(`
+    CREATE TABLE IF NOT EXISTS resume_drafts (
+      resume_key text PRIMARY KEY NOT NULL,
+      schema_version integer NOT NULL,
+      resume_json text NOT NULL,
+      updated_at integer NOT NULL
+    );
+  `);
+
+  await client.execute(`
+    CREATE TABLE IF NOT EXISTS resume_publication_snapshots (
+      id text PRIMARY KEY NOT NULL,
+      resume_key text NOT NULL,
+      schema_version integer NOT NULL,
+      resume_json text NOT NULL,
+      published_at integer NOT NULL
+    );
+  `);
+
+  await client.execute(`
+    CREATE INDEX IF NOT EXISTS resume_publication_snapshots_resume_key_published_at_idx
+    ON resume_publication_snapshots (resume_key, published_at);
+  `);
+}
+
+async function createServiceHarness(
+  databaseFilePath?: string,
+): Promise<ServiceHarness> {
+  const nextDatabaseFilePath =
+    databaseFilePath ??
+    join(
+      mkdtempSync(join(tmpdir(), 'my-resume-publication-')),
+      'resume.db',
+    );
+
+  if (!databaseFilePath) {
+    tempDirectories.push(nextDatabaseFilePath.replace(/\/resume\.db$/, ''));
+  }
+
+  const client = createDatabaseClient({
+    url: `file:${nextDatabaseFilePath}`,
+    dialect: 'libsql',
+    isRemote: false,
+  });
+  await prepareTables(client);
+
+  const database = createDatabase(client);
+  const repository = new ResumePublicationRepository(database);
+  const service = new ResumePublicationService(repository);
+
+  return {
+    client,
+    databaseFilePath: nextDatabaseFilePath,
+    service,
+  };
+}
+
 describe('ResumePublicationService', () => {
-  it('should keep draft editable before publishing', () => {
-    const service = new ResumePublicationService();
+  afterEach(async () => {
+    for (const directory of tempDirectories) {
+      rmSync(directory, {
+        force: true,
+        recursive: true,
+      });
+    }
+
+    tempDirectories.length = 0;
+  });
+
+  it('should keep draft editable before publishing', async () => {
+    const { client, service } = await createServiceHarness();
     const nextDraft = createExampleStandardResume();
 
     nextDraft.profile.headline = {
@@ -13,17 +100,19 @@ describe('ResumePublicationService', () => {
       en: 'Senior Full-Stack Engineer',
     };
 
-    service.updateDraft(nextDraft);
+    await service.updateDraft(nextDraft);
 
-    expect(service.getDraft().resume.profile.headline).toEqual({
+    expect((await service.getDraft()).resume.profile.headline).toEqual({
       zh: '资深全栈工程师',
       en: 'Senior Full-Stack Engineer',
     });
-    expect(service.getPublished()).toBeNull();
+    expect(await service.getPublished()).toBeNull();
+
+    client.close();
   });
 
-  it('should publish the current draft snapshot', () => {
-    const service = new ResumePublicationService();
+  it('should publish the current draft snapshot', async () => {
+    const { client, service } = await createServiceHarness();
     const draft = createExampleStandardResume();
 
     draft.profile.headline = {
@@ -31,9 +120,9 @@ describe('ResumePublicationService', () => {
       en: 'Ready to Publish',
     };
 
-    service.updateDraft(draft);
+    await service.updateDraft(draft);
 
-    const published = service.publish();
+    const published = await service.publish();
 
     expect(published.status).toBe('published');
     expect(published.resume.profile.headline).toEqual({
@@ -41,10 +130,12 @@ describe('ResumePublicationService', () => {
       en: 'Ready to Publish',
     });
     expect(published.publishedAt).toEqual(expect.any(String));
+
+    client.close();
   });
 
-  it('should keep published content stable after draft changes until republish', () => {
-    const service = new ResumePublicationService();
+  it('should keep published content stable after draft changes until republish', async () => {
+    const { client, service } = await createServiceHarness();
     const firstDraft = createExampleStandardResume();
 
     firstDraft.profile.headline = {
@@ -52,8 +143,8 @@ describe('ResumePublicationService', () => {
       en: 'First Version',
     };
 
-    service.updateDraft(firstDraft);
-    service.publish();
+    await service.updateDraft(firstDraft);
+    await service.publish();
 
     const secondDraft = createExampleStandardResume();
     secondDraft.profile.headline = {
@@ -61,15 +152,44 @@ describe('ResumePublicationService', () => {
       en: 'Second Draft',
     };
 
-    service.updateDraft(secondDraft);
+    await service.updateDraft(secondDraft);
 
-    expect(service.getDraft().resume.profile.headline).toEqual({
+    expect((await service.getDraft()).resume.profile.headline).toEqual({
       zh: '第二版草稿',
       en: 'Second Draft',
     });
-    expect(service.getPublished()?.resume.profile.headline).toEqual({
+    expect((await service.getPublished())?.resume.profile.headline).toEqual({
       zh: '第一版',
       en: 'First Version',
     });
+
+    client.close();
+  });
+
+  it('should keep draft and published data after recreating the service on the same database', async () => {
+    const firstHarness = await createServiceHarness();
+    const draft = createExampleStandardResume();
+
+    draft.profile.headline = {
+      zh: '持久化版本',
+      en: 'Persistent Version',
+    };
+
+    await firstHarness.service.updateDraft(draft);
+    await firstHarness.service.publish();
+    firstHarness.client.close();
+
+    const secondHarness = await createServiceHarness(firstHarness.databaseFilePath);
+
+    expect((await secondHarness.service.getDraft()).resume.profile.headline).toEqual({
+      zh: '持久化版本',
+      en: 'Persistent Version',
+    });
+    expect((await secondHarness.service.getPublished())?.resume.profile.headline).toEqual({
+      zh: '持久化版本',
+      en: 'Persistent Version',
+    });
+
+    secondHarness.client.close();
   });
 });

--- a/apps/server/src/modules/resume/resume-publication.service.ts
+++ b/apps/server/src/modules/resume/resume-publication.service.ts
@@ -1,9 +1,10 @@
-import { Injectable } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
 
 import {
   createExampleStandardResume,
   StandardResume,
 } from './domain/standard-resume';
+import { ResumePublicationRepository } from './resume-publication.repository';
 
 export interface ResumeDraftSnapshot {
   status: 'draft';
@@ -23,49 +24,71 @@ function cloneStandardResume(resume: StandardResume): StandardResume {
 
 @Injectable()
 export class ResumePublicationService {
-  private draftSnapshot: ResumeDraftSnapshot = {
-    status: 'draft',
-    resume: createExampleStandardResume(),
-    updatedAt: new Date().toISOString(),
-  };
+  constructor(
+    @Inject(ResumePublicationRepository)
+    private readonly resumePublicationRepository: ResumePublicationRepository,
+  ) {}
 
-  private publishedSnapshot: ResumePublishedSnapshot | null = null;
+  async getDraft(): Promise<ResumeDraftSnapshot> {
+    const existingDraft = await this.resumePublicationRepository.findDraft();
 
-  getDraft(): ResumeDraftSnapshot {
+    if (!existingDraft) {
+      const seededDraft = await this.resumePublicationRepository.saveDraft(
+        createExampleStandardResume(),
+      );
+
+      return {
+        status: 'draft',
+        resume: cloneStandardResume(seededDraft.resumeJson),
+        updatedAt: seededDraft.updatedAt.toISOString(),
+      };
+    }
+
     return {
-      ...this.draftSnapshot,
-      resume: cloneStandardResume(this.draftSnapshot.resume),
+      status: 'draft',
+      resume: cloneStandardResume(existingDraft.resumeJson),
+      updatedAt: existingDraft.updatedAt.toISOString(),
     };
   }
 
-  getPublished(): ResumePublishedSnapshot | null {
-    if (!this.publishedSnapshot) {
+  async getPublished(): Promise<ResumePublishedSnapshot | null> {
+    const publishedSnapshot =
+      await this.resumePublicationRepository.findLatestPublishedSnapshot();
+
+    if (!publishedSnapshot) {
       return null;
     }
 
     return {
-      ...this.publishedSnapshot,
-      resume: cloneStandardResume(this.publishedSnapshot.resume),
-    };
-  }
-
-  updateDraft(resume: StandardResume): ResumeDraftSnapshot {
-    this.draftSnapshot = {
-      status: 'draft',
-      resume: cloneStandardResume(resume),
-      updatedAt: new Date().toISOString(),
-    };
-
-    return this.getDraft();
-  }
-
-  publish(): ResumePublishedSnapshot {
-    this.publishedSnapshot = {
       status: 'published',
-      resume: cloneStandardResume(this.draftSnapshot.resume),
-      publishedAt: new Date().toISOString(),
+      resume: cloneStandardResume(publishedSnapshot.resumeJson),
+      publishedAt: publishedSnapshot.publishedAt.toISOString(),
     };
+  }
 
-    return this.getPublished() as ResumePublishedSnapshot;
+  async updateDraft(resume: StandardResume): Promise<ResumeDraftSnapshot> {
+    const savedDraft = await this.resumePublicationRepository.saveDraft(
+      cloneStandardResume(resume),
+    );
+
+    return {
+      status: 'draft',
+      resume: cloneStandardResume(savedDraft.resumeJson),
+      updatedAt: savedDraft.updatedAt.toISOString(),
+    };
+  }
+
+  async publish(): Promise<ResumePublishedSnapshot> {
+    const draft = await this.getDraft();
+    const publishedSnapshot =
+      await this.resumePublicationRepository.createPublishedSnapshot(
+        cloneStandardResume(draft.resume),
+      );
+
+    return {
+      status: 'published',
+      resume: cloneStandardResume(publishedSnapshot.resumeJson),
+      publishedAt: publishedSnapshot.publishedAt.toISOString(),
+    };
   }
 }

--- a/apps/server/src/modules/resume/resume.controller.ts
+++ b/apps/server/src/modules/resume/resume.controller.ts
@@ -36,8 +36,8 @@ export class ResumeController {
   ) {}
 
   @Get('published')
-  getPublishedResume() {
-    const published = this.resumePublicationService.getPublished();
+  async getPublishedResume() {
+    const published = await this.resumePublicationService.getPublished();
 
     if (!published) {
       throw new NotFoundException('Published resume is not available');
@@ -47,11 +47,11 @@ export class ResumeController {
   }
 
   @Get('published/export/markdown')
-  exportPublishedResumeMarkdown(
+  async exportPublishedResumeMarkdown(
     @Query('locale') localeQuery: string | undefined,
     @Res() response: Response,
   ) {
-    const published = this.resumePublicationService.getPublished();
+    const published = await this.resumePublicationService.getPublished();
 
     if (!published) {
       throw new NotFoundException('Published resume is not available');
@@ -80,7 +80,7 @@ export class ResumeController {
     @Query('locale') localeQuery: string | undefined,
     @Res() response: Response,
   ) {
-    const published = this.resumePublicationService.getPublished();
+    const published = await this.resumePublicationService.getPublished();
 
     if (!published) {
       throw new NotFoundException('Published resume is not available');
@@ -107,7 +107,7 @@ export class ResumeController {
   @Get('draft')
   @UseGuards(JwtAuthGuard, RoleCapabilitiesGuard)
   @RequireCapability('canEditResume')
-  getDraftResume() {
+  async getDraftResume() {
     return this.resumePublicationService.getDraft();
   }
 
@@ -115,7 +115,7 @@ export class ResumeController {
   @HttpCode(HttpStatus.OK)
   @UseGuards(JwtAuthGuard, RoleCapabilitiesGuard)
   @RequireCapability('canEditResume')
-  updateDraftResume(@Body() resume: StandardResume) {
+  async updateDraftResume(@Body() resume: StandardResume) {
     const validationResult = validateStandardResume(resume);
 
     if (!validationResult.valid) {
@@ -129,7 +129,7 @@ export class ResumeController {
   @HttpCode(HttpStatus.OK)
   @UseGuards(JwtAuthGuard, RoleCapabilitiesGuard)
   @RequireCapability('canPublishResume')
-  publishResume() {
+  async publishResume() {
     return this.resumePublicationService.publish();
   }
 

--- a/apps/server/src/modules/resume/resume.module.ts
+++ b/apps/server/src/modules/resume/resume.module.ts
@@ -4,17 +4,20 @@ import { AuthModule } from '../auth/auth.module';
 import { ResumeController } from './resume.controller';
 import { ResumeMarkdownExportService } from './resume-markdown-export.service';
 import { ResumePdfExportService } from './resume-pdf-export.service';
+import { ResumePublicationRepository } from './resume-publication.repository';
 import { ResumePublicationService } from './resume-publication.service';
 
 @Module({
   imports: [AuthModule],
   controllers: [ResumeController],
   providers: [
+    ResumePublicationRepository,
     ResumePublicationService,
     ResumeMarkdownExportService,
     ResumePdfExportService,
   ],
   exports: [
+    ResumePublicationRepository,
     ResumePublicationService,
     ResumeMarkdownExportService,
     ResumePdfExportService,

--- a/apps/server/test/resume-publication.e2e-spec.ts
+++ b/apps/server/test/resume-publication.e2e-spec.ts
@@ -1,17 +1,59 @@
+import { mkdtempSync, rmSync } from 'fs';
 import { INestApplication } from '@nestjs/common';
+import { tmpdir } from 'os';
+import { join } from 'path';
 import { Test, TestingModule } from '@nestjs/testing';
 import request from 'supertest';
 import { App } from 'supertest/types';
 
+import type { DatabaseClient } from './../src/database/database.client';
+import { DATABASE_CLIENT } from './../src/database/database.tokens';
 import { AppModule } from './../src/app.module';
+
+async function prepareResumeTables(client: DatabaseClient) {
+  await client.execute(`
+    CREATE TABLE IF NOT EXISTS resume_drafts (
+      resume_key text PRIMARY KEY NOT NULL,
+      schema_version integer NOT NULL,
+      resume_json text NOT NULL,
+      updated_at integer NOT NULL
+    );
+  `);
+
+  await client.execute(`
+    CREATE TABLE IF NOT EXISTS resume_publication_snapshots (
+      id text PRIMARY KEY NOT NULL,
+      resume_key text NOT NULL,
+      schema_version integer NOT NULL,
+      resume_json text NOT NULL,
+      published_at integer NOT NULL
+    );
+  `);
+
+  await client.execute(`
+    CREATE INDEX IF NOT EXISTS resume_publication_snapshots_resume_key_published_at_idx
+    ON resume_publication_snapshots (resume_key, published_at);
+  `);
+
+  await client.execute('DELETE FROM resume_publication_snapshots;');
+  await client.execute('DELETE FROM resume_drafts;');
+}
 
 describe('Resume publication flow (e2e)', () => {
   let app: INestApplication<App>;
+  let previousDatabaseUrl: string | undefined;
+  let tempDirectory: string;
 
   beforeEach(async () => {
+    previousDatabaseUrl = process.env.DATABASE_URL;
+    tempDirectory = mkdtempSync(join(tmpdir(), 'my-resume-resume-e2e-'));
+    process.env.DATABASE_URL = `file:${join(tempDirectory, 'resume-publication.db')}`;
+
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports: [AppModule],
     }).compile();
+
+    await prepareResumeTables(moduleFixture.get<DatabaseClient>(DATABASE_CLIENT));
 
     app = moduleFixture.createNestApplication();
     await app.init();
@@ -19,6 +61,17 @@ describe('Resume publication flow (e2e)', () => {
 
   afterEach(async () => {
     await app.close();
+
+    if (previousDatabaseUrl) {
+      process.env.DATABASE_URL = previousDatabaseUrl;
+    } else {
+      delete process.env.DATABASE_URL;
+    }
+
+    rmSync(tempDirectory, {
+      force: true,
+      recursive: true,
+    });
   });
 
   it('should hide unpublished resume from the public endpoint', () => {

--- a/docs/30-开发日志/M8-issue-38-ResumePublicationService-持久化改造.md
+++ b/docs/30-开发日志/M8-issue-38-ResumePublicationService-持久化改造.md
@@ -1,0 +1,208 @@
+# M8 / issue-38 开发日志：ResumePublicationService 持久化改造
+
+- Issue：#66
+- 里程碑：M8 数据持久化与共享契约：从内存态到可持续演进
+- 分支：`fys-dev/feat-m8-issue-38-publication-persistence`
+- 日期：2026-03-26
+
+## 背景
+
+在 `issue-37` 中，我们已经完成了 `resume_drafts` 与 `resume_publication_snapshots` 两张核心表的设计，但 `ResumePublicationService` 仍然停留在内存态。
+
+这会带来一个明显问题：
+
+- 服务重启后草稿与已发布内容都会丢失
+- 当前 API 虽然能跑通，但还不具备真实可持续演进的基础
+
+所以 `issue-38` 的重点，不是重做接口，而是把现有发布流平滑切到数据库持久化实现上。
+
+## 本次目标
+
+- 将 `ResumePublicationService` 从内存实现切换为数据库仓储实现
+- 保持现有控制器与 API 语义尽量稳定
+- 让草稿、发布态在服务重启后仍然可读取
+- 用测试保护“草稿保存 / 发布 / 重启后仍保留”的关键行为
+
+## 非目标
+
+- 不新增新的业务模块
+- 不改动前端展示层逻辑
+- 不引入多份简历、多租户或 JD 定制版
+- 不在本次处理 AI、附件或导出持久化
+
+## TDD / 测试设计
+
+这次测试重点不再是表结构，而是“服务行为是否真的完成了持久化切换”。
+
+### 1. 服务层持久化行为测试
+
+更新：
+
+- `apps/server/src/modules/resume/resume-publication.service.spec.ts`
+
+测试策略：
+
+- 不再只依赖内存对象
+- 改为使用真实临时 sqlite 文件
+- 在测试中手动建表，避免把关注点放到 CLI 推表流程
+
+覆盖场景：
+
+- 草稿可持续编辑
+- 发布会生成稳定快照
+- 发布后继续改草稿，不影响已发布内容
+- 使用同一数据库文件重新创建 service 后，草稿与发布内容仍然存在
+
+### 2. API 层回归验证
+
+通过现有 e2e 测试确认：
+
+- 控制器异步化后，接口语义没有漂移
+- 公开读取与后台读写链路仍然成立
+
+## 实际改动
+
+### 1. 新增发布流仓储层
+
+新增：
+
+- `apps/server/src/modules/resume/resume-publication.repository.ts`
+
+提供的最小能力：
+
+- `findDraft()`
+- `saveDraft()`
+- `findLatestPublishedSnapshot()`
+- `createPublishedSnapshot()`
+
+这样做的目的，是把数据库查询、写入和 service 里的业务编排拆开，保持单一职责，也更方便后续继续补仓储测试。
+
+### 2. 将发布服务改造成数据库驱动
+
+更新：
+
+- `apps/server/src/modules/resume/resume-publication.service.ts`
+
+核心变化：
+
+- `getDraft()` 改为从数据库读草稿
+- 首次读取无数据时，自动写入示例简历作为种子草稿
+- `getPublished()` 改为读取最新发布快照
+- `updateDraft()` 改为保存数据库草稿
+- `publish()` 改为基于当前草稿写入发布快照
+
+这里保持了原本的接口语义：
+
+- 仍然区分 `draft` / `published`
+- 仍然返回 ISO 时间字符串
+- 仍然对外暴露标准简历结构
+
+## 3. 控制器与模块完成异步适配
+
+更新：
+
+- `apps/server/src/modules/resume/resume.controller.ts`
+- `apps/server/src/modules/resume/resume.module.ts`
+
+调整内容：
+
+- 控制器方法改为 `async`
+- 与发布流相关的读取、保存、发布都显式 `await`
+- 在模块中注册 `ResumePublicationRepository`
+
+这一步让控制器无需关心持久化细节，只是顺着 service 的异步语义往下调用。
+
+### 4. 测试切换到真实持久化场景
+
+更新：
+
+- `apps/server/src/modules/resume/resume-publication.service.spec.ts`
+
+本次没有只做 mock 仓储测试，而是直接让 service 面对真实 sqlite 临时文件。
+
+这样做更适合当前阶段教学，因为它能直接回答一个关键问题：
+
+“这次改造后，服务重启数据真的还在吗？”
+
+## Review 记录
+
+### 是否符合当前 Issue 与里程碑目标
+
+符合。
+
+本次只完成了发布流服务的持久化替换，没有越界到：
+
+- 更复杂的发布历史管理 UI
+- 回滚机制
+- 共享 API client
+- 前端联动改造
+
+### 是否存在可抽离的组件、公共函数、skills 或其他复用能力
+
+本次新增的可复用抽象主要是：
+
+- `ResumePublicationRepository`
+
+当前先保持它只服务发布流，不额外提前抽成更泛化的 repository 基类，避免教学复杂度上升。
+
+### 这次最关键的边界判断
+
+我们没有为了“更完整”而一次性补：
+
+- 发布历史查询列表
+- 当前发布版本标记
+- 发布回滚
+- 草稿多版本
+
+因为当前 issue 的重点是“把内存态平滑换成持久化实现”，不是把整个内容后台一次做满。
+
+## 自测结果
+
+已执行：
+
+- `pnpm --filter @my-resume/server exec vitest run --config ./vitest.config.mts src/modules/resume/resume-publication.service.spec.ts`
+- `pnpm --filter @my-resume/server test:e2e`
+- `pnpm --filter @my-resume/server test`
+- `pnpm --filter @my-resume/server typecheck`
+- `pnpm --filter @my-resume/server build`
+
+结果：全部通过。
+
+## 遇到的问题
+
+### 1. Vitest 下 Nest 依赖注入元数据不稳定
+
+问题：
+
+迁移到 `Vitest` 后，不能继续依赖 `emitDecoratorMetadata` 的隐式注入体验。
+
+处理：
+
+- 保持 server 代码中的显式注入写法
+- 使用 `@Inject(...)` 明确仓储与数据库依赖
+
+这样可以减少测试环境和运行环境的注入差异。
+
+### 2. 如何验证“持久化”而不是“内存态伪通过”
+
+问题：
+
+如果只 mock repository，虽然测试能过，但无法证明服务重启后数据仍然存在。
+
+处理：
+
+- 使用真实临时 sqlite 文件
+- 在同一数据库文件上重建 service 实例
+- 直接验证草稿与发布内容是否仍然可读
+
+## 可沉淀为教程/博客的点
+
+- 如何把一个内存态 service 平滑迁移到 repository + database
+- 为什么教程型项目里，先做“可持续保存”比先做复杂后台更重要
+- 在 `Vitest + NestJS` 组合下，为什么更推荐显式依赖注入
+
+## 后续待办
+
+- 提交并合并 `issue-38`
+- 继续推进 `M8` 后续共享契约相关 issue
+- 逐步把“仅能跑”的内存态模块替换成“可持续演进”的基础设施能力

--- a/docs/30-开发日志/M8-issue-38-ResumePublicationService-持久化改造.md
+++ b/docs/30-开发日志/M8-issue-38-ResumePublicationService-持久化改造.md
@@ -195,6 +195,21 @@
 - 在同一数据库文件上重建 service 实例
 - 直接验证草稿与发布内容是否仍然可读
 
+### 3. CI 下的 e2e 共享数据库污染
+
+问题：
+
+本地单独跑 service 测试和 e2e 都能通过，但 PR CI 暴露出两个隐藏问题：
+
+- e2e 初始化缺少 `resume_drafts` / `resume_publication_snapshots`
+- 多个 e2e 文件共享同一个 sqlite 文件时，容易出现状态串扰或锁冲突
+
+处理：
+
+- 在 `resume-publication.e2e` 中补齐最小建表逻辑
+- 为该 e2e 文件切换到临时独立 sqlite 文件
+- 每次用例前清空相关表，确保未发布与已发布场景都能稳定复现
+
 ## 可沉淀为教程/博客的点
 
 - 如何把一个内存态 service 平滑迁移到 repository + database


### PR DESCRIPTION
## Summary
- add `ResumePublicationRepository` for draft and published snapshot persistence
- refactor `ResumePublicationService` from in-memory state to db-backed async implementation
- update service tests and add M8 / issue-38 development log

## Testing
- pnpm --filter @my-resume/server exec vitest run --config ./vitest.config.mts src/modules/resume/resume-publication.service.spec.ts
- pnpm --filter @my-resume/server typecheck

Closes #66
