### PR TITLE
feat(m9): extract shared display primitives

### DIFF
--- a/apps/admin/app/globals.css
+++ b/apps/admin/app/globals.css
@@ -48,10 +48,6 @@ textarea {
 }
 
 .card {
-  background: var(--display-color-surface);
-  border: 1px solid var(--display-color-border);
-  border-radius: var(--display-radius-card);
-  box-shadow: var(--display-shadow-card);
   padding: 1.5rem;
 }
 
@@ -114,20 +110,6 @@ textarea {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 1rem;
-}
-
-.info-item {
-  display: grid;
-  gap: 0.35rem;
-  padding: 1rem;
-  border-radius: 16px;
-  background: var(--display-color-surface-muted);
-  border: 1px solid var(--display-color-border);
-}
-
-.info-item span {
-  color: var(--display-color-text-muted);
-  font-size: 0.9rem;
 }
 
 .readonly-box {

--- a/apps/admin/components/admin-dashboard-shell.tsx
+++ b/apps/admin/components/admin-dashboard-shell.tsx
@@ -1,5 +1,11 @@
 'use client';
 
+import {
+  DisplayPill,
+  DisplaySectionIntro,
+  DisplayStatCard,
+  DisplaySurfaceCard,
+} from '@my-resume/ui/display';
 import Link from 'next/link';
 import { useEffect, useState } from 'react';
 
@@ -53,22 +59,27 @@ export function AdminDashboardShell() {
   }, []);
 
   if (status === 'loading') {
-    return <main className="page-shell single-card">正在加载后台壳...</main>;
+    return (
+      <main className="page-shell single-card">
+        <DisplaySurfaceCard className="card">正在加载后台壳...</DisplaySurfaceCard>
+      </main>
+    );
   }
 
   if (status === 'unauthorized' || !currentUser) {
     return (
       <main className="page-shell single-card">
-        <section className="card stack">
-          <div>
-            <p className="eyebrow">未登录</p>
-            <h1>请先登录后台</h1>
-            <p className="muted">当前页面是最小受保护壳，需要先获取 JWT。</p>
-          </div>
+        <DisplaySurfaceCard className="card stack">
+          <DisplaySectionIntro
+            description="当前页面是最小受保护壳，需要先获取 JWT。"
+            eyebrow="未登录"
+            title="请先登录后台"
+            titleAs="h1"
+          />
           <Link className="link-button" href="/">
             返回登录页
           </Link>
-        </section>
+        </DisplaySurfaceCard>
       </main>
     );
   }
@@ -176,16 +187,15 @@ export function AdminDashboardShell() {
 
   return (
     <main className="dashboard-shell">
-      <section className="card dashboard-hero">
+      <DisplaySurfaceCard className="card dashboard-hero">
         <div className="page-header">
-          <div className="page-header-copy">
-            <p className="eyebrow">受保护页面</p>
-            <h1>后台控制台</h1>
-            <p className="muted">
-              当前阶段先把“草稿编辑、手动发布、角色边界、导出入口”收进一张可解释的后台首页，
-              为后续信息架构升级和教学演示打底。
-            </p>
-          </div>
+          <DisplaySectionIntro
+            className="page-header-copy"
+            description="当前阶段先把“草稿编辑、手动发布、角色边界、导出入口”收进一张可解释的后台首页，为后续信息架构升级和教学演示打底。"
+            eyebrow="受保护页面"
+            title="后台控制台"
+            titleAs="h1"
+          />
           <div className="dashboard-hero-actions">
             <ThemeModeToggle />
             <button
@@ -202,37 +212,45 @@ export function AdminDashboardShell() {
         </div>
 
         <div className="dashboard-badge-row">
-          <span className="display-pill dashboard-badge">当前账号：{currentUser.username}</span>
-          <span className="display-pill dashboard-badge">当前角色：{currentUser.role}</span>
-          <span className="display-pill dashboard-badge">公开站只读已发布版本</span>
-          <span className="display-pill dashboard-badge">单后端业务入口：apps/server</span>
+          <DisplayPill className="dashboard-badge">
+            当前账号：{currentUser.username}
+          </DisplayPill>
+          <DisplayPill className="dashboard-badge">
+            当前角色：{currentUser.role}
+          </DisplayPill>
+          <DisplayPill className="dashboard-badge">
+            公开站只读已发布版本
+          </DisplayPill>
+          <DisplayPill className="dashboard-badge">
+            单后端业务入口：apps/server
+          </DisplayPill>
         </div>
 
         <div className="dashboard-overview-grid">
           {capabilityCards.map((card) => (
-            <div className="info-item dashboard-overview-card" key={card.label}>
-              <span>{card.label}</span>
-              <strong>{card.value}</strong>
-              <p className="muted">{card.description}</p>
-            </div>
+            <DisplayStatCard
+              className="dashboard-overview-card"
+              description={card.description}
+              key={card.label}
+              label={card.label}
+              value={card.value}
+            />
           ))}
         </div>
-      </section>
+      </DisplaySurfaceCard>
 
       <section className="dashboard-main-grid">
         <div className="dashboard-column stack">
-          <section className="card stack">
-            <div>
-              <p className="eyebrow">工作区概览</p>
-              <h2>内容工作区</h2>
-              <p className="muted">
-                当前先聚焦 profile 草稿编辑，保持“先保存草稿，再手动发布”的主线节奏。
-              </p>
-            </div>
+          <DisplaySurfaceCard className="card stack">
+            <DisplaySectionIntro
+              description="当前先聚焦 profile 草稿编辑，保持“先保存草稿，再手动发布”的主线节奏。"
+              eyebrow="工作区概览"
+              title="内容工作区"
+            />
             <div className="dashboard-inline-note">
               这一区域只负责内容维护，不直接承载公开站语义和 AI 业务逻辑。
             </div>
-          </section>
+          </DisplaySurfaceCard>
 
           <ResumeDraftEditorPanel
             accessToken={readAccessToken() ?? ''}
@@ -242,24 +260,16 @@ export function AdminDashboardShell() {
         </div>
 
         <aside className="dashboard-column stack">
-          <section className="card stack">
-            <div>
-              <p className="eyebrow">会话信息</p>
-              <h2>会话与边界</h2>
-              <p className="muted">
-                当前后台只做单管理员 / viewer 教学型权限边界，不扩展到复杂多角色后台。
-              </p>
-            </div>
+          <DisplaySurfaceCard className="card stack">
+            <DisplaySectionIntro
+              description="当前后台只做单管理员 / viewer 教学型权限边界，不扩展到复杂多角色后台。"
+              eyebrow="会话信息"
+              title="会话与边界"
+            />
 
             <div className="info-grid">
-              <div className="info-item">
-                <span>当前账号</span>
-                <strong>{currentUser.username}</strong>
-              </div>
-              <div className="info-item">
-                <span>角色身份</span>
-                <strong>{currentUser.role}</strong>
-              </div>
+              <DisplayStatCard label="当前账号" value={currentUser.username} />
+              <DisplayStatCard label="角色身份" value={currentUser.role} />
             </div>
 
             <p className="muted">
@@ -271,7 +281,7 @@ export function AdminDashboardShell() {
             <div className="dashboard-inline-note">
               业务规则继续只由 `apps/server` 提供，后台页面只负责组织信息与触发入口。
             </div>
-          </section>
+          </DisplaySurfaceCard>
 
           <RoleActionPanel
             currentUser={currentUser}
@@ -281,14 +291,12 @@ export function AdminDashboardShell() {
             pendingAction={pendingAction}
           />
 
-          <section className="card stack">
-            <div>
-              <p className="eyebrow">发布流提示</p>
-              <h2>流程提示</h2>
-              <p className="muted">
-                把当前后台里最重要的几步写清楚，方便演示、截图和后续教学交接。
-              </p>
-            </div>
+          <DisplaySurfaceCard className="card stack">
+            <DisplaySectionIntro
+              description="把当前后台里最重要的几步写清楚，方便演示、截图和后续教学交接。"
+              eyebrow="发布流提示"
+              title="流程提示"
+            />
 
             <ol className="workflow-list">
               {workflowSteps.map((step) => (
@@ -298,7 +306,7 @@ export function AdminDashboardShell() {
                 </li>
               ))}
             </ol>
-          </section>
+          </DisplaySurfaceCard>
 
           <ExportEntryPanel
             apiBaseUrl={DEFAULT_API_BASE_URL}

--- a/apps/admin/components/admin-login-shell.tsx
+++ b/apps/admin/components/admin-login-shell.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { DisplaySectionIntro, DisplaySurfaceCard } from '@my-resume/ui/display';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
@@ -65,7 +66,9 @@ export function AdminLoginShell() {
   }
 
   if (checkingSession) {
-    return <section className="card">正在检查登录状态...</section>;
+    return (
+      <DisplaySurfaceCard className="card">正在检查登录状态...</DisplaySurfaceCard>
+    );
   }
 
   return (
@@ -76,12 +79,13 @@ export function AdminLoginShell() {
         pending={pending}
       />
 
-      <section className="card stack">
+      <DisplaySurfaceCard className="card stack">
         <div className="page-header">
-          <div className="page-header-copy">
-            <p className="eyebrow">当前说明</p>
-            <h2>最小后台登录说明</h2>
-          </div>
+          <DisplaySectionIntro
+            className="page-header-copy"
+            eyebrow="当前说明"
+            title="最小后台登录说明"
+          />
           <ThemeModeToggle />
         </div>
         <ul className="muted-list">
@@ -101,7 +105,7 @@ export function AdminLoginShell() {
             </Link>
           </div>
         ) : null}
-      </section>
+      </DisplaySurfaceCard>
     </main>
   );
 }

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -29,15 +29,6 @@
   opacity: 0.2;
 }
 
-.hero-card,
-.section-card,
-.empty-card {
-  background: var(--display-color-surface);
-  border: 1px solid var(--display-color-border);
-  border-radius: var(--display-radius-card);
-  box-shadow: var(--display-shadow-card);
-}
-
 .hero-card {
   position: relative;
   overflow: hidden;
@@ -83,14 +74,11 @@
 }
 
 .subtitle,
-.section-subtitle,
-.meta-text,
-.signal-description {
+.meta-text {
   color: var(--display-color-text-muted);
 }
 
-.subtitle,
-.section-subtitle {
+.subtitle {
   margin: 0;
   line-height: 1.7;
 }
@@ -108,38 +96,8 @@
   z-index: 1;
 }
 
-.meta-pill,
-.link-pill {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.35rem;
-  min-height: 42px;
-  padding: 0.68rem 0.95rem;
-  border-radius: var(--display-radius-pill);
-  background: var(--display-color-surface-muted);
-  border: 1px solid var(--display-color-border);
-}
-
-.meta-pill {
+.hero-meta .display-pill {
   font-size: 0.94rem;
-}
-
-.link-pill {
-  text-decoration: none;
-  transition:
-    transform 160ms ease,
-    border-color 160ms ease,
-    background 160ms ease;
-}
-
-.link-pill:hover {
-  transform: translateY(-1px);
-  border-color: color-mix(in srgb, var(--display-color-accent) 48%, var(--display-color-border));
-  background: color-mix(
-    in srgb,
-    var(--display-color-accent-soft) 48%,
-    var(--display-color-surface-muted)
-  );
 }
 
 .link-grid,
@@ -210,22 +168,6 @@
   );
 }
 
-.section-header {
-  display: grid;
-  gap: 0.42rem;
-  position: relative;
-  z-index: 1;
-}
-
-.section-header.compact {
-  gap: 0.2rem;
-}
-
-.section-title {
-  margin: 0;
-  font-size: 1.28rem;
-}
-
 .hero-block {
   display: grid;
   gap: 0.75rem;
@@ -253,11 +195,8 @@
 }
 
 .signal-card {
-  display: grid;
-  gap: 0.45rem;
   padding: 1.1rem 1.15rem;
   border-radius: 22px;
-  border: 1px solid var(--display-color-border);
   background: color-mix(
     in srgb,
     var(--display-color-surface) 80%,
@@ -266,20 +205,19 @@
   box-shadow: var(--display-shadow-card);
 }
 
-.signal-label {
+.signal-card .display-stat-label {
   color: var(--display-color-text-muted);
   font-size: 0.88rem;
   letter-spacing: 0.04em;
   text-transform: uppercase;
 }
 
-.signal-value {
+.signal-card .display-stat-value {
   font-size: clamp(1.5rem, 2vw, 2rem);
   letter-spacing: -0.04em;
 }
 
-.signal-description {
-  margin: 0;
+.signal-card .display-stat-description {
   line-height: 1.6;
   font-size: 0.95rem;
 }

--- a/apps/web/components/published-resume-shell.tsx
+++ b/apps/web/components/published-resume-shell.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { DisplayStatCard } from '@my-resume/ui/display';
 import { useThemeMode } from '@my-resume/ui/theme';
 import { useState } from 'react';
 
@@ -78,11 +79,13 @@ export function PublishedResumeShell({
         </div>
         <div className="signal-grid">
           {signalCards.map((card) => (
-            <article className="signal-card" key={card.label}>
-              <span className="signal-label">{card.label}</span>
-              <strong className="signal-value">{card.value}</strong>
-              <p className="signal-description">{card.description}</p>
-            </article>
+            <DisplayStatCard
+              className="signal-card"
+              description={card.description}
+              key={card.label}
+              label={card.label}
+              value={card.value}
+            />
           ))}
         </div>
       </section>

--- a/apps/web/components/published-resume/published-resume-empty-state.tsx
+++ b/apps/web/components/published-resume/published-resume-empty-state.tsx
@@ -1,3 +1,5 @@
+import { DisplaySectionIntro, DisplaySurfaceCard } from '@my-resume/ui/display';
+
 import { resumeLabels } from './published-resume-utils';
 
 export function PublishedResumeEmptyState() {
@@ -5,11 +7,14 @@ export function PublishedResumeEmptyState() {
 
   return (
     <main className="page-shell">
-      <section className="empty-card">
-        <p className="eyebrow">{labels.pageEyebrow}</p>
-        <h1>{labels.emptyTitle}</h1>
-        <p className="muted">{labels.emptyDescription}</p>
-      </section>
+      <DisplaySurfaceCard className="empty-card">
+        <DisplaySectionIntro
+          description={labels.emptyDescription}
+          eyebrow={labels.pageEyebrow}
+          title={labels.emptyTitle}
+          titleAs="h1"
+        />
+      </DisplaySurfaceCard>
     </main>
   );
 }

--- a/apps/web/components/published-resume/published-resume-experience-section.tsx
+++ b/apps/web/components/published-resume/published-resume-experience-section.tsx
@@ -1,3 +1,5 @@
+import { DisplayPill } from '@my-resume/ui/display';
+
 import {
   ResumeExperienceItem,
   ResumeLocale,
@@ -69,9 +71,9 @@ export function PublishedResumeExperienceSection({
             {experience.technologies.length > 0 ? (
               <div className="tag-grid">
                 {experience.technologies.map((tech) => (
-                  <span className="meta-pill" key={tech}>
+                  <DisplayPill key={tech}>
                     {tech}
-                  </span>
+                  </DisplayPill>
                 ))}
               </div>
             ) : null}

--- a/apps/web/components/published-resume/published-resume-hero.tsx
+++ b/apps/web/components/published-resume/published-resume-hero.tsx
@@ -1,4 +1,9 @@
 import { buildPublishedResumeExportUrl } from '@my-resume/api-client';
+import {
+  DisplayPill,
+  DisplaySectionIntro,
+  DisplaySurfaceCard,
+} from '@my-resume/ui/display';
 import type { ThemeMode } from '@my-resume/ui/theme';
 
 import { ResumeLocale, ResumePublishedSnapshot } from '../../lib/published-resume-types';
@@ -42,7 +47,7 @@ export function PublishedResumeHero({
   );
 
   return (
-    <section className="hero-card">
+    <DisplaySurfaceCard className="hero-card">
       <div className="hero-header">
         <div className="hero-copy">
           <p className="eyebrow">{labels.pageEyebrow}</p>
@@ -89,65 +94,67 @@ export function PublishedResumeHero({
           </div>
 
           <div className="hero-edition-card">
-            <p className="eyebrow">{labels.standardEditionEyebrow}</p>
-            <h2 className="hero-edition-title">{labels.standardEditionTitle}</h2>
-            <p className="section-subtitle">{labels.standardEditionDescription}</p>
+            <DisplaySectionIntro
+              description={labels.standardEditionDescription}
+              eyebrow={labels.standardEditionEyebrow}
+              title={labels.standardEditionTitle}
+              titleAs="h2"
+            />
             <div className="link-grid">
-              <a className="link-pill" href={markdownExportUrl}>
+              <DisplayPill href={markdownExportUrl}>
                 {labels.exportMarkdown}
-              </a>
-              <a className="link-pill" href={pdfExportUrl}>
+              </DisplayPill>
+              <DisplayPill href={pdfExportUrl}>
                 {labels.exportPdf}
-              </a>
+              </DisplayPill>
             </div>
           </div>
         </aside>
       </div>
 
       <div className="hero-meta">
-        <span className="meta-pill">{readLocalizedText(profile.location, locale)}</span>
-        <span className="meta-pill">{profile.email}</span>
-        <span className="meta-pill">{profile.phone}</span>
-        <span className="meta-pill">{profile.website}</span>
-        <span className="meta-pill">
+        <DisplayPill>{readLocalizedText(profile.location, locale)}</DisplayPill>
+        <DisplayPill>{profile.email}</DisplayPill>
+        <DisplayPill>{profile.phone}</DisplayPill>
+        <DisplayPill>{profile.website}</DisplayPill>
+        <DisplayPill>
           {labels.publishedAt}{' '}
           <span className="meta-text">
             {formatPublishedAt(publishedResume.publishedAt, locale)}
           </span>
-        </span>
+        </DisplayPill>
       </div>
 
       {profile.links.length > 0 ? (
         <div className="link-grid">
           {profile.links.map((link) => (
-            <a
-              className="link-pill"
+            <DisplayPill
+              external
               href={link.url}
               key={link.url}
-              rel="noreferrer"
-              target="_blank"
             >
               {readLocalizedText(link.label, locale)}
-            </a>
+            </DisplayPill>
           ))}
         </div>
       ) : null}
 
       {localizedInterests.length > 0 ? (
         <div className="hero-block">
-          <div className="section-header compact">
-            <p className="eyebrow">{labels.interestsEyebrow}</p>
-            <h2 className="section-title">{labels.interestsTitle}</h2>
-          </div>
+          <DisplaySectionIntro
+            compact
+            eyebrow={labels.interestsEyebrow}
+            title={labels.interestsTitle}
+          />
           <div className="tag-grid">
             {localizedInterests.map((interest) => (
-              <span className="meta-pill" key={interest}>
+              <DisplayPill key={interest}>
                 {interest}
-              </span>
+              </DisplayPill>
             ))}
           </div>
         </div>
       ) : null}
-    </section>
+    </DisplaySurfaceCard>
   );
 }

--- a/apps/web/components/published-resume/published-resume-projects-section.tsx
+++ b/apps/web/components/published-resume/published-resume-projects-section.tsx
@@ -1,3 +1,5 @@
+import { DisplayPill } from '@my-resume/ui/display';
+
 import {
   ResumeLocale,
   ResumeProjectItem,
@@ -56,9 +58,9 @@ export function PublishedResumeProjectsSection({
             {project.technologies.length > 0 ? (
               <div className="tag-grid">
                 {project.technologies.map((tech) => (
-                  <span className="meta-pill" key={tech}>
+                  <DisplayPill key={tech}>
                     {tech}
-                  </span>
+                  </DisplayPill>
                 ))}
               </div>
             ) : null}
@@ -66,15 +68,13 @@ export function PublishedResumeProjectsSection({
             {project.links.length > 0 ? (
               <div className="link-grid">
                 {project.links.map((link) => (
-                  <a
-                    className="link-pill"
+                  <DisplayPill
+                    external
                     href={link.url}
                     key={link.url}
-                    rel="noreferrer"
-                    target="_blank"
                   >
                     {readLocalizedText(link.label, locale)}
-                  </a>
+                  </DisplayPill>
                 ))}
               </div>
             ) : null}

--- a/apps/web/components/published-resume/published-resume-section-card.tsx
+++ b/apps/web/components/published-resume/published-resume-section-card.tsx
@@ -1,3 +1,4 @@
+import { DisplaySectionIntro, DisplaySurfaceCard } from '@my-resume/ui/display';
 import { ReactNode } from 'react';
 
 interface PublishedResumeSectionCardProps {
@@ -14,13 +15,13 @@ export function PublishedResumeSectionCard({
   children,
 }: PublishedResumeSectionCardProps) {
   return (
-    <section className="section-card">
-      <div className="section-header">
-        <p className="eyebrow">{eyebrow}</p>
-        <h2 className="section-title">{title}</h2>
-        {description ? <p className="section-subtitle">{description}</p> : null}
-      </div>
+    <DisplaySurfaceCard className="section-card">
+      <DisplaySectionIntro
+        description={description}
+        eyebrow={eyebrow}
+        title={title}
+      />
       {children}
-    </section>
+    </DisplaySurfaceCard>
   );
 }

--- a/apps/web/components/published-resume/published-resume-skills-section.tsx
+++ b/apps/web/components/published-resume/published-resume-skills-section.tsx
@@ -1,3 +1,5 @@
+import { DisplayPill } from '@my-resume/ui/display';
+
 import {
   ResumeLocale,
   ResumeSkillGroup,
@@ -35,9 +37,9 @@ export function PublishedResumeSkillsSection({
             <h3 className="item-title">{readLocalizedText(group.name, locale)}</h3>
             <div className="tag-grid">
               {group.keywords.map((keyword) => (
-                <span className="meta-pill" key={`${group.name.en}-${keyword}`}>
+                <DisplayPill key={`${group.name.en}-${keyword}`}>
                   {keyword}
-                </span>
+                </DisplayPill>
               ))}
             </div>
           </article>

--- a/docs/30-开发日志/M9-issue-45-packages-ui-最小共享展示组件沉淀.md
+++ b/docs/30-开发日志/M9-issue-45-packages-ui-最小共享展示组件沉淀.md
@@ -1,0 +1,253 @@
+# M9 / issue-45 开发日志：packages/ui 最小共享展示组件沉淀
+
+- Issue：#79
+- 里程碑：M9 体验基线与主题边界：从可用到可继续设计
+- 分支：`fys-dev/feat-m9-issue-45-shared-display-primitives`
+- 日期：2026-03-26
+
+## 背景
+
+前面的几个 M9 任务已经把两端页面逐步拉出了“纯验证页”状态：
+
+- `issue-42` 建立了共享主题基线
+- `issue-43` 梳理了后台仪表盘壳
+- `issue-44` 升级了公开简历页的视觉基线
+
+但随着 `admin / web` 都开始承载更完整的展示结构，重复也开始出现：
+
+- 两端都有“表面卡片”容器
+- 两端都有“题眉 + 标题 + 说明”的标题块
+- 两端都有“标签 / 状态 / 指标卡”这类展示结构
+
+如果继续在各自页面里复制这些结构，后续再做样式升级、模板化或主题化时，会很难判断哪些应该共享、哪些应该继续留在业务层。
+
+## 本次目标
+
+- 在 `packages/ui` 沉淀最小共享展示原语
+- 优先解决 `web / admin` 都在重复的展示结构
+- 保持共享层轻量、通用、易教学
+- 让两端页面代码更聚焦于业务表达，而不是重复写壳结构
+
+## 非目标
+
+- 不做完整组件库
+- 不引入新的业务逻辑或数据请求抽象
+- 不把所有页面组件都搬进 `packages/ui`
+- 不改动 `apps/server` 接口和数据契约
+
+## TDD / 测试设计
+
+### 1. 先为共享展示原语补测试
+
+新增：
+
+- `packages/ui/src/display.spec.tsx`
+
+先验证以下最小能力：
+
+- `DisplaySurfaceCard` 能以不同语义元素渲染共享表面容器
+- `DisplaySectionIntro` 能输出题眉、标题和说明
+- `DisplayStatCard` 能输出标签、值和说明
+- `DisplayPill` 能按文本或链接两种语义渲染
+
+这样做的目的，是先把共享层的最小行为钉住，再去迁移使用方。
+
+### 2. 使用侧回归测试继续保护
+
+继续执行现有回归：
+
+- `apps/web/components/published-resume-shell.spec.tsx`
+- `apps/admin/components/admin-dashboard-shell.spec.tsx`
+
+重点确认：
+
+- 公开页的语言切换、主题切换、导出链接和空状态不回退
+- 后台壳的未登录态、概览区、角色提示和占位面板不回退
+
+### 3. 工程级验证
+
+执行：
+
+- `pnpm --filter @my-resume/ui test`
+- `pnpm --filter @my-resume/ui typecheck`
+- `pnpm --filter @my-resume/web test`
+- `pnpm --filter @my-resume/web typecheck`
+- `pnpm --filter @my-resume/web build`
+- `pnpm --filter @my-resume/admin test`
+- `pnpm --filter @my-resume/admin typecheck`
+- `pnpm --filter @my-resume/admin build`
+
+## 实际改动
+
+### 1. 在 `packages/ui` 新增四个最小共享展示原语
+
+新增 / 更新：
+
+- `packages/ui/src/display.tsx`
+- `packages/ui/src/display.css`
+- `packages/ui/src/display.spec.tsx`
+
+本轮沉淀的共享原语是：
+
+- `DisplaySurfaceCard`
+- `DisplaySectionIntro`
+- `DisplayStatCard`
+- `DisplayPill`
+
+它们的定位不是“页面组件”，而是更基础的展示原语：
+
+- `DisplaySurfaceCard` 负责共享的表面容器
+- `DisplaySectionIntro` 负责标题块
+- `DisplayStatCard` 负责指标或状态卡
+- `DisplayPill` 负责标签和链接胶囊
+
+这样既能把重复结构收起来，又不会一下子把业务组件都拉进共享层。
+
+### 2. 把公开简历页接到共享展示层
+
+更新：
+
+- `apps/web/components/published-resume/published-resume-section-card.tsx`
+- `apps/web/components/published-resume/published-resume-empty-state.tsx`
+- `apps/web/components/published-resume/published-resume-hero.tsx`
+- `apps/web/components/published-resume/published-resume-experience-section.tsx`
+- `apps/web/components/published-resume/published-resume-projects-section.tsx`
+- `apps/web/components/published-resume/published-resume-skills-section.tsx`
+- `apps/web/components/published-resume-shell.tsx`
+- `apps/web/app/globals.css`
+
+这轮没有把公开页“组件库化”，而是只把明显重复的展示结构切换到共享原语：
+
+- section 卡片改为 `DisplaySurfaceCard + DisplaySectionIntro`
+- signal cards 改为 `DisplayStatCard`
+- meta / 技术栈 / 外部链接改为 `DisplayPill`
+- 空状态也改为共享卡片 + 标题块
+
+这样公开页仍然保留自己的页面语义和布局，但展示骨架开始共用。
+
+### 3. 把后台登录页与仪表盘壳接到共享展示层
+
+更新：
+
+- `apps/admin/components/admin-login-shell.tsx`
+- `apps/admin/components/admin-dashboard-shell.tsx`
+- `apps/admin/app/globals.css`
+
+后台侧主要切换了这些部分：
+
+- 登录说明卡和未登录态改为共享表面卡片 + 标题块
+- 仪表盘 hero 区块改为共享卡片 + 标题块
+- 概览卡、会话信息卡改为 `DisplayStatCard`
+- 顶部状态标签改为 `DisplayPill`
+
+这让后台壳组件可以更专注于“信息组织、角色边界和动作入口”，而不是重复维护底层展示骨架。
+
+### 4. 同时收掉一部分重复样式
+
+这轮不只是抽 React 组件，也顺手把一部分重复 CSS 收敛回共享层：
+
+- 表面容器边框、阴影、圆角回到 `packages/ui/src/display.css`
+- 指标卡的基础视觉回到共享层
+- 胶囊链接的基础 hover 效果回到共享层
+
+应用侧 CSS 只保留布局、间距和个别页面特有的视觉调整。
+
+## Review 记录
+
+### 是否符合当前 Issue 与里程碑目标
+
+符合。
+
+本次只做：
+
+- `packages/ui` 最小共享展示原语
+- `admin / web` 使用侧迁移
+- 共享层测试与工程校验
+
+没有越界去做：
+
+- 完整组件库
+- 业务状态管理抽象
+- 页面级模板系统
+- 新的服务端接口或 DTO
+
+### 是否可抽离组件、公共函数、skills 或其他复用能力
+
+本次已经完成当前最合适的一层抽离：展示原语层。
+
+刻意没有继续往上抽：
+
+- `PublishedResumeHero`
+- `RoleActionPanel`
+- `ResumeDraftEditorPanel`
+
+原因是这些组件仍然有强业务语义，过早放进共享层会让教程和维护都变得更难解释。
+
+### 本次最重要的边界判断
+
+这轮抽的是“原语”，不是“成品组件”。
+
+如果直接把公开页 hero、后台卡片区都整体搬进 `packages/ui`，短期看会更省事，但很快就会让共享层掺进：
+
+- 路由语义
+- 权限语义
+- 简历业务语义
+
+这和当前教程型仓库的节奏不匹配。
+
+## 自测结果
+
+已执行：
+
+- `pnpm --filter @my-resume/ui test`
+- `pnpm --filter @my-resume/ui typecheck`
+- `pnpm --filter @my-resume/web test`
+- `pnpm --filter @my-resume/web typecheck`
+- `pnpm --filter @my-resume/web build`
+- `pnpm --filter @my-resume/admin test`
+- `pnpm --filter @my-resume/admin typecheck`
+- `pnpm --filter @my-resume/admin build`
+
+结果：全部通过。
+
+补充说明：
+
+- `web / admin build` 过程中仍有现存 Tailwind `content` 配置告警，但不是本轮引入的问题，当前不影响构建结果。
+
+## 遇到的问题
+
+### 1. 共享层很容易抽过头
+
+问题：
+
+看到 `web / admin` 都有卡片和标题块后，很容易顺手把更高层的页面结构也一起抽进去。
+
+处理：
+
+- 只抽“展示原语”
+- 页面级组件继续留在应用层
+- 先解决重复结构，不抢跑模板系统
+
+### 2. 测试通过不代表 TypeScript 测试类型也完整
+
+问题：
+
+`packages/ui` 新增 Testing Library 测试后，Vitest 能跑通，但 `tsc` 一开始还不认识 jest-dom matcher。
+
+处理：
+
+- 为 `packages/ui` 增加 `vitest.setup.ts`
+- 在 `tsconfig.json` 中补上 `vitest/globals` 与 `@testing-library/jest-dom` 类型声明
+
+## 可沉淀为教程/博客的点
+
+- 什么时候该抽共享展示原语，什么时候不该直接上组件库
+- 为什么共享层更适合先抽 `Surface / Intro / Stat / Pill` 这类基础结构
+- 如何让共享样式和页面样式各司其职，而不是互相覆盖
+- 如何用 TDD 验证“共享层抽象”而不是只验证页面最终长相
+
+## 后续待办
+
+- 继续推进 `M9 / issue-46`：M9 教程大纲与里程碑收束
+- 后续如进入模板化阶段，再判断哪些展示原语需要继续往上组合
+- 如果后面 `admin / web` 出现新的稳定重复结构，再新增下一层共享组件

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "exports": {
     ".": "./src/theme.tsx",
-    "./theme": "./src/theme.tsx"
+    "./theme": "./src/theme.tsx",
+    "./display": "./src/display.tsx"
   },
   "scripts": {
     "test": "vitest run",
@@ -16,6 +17,8 @@
     "react-dom": "^19.1.1"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.8.0",
+    "@testing-library/react": "^16.3.0",
     "@types/react": "^19.1.9",
     "@types/react-dom": "^19.1.7",
     "jsdom": "^26.1.0",

--- a/packages/ui/src/display.css
+++ b/packages/ui/src/display.css
@@ -109,10 +109,81 @@ select {
   box-shadow: var(--display-shadow-card);
 }
 
+.display-section-intro {
+  display: grid;
+  gap: 0.42rem;
+}
+
+.display-section-intro.is-compact {
+  gap: 0.2rem;
+}
+
+.display-section-title {
+  margin: 0;
+  font-size: 1.28rem;
+}
+
+.display-section-description {
+  margin: 0;
+  color: var(--display-color-text-muted);
+  line-height: 1.7;
+}
+
 .display-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  min-height: 42px;
+  padding: 0.68rem 0.95rem;
   border-radius: var(--display-radius-pill);
   background: var(--display-color-surface-muted);
   border: 1px solid var(--display-color-border);
+}
+
+.display-pill-link {
+  text-decoration: none;
+  transition:
+    transform 160ms ease,
+    border-color 160ms ease,
+    background 160ms ease;
+}
+
+.display-pill-link:hover {
+  transform: translateY(-1px);
+  border-color: color-mix(
+    in srgb,
+    var(--display-color-accent) 48%,
+    var(--display-color-border)
+  );
+  background: color-mix(
+    in srgb,
+    var(--display-color-accent-soft) 48%,
+    var(--display-color-surface-muted)
+  );
+}
+
+.display-stat-card {
+  display: grid;
+  gap: 0.45rem;
+  padding: 1rem;
+  border-radius: 18px;
+  background: var(--display-color-surface-muted);
+  border: 1px solid var(--display-color-border);
+}
+
+.display-stat-label {
+  color: var(--display-color-text-muted);
+  font-size: 0.9rem;
+}
+
+.display-stat-value {
+  line-height: 1.1;
+}
+
+.display-stat-description {
+  margin: 0;
+  color: var(--display-color-text-muted);
+  line-height: 1.6;
 }
 
 .toolbar {

--- a/packages/ui/src/display.spec.tsx
+++ b/packages/ui/src/display.spec.tsx
@@ -1,0 +1,73 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import {
+  DisplayPill,
+  DisplaySectionIntro,
+  DisplayStatCard,
+  DisplaySurfaceCard,
+} from './display';
+
+describe('display primitives', () => {
+  it('should render surface card with semantic element override', () => {
+    render(
+      <DisplaySurfaceCard as="article">
+        <p>共享容器内容</p>
+      </DisplaySurfaceCard>,
+    );
+
+    const card = screen.getByRole('article');
+
+    expect(card).toHaveClass('display-surface-card');
+    expect(screen.getByText('共享容器内容')).toBeInTheDocument();
+  });
+
+  it('should render section intro with eyebrow, title and description', () => {
+    render(
+      <DisplaySectionIntro
+        compact
+        description="帮助两端共享标题块结构。"
+        eyebrow="共享展示"
+        title="Section Intro"
+      />,
+    );
+
+    expect(screen.getByText('共享展示')).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: 'Section Intro', level: 2 }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('帮助两端共享标题块结构。')).toBeInTheDocument();
+  });
+
+  it('should render stat card with label, value and description', () => {
+    render(
+      <DisplayStatCard
+        description="当前统计项说明"
+        label="当前状态"
+        value="READY"
+      />,
+    );
+
+    expect(screen.getByText('当前状态')).toBeInTheDocument();
+    expect(screen.getByText('READY')).toBeInTheDocument();
+    expect(screen.getByText('当前统计项说明')).toBeInTheDocument();
+  });
+
+  it('should render pill as text or link based on props', () => {
+    const { rerender } = render(<DisplayPill>只读标签</DisplayPill>);
+
+    expect(screen.getByText('只读标签').tagName).toBe('SPAN');
+
+    rerender(
+      <DisplayPill external href="https://example.com">
+        外部链接
+      </DisplayPill>,
+    );
+
+    const link = screen.getByRole('link', { name: '外部链接' });
+
+    expect(link).toHaveAttribute('href', 'https://example.com');
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noreferrer');
+  });
+});

--- a/packages/ui/src/display.tsx
+++ b/packages/ui/src/display.tsx
@@ -1,0 +1,156 @@
+import {
+  createElement,
+  type AnchorHTMLAttributes,
+  type ComponentPropsWithoutRef,
+  type ElementType,
+  type HTMLAttributes,
+  type ReactNode,
+} from 'react';
+
+function joinClassNames(
+  ...classNames: Array<string | false | null | undefined>
+): string {
+  return classNames.filter(Boolean).join(' ');
+}
+
+type DisplaySurfaceCardProps<T extends ElementType = 'section'> = {
+  as?: T;
+  children: ReactNode;
+  className?: string;
+} & Omit<ComponentPropsWithoutRef<T>, 'as' | 'children' | 'className'>;
+
+export function DisplaySurfaceCard<T extends ElementType = 'section'>({
+  as,
+  children,
+  className,
+  ...restProps
+}: DisplaySurfaceCardProps<T>) {
+  const Component = (as ?? 'section') as ElementType;
+
+  return createElement(
+    Component,
+    {
+      className: joinClassNames('display-surface-card', className),
+      ...restProps,
+    },
+    children,
+  );
+}
+
+interface DisplaySectionIntroProps<T extends ElementType = 'h2'> {
+  compact?: boolean;
+  description?: ReactNode;
+  eyebrow?: ReactNode;
+  title: ReactNode;
+  titleAs?: T;
+  className?: string;
+}
+
+export function DisplaySectionIntro<T extends ElementType = 'h2'>({
+  compact = false,
+  description,
+  eyebrow,
+  title,
+  titleAs,
+  className,
+}: DisplaySectionIntroProps<T>) {
+  const TitleComponent = (titleAs ?? 'h2') as ElementType;
+
+  return (
+    <div
+      className={joinClassNames(
+        'display-section-intro',
+        compact && 'is-compact',
+        className,
+      )}
+    >
+      {eyebrow ? <p className="eyebrow">{eyebrow}</p> : null}
+      {createElement(TitleComponent, { className: 'display-section-title' }, title)}
+      {description ? (
+        <p className="display-section-description">{description}</p>
+      ) : null}
+    </div>
+  );
+}
+
+type DisplayStatCardProps<T extends ElementType = 'article'> = {
+  as?: T;
+  className?: string;
+  description?: ReactNode;
+  label: ReactNode;
+  value: ReactNode;
+} & Omit<ComponentPropsWithoutRef<T>, 'as' | 'className' | 'children'>;
+
+export function DisplayStatCard<T extends ElementType = 'article'>({
+  as,
+  className,
+  description,
+  label,
+  value,
+  ...restProps
+}: DisplayStatCardProps<T>) {
+  const Component = (as ?? 'article') as ElementType;
+
+  return createElement(
+    Component,
+    {
+      className: joinClassNames('display-stat-card', className),
+      ...restProps,
+    },
+    <>
+      <span className="display-stat-label">{label}</span>
+      <strong className="display-stat-value">{value}</strong>
+      {description ? (
+        <p className="display-stat-description">{description}</p>
+      ) : null}
+    </>,
+  );
+}
+
+type DisplayPillBaseProps = {
+  children: ReactNode;
+  className?: string;
+};
+
+type DisplayPillLinkProps = DisplayPillBaseProps &
+  AnchorHTMLAttributes<HTMLAnchorElement> & {
+    external?: boolean;
+    href: string;
+  };
+
+type DisplayPillTextProps = DisplayPillBaseProps &
+  HTMLAttributes<HTMLSpanElement> & {
+    external?: never;
+    href?: undefined;
+  };
+
+export function DisplayPill(props: DisplayPillLinkProps | DisplayPillTextProps) {
+  const className = joinClassNames(
+    'display-pill',
+    'href' in props && props.href ? 'display-pill-link' : null,
+    props.className,
+  );
+
+  if ('href' in props && props.href) {
+    const { children, className: _className, external, rel, ...restProps } = props;
+
+    return (
+      <a
+        className={className}
+        rel={external ? rel ?? 'noreferrer' : rel}
+        target={external ? '_blank' : undefined}
+        {...restProps}
+      >
+        {children}
+      </a>
+    );
+  }
+
+  const { children, className: _className, ...restProps } = props;
+
+  return (
+    <span className={className} {...restProps}>
+      {children}
+    </span>
+  );
+}

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "jsx": "react-jsx",
     "lib": ["dom", "es2022"],
-    "noEmit": true
+    "noEmit": true,
+    "types": ["vitest/globals", "@testing-library/jest-dom"]
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"]
 }

--- a/packages/ui/vitest.config.ts
+++ b/packages/ui/vitest.config.ts
@@ -6,5 +6,7 @@ export default defineConfig({
   },
   test: {
     environment: 'jsdom',
+    globals: true,
+    setupFiles: ['./vitest.setup.ts'],
   },
 });

--- a/packages/ui/vitest.setup.ts
+++ b/packages/ui/vitest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -316,6 +316,12 @@ importers:
         specifier: ^19.1.1
         version: 19.2.4(react@19.2.4)
     devDependencies:
+      '@testing-library/jest-dom':
+        specifier: ^6.8.0
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: ^16.3.0
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@types/react':
         specifier: ^19.1.9
         version: 19.2.14


### PR DESCRIPTION
## Summary
- add minimal shared display primitives to 
- migrate  and  shells to the shared display layer
- add tests and issue log for the shared UI extraction

## Testing
- pnpm --filter @my-resume/ui test
- pnpm --filter @my-resume/ui typecheck
- pnpm --filter @my-resume/web test
- pnpm --filter @my-resume/web typecheck
- pnpm --filter @my-resume/web build
- pnpm --filter @my-resume/admin test
- pnpm --filter @my-resume/admin typecheck
- pnpm --filter @my-resume/admin build