### PR TITLE
feat(m10): add ai workbench entry shell

### DIFF
--- a/apps/admin/app/dashboard/ai/page.tsx
+++ b/apps/admin/app/dashboard/ai/page.tsx
@@ -1,0 +1,5 @@
+import { AdminAiWorkbenchShell } from '../../../components/admin-ai-workbench-shell';
+
+export default function AdminAiWorkbenchPage() {
+  return <AdminAiWorkbenchShell />;
+}

--- a/apps/admin/app/globals.css
+++ b/apps/admin/app/globals.css
@@ -190,11 +190,45 @@ textarea {
   margin: 0;
 }
 
+.dashboard-entry-card {
+  display: grid;
+  gap: 1rem;
+  padding: 1.1rem 1.15rem;
+  border-radius: 22px;
+}
+
+.dashboard-entry-actions {
+  display: flex;
+  justify-content: flex-start;
+}
+
 .dashboard-main-grid {
   display: grid;
   grid-template-columns: minmax(0, 1.45fr) minmax(320px, 0.95fr);
   gap: 1.25rem;
   align-items: start;
+}
+
+.ai-workbench-grid {
+  grid-template-columns: minmax(0, 1.2fr) minmax(320px, 0.8fr);
+}
+
+.scenario-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.scenario-card {
+  display: grid;
+  gap: 0.75rem;
+  padding: 1rem;
+  border-radius: 20px;
+  background: color-mix(
+    in srgb,
+    var(--display-color-surface) 84%,
+    var(--display-color-surface-muted)
+  );
 }
 
 .dashboard-column {
@@ -230,6 +264,20 @@ textarea {
   border: 1px solid var(--display-color-border);
 }
 
+.secondary-link-button {
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 44px;
+  border-radius: var(--display-radius-control);
+  background: var(--display-color-surface-muted);
+  color: var(--display-color-text);
+  border: 1px solid var(--display-color-border);
+  padding: 0.85rem 1rem;
+  font-weight: 600;
+  text-decoration: none;
+}
+
 @media (max-width: 960px) {
   .page-shell {
     grid-template-columns: minmax(0, 1fr);
@@ -258,7 +306,8 @@ textarea {
   }
 
   .dashboard-main-grid,
-  .dashboard-overview-grid {
+  .dashboard-overview-grid,
+  .scenario-grid {
     grid-template-columns: 1fr;
   }
 

--- a/apps/admin/components/admin-ai-workbench-shell.spec.tsx
+++ b/apps/admin/components/admin-ai-workbench-shell.spec.tsx
@@ -1,0 +1,123 @@
+'use client';
+
+import { render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  fetchCurrentUserMock,
+  fetchAiWorkbenchRuntimeMock,
+  readAccessTokenMock,
+  clearAccessTokenMock,
+} = vi.hoisted(() => ({
+  fetchCurrentUserMock: vi.fn(),
+  fetchAiWorkbenchRuntimeMock: vi.fn(),
+  readAccessTokenMock: vi.fn(),
+  clearAccessTokenMock: vi.fn(),
+}));
+
+vi.mock('../lib/auth-api', () => ({
+  fetchCurrentUser: fetchCurrentUserMock,
+}));
+
+vi.mock('../lib/ai-workbench-api', () => ({
+  fetchAiWorkbenchRuntime: fetchAiWorkbenchRuntimeMock,
+}));
+
+vi.mock('../lib/session-storage', () => ({
+  clearAccessToken: clearAccessTokenMock,
+  readAccessToken: readAccessTokenMock,
+}));
+
+vi.mock('./theme-mode-toggle', () => ({
+  ThemeModeToggle: () => <div>主题切换占位</div>,
+}));
+
+import { AdminAiWorkbenchShell } from './admin-ai-workbench-shell';
+
+const runtimeSummary = {
+  provider: 'qiniu',
+  model: 'deepseek-v3',
+  mode: 'live',
+  supportedScenarios: ['jd-match', 'resume-review', 'offer-compare'] as const,
+};
+
+const adminUser = {
+  id: 'admin-demo-user',
+  username: 'admin',
+  role: 'admin' as const,
+  isActive: true,
+  capabilities: {
+    canEditResume: true,
+    canPublishResume: true,
+    canTriggerAiAnalysis: true,
+  },
+};
+
+const viewerUser = {
+  id: 'viewer-demo-user',
+  username: 'viewer',
+  role: 'viewer' as const,
+  isActive: true,
+  capabilities: {
+    canEditResume: false,
+    canPublishResume: false,
+    canTriggerAiAnalysis: false,
+  },
+};
+
+describe('AdminAiWorkbenchShell', () => {
+  beforeEach(() => {
+    fetchCurrentUserMock.mockReset();
+    fetchAiWorkbenchRuntimeMock.mockReset();
+    readAccessTokenMock.mockReset();
+    clearAccessTokenMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should show unauthorized state when access token is missing', () => {
+    readAccessTokenMock.mockReturnValue(null);
+
+    render(<AdminAiWorkbenchShell />);
+
+    expect(screen.getByRole('heading', { name: '请先登录后台' })).toBeInTheDocument();
+    expect(
+      screen.getByText('AI 工作台属于受保护页面，需要先获取 JWT。'),
+    ).toBeInTheDocument();
+  });
+
+  it('should render runtime summary and scenario cards for admin', async () => {
+    readAccessTokenMock.mockReturnValue('admin-token');
+    fetchCurrentUserMock.mockResolvedValue(adminUser);
+    fetchAiWorkbenchRuntimeMock.mockResolvedValue(runtimeSummary);
+
+    render(<AdminAiWorkbenchShell />);
+
+    expect(await screen.findByRole('heading', { name: 'AI 工作台' })).toBeInTheDocument();
+    expect(screen.getByText('当前 Provider：qiniu')).toBeInTheDocument();
+    expect(screen.getByText('当前模型：deepseek-v3')).toBeInTheDocument();
+    expect(screen.getByText('运行模式：live')).toBeInTheDocument();
+    expect(screen.getByText('主题切换占位')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'JD 匹配分析' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: '简历优化建议' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Offer 对比建议' })).toBeInTheDocument();
+    expect(
+      screen.getByText('当前账号可继续接入上传、真实分析和结果阅读。'),
+    ).toBeInTheDocument();
+  });
+
+  it('should render viewer-specific guidance for read-only AI experience', async () => {
+    readAccessTokenMock.mockReturnValue('viewer-token');
+    fetchCurrentUserMock.mockResolvedValue(viewerUser);
+    fetchAiWorkbenchRuntimeMock.mockResolvedValue(runtimeSummary);
+
+    render(<AdminAiWorkbenchShell />);
+
+    expect(await screen.findByText('当前账号：viewer')).toBeInTheDocument();
+    expect(
+      screen.getByText('viewer 当前只允许查看缓存结果与预设体验，不能上传文件或触发真实分析。'),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/admin/components/admin-ai-workbench-shell.tsx
+++ b/apps/admin/components/admin-ai-workbench-shell.tsx
@@ -1,0 +1,208 @@
+'use client';
+
+import {
+  DisplayPill,
+  DisplaySectionIntro,
+  DisplayStatCard,
+  DisplaySurfaceCard,
+} from '@my-resume/ui/display';
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+
+import {
+  fetchCurrentUser,
+} from '../lib/auth-api';
+import { fetchAiWorkbenchRuntime } from '../lib/ai-workbench-api';
+import { AiWorkbenchRuntimeSummary } from '../lib/ai-workbench-types';
+import { AuthUserView } from '../lib/auth-types';
+import { DEFAULT_API_BASE_URL } from '../lib/env';
+import {
+  clearAccessToken,
+  readAccessToken,
+} from '../lib/session-storage';
+import { ThemeModeToggle } from './theme-mode-toggle';
+
+const scenarioCards = {
+  'jd-match': {
+    title: 'JD 匹配分析',
+    description: '后续用于粘贴 JD 或解析后的文本，生成匹配度与补强建议。',
+  },
+  'resume-review': {
+    title: '简历优化建议',
+    description: '后续用于基于当前标准简历内容，输出更聚焦的优化方向。',
+  },
+  'offer-compare': {
+    title: 'Offer 对比建议',
+    description: '后续用于对比多个 offer 的岗位信息、成长空间与取舍理由。',
+  },
+} as const;
+
+export function AdminAiWorkbenchShell() {
+  const [status, setStatus] = useState<'loading' | 'ready' | 'unauthorized'>(
+    'loading',
+  );
+  const [currentUser, setCurrentUser] = useState<AuthUserView | null>(null);
+  const [runtimeSummary, setRuntimeSummary] =
+    useState<AiWorkbenchRuntimeSummary | null>(null);
+
+  useEffect(() => {
+    const accessToken = readAccessToken();
+
+    if (!accessToken) {
+      setStatus('unauthorized');
+      return;
+    }
+
+    Promise.all([
+      fetchCurrentUser({
+        apiBaseUrl: DEFAULT_API_BASE_URL,
+        accessToken,
+      }),
+      fetchAiWorkbenchRuntime({
+        apiBaseUrl: DEFAULT_API_BASE_URL,
+        accessToken,
+      }),
+    ])
+      .then(([user, runtime]) => {
+        setCurrentUser(user);
+        setRuntimeSummary(runtime);
+        setStatus('ready');
+      })
+      .catch(() => {
+        clearAccessToken();
+        setCurrentUser(null);
+        setRuntimeSummary(null);
+        setStatus('unauthorized');
+      });
+  }, []);
+
+  if (status === 'loading') {
+    return (
+      <main className="page-shell single-card">
+        <DisplaySurfaceCard className="card">正在加载 AI 工作台...</DisplaySurfaceCard>
+      </main>
+    );
+  }
+
+  if (status === 'unauthorized' || !currentUser || !runtimeSummary) {
+    return (
+      <main className="page-shell single-card">
+        <DisplaySurfaceCard className="card stack">
+          <DisplaySectionIntro
+            description="AI 工作台属于受保护页面，需要先获取 JWT。"
+            eyebrow="未登录"
+            title="请先登录后台"
+            titleAs="h1"
+          />
+          <Link className="link-button" href="/">
+            返回登录页
+          </Link>
+        </DisplaySurfaceCard>
+      </main>
+    );
+  }
+
+  const isAdmin = Boolean(currentUser.capabilities.canTriggerAiAnalysis);
+  const roleMessage = isAdmin
+    ? '当前账号可继续接入上传、真实分析和结果阅读。'
+    : 'viewer 当前只允许查看缓存结果与预设体验，不能上传文件或触发真实分析。';
+
+  return (
+    <main className="dashboard-shell ai-workbench-shell">
+      <DisplaySurfaceCard className="card dashboard-hero">
+        <div className="page-header">
+          <DisplaySectionIntro
+            className="page-header-copy"
+            description="这一页先把 AI 能力入口、Provider 状态、分析场景和角色边界集中讲清楚，为后续上传、提取和真实分析闭环打底。"
+            eyebrow="受保护页面"
+            title="AI 工作台"
+            titleAs="h1"
+          />
+          <div className="dashboard-hero-actions">
+            <ThemeModeToggle />
+            <Link className="secondary-link-button" href="/dashboard">
+              返回控制台
+            </Link>
+          </div>
+        </div>
+
+        <div className="dashboard-badge-row">
+          <DisplayPill className="dashboard-badge">
+            当前账号：{currentUser.username}
+          </DisplayPill>
+          <DisplayPill className="dashboard-badge">
+            当前角色：{currentUser.role}
+          </DisplayPill>
+          <DisplayPill className="dashboard-badge">
+            当前 Provider：{runtimeSummary.provider}
+          </DisplayPill>
+          <DisplayPill className="dashboard-badge">
+            当前模型：{runtimeSummary.model}
+          </DisplayPill>
+          <DisplayPill className="dashboard-badge">
+            运行模式：{runtimeSummary.mode}
+          </DisplayPill>
+        </div>
+
+        <div className="dashboard-inline-note">{roleMessage}</div>
+      </DisplaySurfaceCard>
+
+      <section className="dashboard-main-grid ai-workbench-grid">
+        <div className="dashboard-column stack">
+          <DisplaySurfaceCard className="card stack">
+            <DisplaySectionIntro
+              description="当前先把 AI 能力按场景讲清楚，不急着把上传、分析和结果阅读一次性全部做完。"
+              eyebrow="场景规划"
+              title="支持的分析场景"
+            />
+            <div className="scenario-grid">
+              {runtimeSummary.supportedScenarios.map((scenario) => (
+                <DisplaySurfaceCard
+                  as="article"
+                  className="scenario-card"
+                  key={scenario}
+                >
+                  <DisplaySectionIntro
+                    compact
+                    description={scenarioCards[scenario].description}
+                    eyebrow="M10 入口"
+                    title={scenarioCards[scenario].title}
+                    titleAs="h2"
+                  />
+                </DisplaySurfaceCard>
+              ))}
+            </div>
+          </DisplaySurfaceCard>
+        </div>
+
+        <aside className="dashboard-column stack">
+          <DisplaySurfaceCard className="card stack">
+            <DisplaySectionIntro
+              description="先把当前运行时状态和角色限制写清楚，避免 AI 工作台后续越做越散。"
+              eyebrow="运行时摘要"
+              title="Provider 与边界"
+            />
+
+            <div className="info-grid">
+              <DisplayStatCard label="Provider" value={runtimeSummary.provider} />
+              <DisplayStatCard label="Model" value={runtimeSummary.model} />
+              <DisplayStatCard label="Mode" value={runtimeSummary.mode} />
+              <DisplayStatCard
+                label="分析场景"
+                value={String(runtimeSummary.supportedScenarios.length)}
+              />
+            </div>
+
+            <ul className="muted-list">
+              <li>业务逻辑继续统一由 `apps/server` 承载，不写 Next Route Handlers 业务接口。</li>
+              <li>本轮只搭 AI 工作台入口，不在这里直接展开上传和真实分析实现。</li>
+              <li>
+                后续 issue 会按“上传提取 {'->'} 真实分析 {'->'} viewer 边界”继续推进。
+              </li>
+            </ul>
+          </DisplaySurfaceCard>
+        </aside>
+      </section>
+    </main>
+  );
+}

--- a/apps/admin/components/admin-dashboard-shell.spec.tsx
+++ b/apps/admin/components/admin-dashboard-shell.spec.tsx
@@ -15,6 +15,7 @@ const {
 
 vi.mock('../lib/auth-api', () => ({
   fetchCurrentUser: fetchCurrentUserMock,
+  fetchAiWorkbenchRuntime: vi.fn(),
   postProtectedAction: vi.fn(),
   publishResume: vi.fn(),
 }));
@@ -107,6 +108,9 @@ describe('AdminDashboardShell', () => {
     expect(screen.getByText('导出入口占位')).toBeInTheDocument();
     expect(screen.getByText('当前账号：admin')).toBeInTheDocument();
     expect(screen.getByText('当前角色：admin')).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: '进入 AI 工作台' }),
+    ).toHaveAttribute('href', '/dashboard/ai');
   });
 
   it('should render viewer-specific guidance in the overview section', async () => {

--- a/apps/admin/components/admin-dashboard-shell.tsx
+++ b/apps/admin/components/admin-dashboard-shell.tsx
@@ -237,6 +237,20 @@ export function AdminDashboardShell() {
             />
           ))}
         </div>
+
+        <DisplaySurfaceCard className="dashboard-entry-card">
+          <DisplaySectionIntro
+            compact
+            description="把 AI 场景、Provider 状态和角色边界集中收进独立工作台，后续上传和分析都从这里继续扩展。"
+            eyebrow="M10 入口"
+            title="AI 工作台"
+          />
+          <div className="dashboard-entry-actions">
+            <Link className="link-button" href="/dashboard/ai">
+              进入 AI 工作台
+            </Link>
+          </div>
+        </DisplaySurfaceCard>
       </DisplaySurfaceCard>
 
       <section className="dashboard-main-grid">

--- a/apps/admin/lib/ai-workbench-api.spec.ts
+++ b/apps/admin/lib/ai-workbench-api.spec.ts
@@ -1,0 +1,41 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { fetchAiWorkbenchRuntime } from './ai-workbench-api';
+
+describe('ai workbench api client', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should fetch ai runtime summary with bearer token', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          provider: 'qiniu',
+          model: 'deepseek-v3',
+          mode: 'live',
+          supportedScenarios: ['jd-match', 'resume-review', 'offer-compare'],
+        }),
+      }),
+    );
+
+    const response = await fetchAiWorkbenchRuntime({
+      apiBaseUrl: 'http://localhost:5577',
+      accessToken: 'demo-token',
+    });
+
+    expect(fetch).toHaveBeenCalledWith(
+      'http://localhost:5577/ai/reports/runtime',
+      expect.objectContaining({
+        headers: {
+          Authorization: 'Bearer demo-token',
+        },
+      }),
+    );
+    expect(response.provider).toBe('qiniu');
+    expect(response.model).toBe('deepseek-v3');
+    expect(response.supportedScenarios).toContain('jd-match');
+  });
+});

--- a/apps/admin/lib/ai-workbench-api.ts
+++ b/apps/admin/lib/ai-workbench-api.ts
@@ -1,0 +1,26 @@
+import { AiWorkbenchRuntimeSummary } from './ai-workbench-types';
+
+interface FetchAiWorkbenchRuntimeInput {
+  apiBaseUrl: string;
+  accessToken: string;
+}
+
+function joinApiUrl(apiBaseUrl: string, pathname: string): string {
+  return `${apiBaseUrl.replace(/\/$/, '')}${pathname}`;
+}
+
+export async function fetchAiWorkbenchRuntime(
+  input: FetchAiWorkbenchRuntimeInput,
+): Promise<AiWorkbenchRuntimeSummary> {
+  const response = await fetch(joinApiUrl(input.apiBaseUrl, '/ai/reports/runtime'), {
+    headers: {
+      Authorization: `Bearer ${input.accessToken}`,
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error('AI 工作台运行时信息加载失败');
+  }
+
+  return (await response.json()) as AiWorkbenchRuntimeSummary;
+}

--- a/apps/admin/lib/ai-workbench-types.ts
+++ b/apps/admin/lib/ai-workbench-types.ts
@@ -1,0 +1,11 @@
+export type AiWorkbenchScenario =
+  | 'jd-match'
+  | 'resume-review'
+  | 'offer-compare';
+
+export interface AiWorkbenchRuntimeSummary {
+  provider: string;
+  model: string;
+  mode: string;
+  supportedScenarios: AiWorkbenchScenario[];
+}

--- a/apps/server/src/modules/ai/ai-report.controller.ts
+++ b/apps/server/src/modules/ai/ai-report.controller.ts
@@ -24,6 +24,12 @@ interface CacheReportBody {
   locale?: AnalysisLocale;
 }
 
+const SUPPORTED_SCENARIOS: AnalysisScenario[] = [
+  'jd-match',
+  'resume-review',
+  'offer-compare',
+];
+
 @Controller('ai/reports')
 @UseGuards(JwtAuthGuard)
 export class AiReportController {
@@ -38,6 +44,14 @@ export class AiReportController {
   listCachedReports() {
     return {
       reports: this.analysisReportCacheService.listReports(),
+    };
+  }
+
+  @Get('runtime')
+  getRuntimeSummary() {
+    return {
+      ...this.aiService.getProviderSummary(),
+      supportedScenarios: SUPPORTED_SCENARIOS,
     };
   }
 

--- a/apps/server/test/ai-report-role-access.e2e-spec.ts
+++ b/apps/server/test/ai-report-role-access.e2e-spec.ts
@@ -32,6 +32,14 @@ describe('AI report role access (e2e)', () => {
 
     const accessToken = loginResponse.body.accessToken as string;
 
+    const runtimeResponse = await request(app.getHttpServer())
+      .get('/ai/reports/runtime')
+      .set('Authorization', `Bearer ${accessToken}`)
+      .expect(200);
+
+    expect(runtimeResponse.body.supportedScenarios).toContain('jd-match');
+    expect(runtimeResponse.body.provider).toBeDefined();
+
     const listResponse = await request(app.getHttpServer())
       .get('/ai/reports/cache')
       .set('Authorization', `Bearer ${accessToken}`)
@@ -77,6 +85,17 @@ describe('AI report role access (e2e)', () => {
       .expect(200);
 
     const accessToken = loginResponse.body.accessToken as string;
+
+    const runtimeResponse = await request(app.getHttpServer())
+      .get('/ai/reports/runtime')
+      .set('Authorization', `Bearer ${accessToken}`)
+      .expect(200);
+
+    expect(runtimeResponse.body.supportedScenarios).toEqual([
+      'jd-match',
+      'resume-review',
+      'offer-compare',
+    ]);
 
     const response = await request(app.getHttpServer())
       .post('/ai/reports/analyze')

--- a/docs/30-开发日志/M10-issue-47-admin-AI-工作台最小入口.md
+++ b/docs/30-开发日志/M10-issue-47-admin-AI-工作台最小入口.md
@@ -1,0 +1,253 @@
+# M10 / issue-47 开发日志：admin AI 工作台最小入口
+
+- Issue：#88
+- 里程碑：M10 AI 工作台与真实分析：从基础接口到后台闭环
+- 分支：`fys-dev/feat-m10-issue-47-ai-workbench-entry`
+- 日期：2026-03-27
+
+## 背景
+
+当前仓库已经具备一部分 AI 后端基础：
+
+- `apps/server` 已有 Provider 适配器
+- 已有缓存分析报告接口
+- 已有文件提取服务
+- `admin / viewer` 的角色边界也已经成立
+
+但后台侧还没有一个清晰的 AI 工作台入口。继续把 AI 功能塞在仪表盘动作按钮里，会带来两个问题：
+
+- 教学上很难解释后续 AI 能力要从哪里继续长
+- 后续上传、提取、分析与结果阅读会继续散落在控制台首页
+
+所以这一轮的目标，不是接完整 AI 功能，而是先把“AI 工作台入口壳”立起来。
+
+## 本次目标
+
+- 在 `apps/admin` 建立独立的 AI 工作台页面与入口
+- 统一展示分析场景、Provider 状态与角色边界说明
+- 为后续上传、提取、真实分析和 viewer 体验留出稳定页面结构
+
+## 非目标
+
+- 不接入文件上传与文本提取实现
+- 不接入真实分析结果渲染
+- 不做复杂多页面后台
+- 不改动现有 AI 业务主逻辑
+
+## TDD / 测试设计
+
+### 1. 后台入口与工作台壳测试
+
+新增：
+
+- `apps/admin/components/admin-ai-workbench-shell.spec.tsx`
+
+验证：
+
+- 未登录时仍回到受保护页面提示
+- `admin` 能看到 AI 工作台、Provider / model / mode 与分析场景
+- `viewer` 能看到只读体验边界说明
+
+同时补充：
+
+- `apps/admin/components/admin-dashboard-shell.spec.tsx`
+
+验证仪表盘首页存在 “进入 AI 工作台” 入口。
+
+### 2. API 客户端测试
+
+新增：
+
+- `apps/admin/lib/ai-workbench-api.spec.ts`
+
+验证：
+
+- 后台会以 Bearer Token 读取新的 AI 运行时摘要接口
+
+### 3. 后端接口回归
+
+补充：
+
+- `apps/server/test/ai-report-role-access.e2e-spec.ts`
+
+验证：
+
+- `viewer / admin` 都可以读取运行时摘要
+- `viewer` 仍然不能触发真实分析
+
+### 4. 工程级验证
+
+执行：
+
+- `pnpm --filter @my-resume/admin test`
+- `pnpm --filter @my-resume/admin typecheck`
+- `pnpm --filter @my-resume/admin build`
+- `pnpm --filter @my-resume/server test:e2e -- --runInBand apps/server/test/ai-report-role-access.e2e-spec.ts`
+- `pnpm --filter @my-resume/server typecheck`
+- `pnpm --filter @my-resume/server build`
+
+## 实际改动
+
+### 1. 新增独立的后台 AI 工作台页面壳
+
+新增：
+
+- `apps/admin/app/dashboard/ai/page.tsx`
+- `apps/admin/components/admin-ai-workbench-shell.tsx`
+
+这一页当前只做最小入口壳，集中承接：
+
+- 当前 Provider / model / mode
+- 当前支持的分析场景
+- 当前账号的角色边界
+- 后续 issue 的推进顺序提示
+
+这样后面继续做上传、提取与真实分析时，就不需要继续把 AI 入口塞回控制台首页。
+
+### 2. 在仪表盘首页补清晰入口
+
+更新：
+
+- `apps/admin/components/admin-dashboard-shell.tsx`
+- `apps/admin/components/admin-dashboard-shell.spec.tsx`
+
+本轮在后台控制台首页补了一张 `AI 工作台` 入口卡，让读者和使用者在首页就能看出：
+
+- AI 能力已经有独立入口
+- 后续 M10 的工作会从这里继续扩展
+
+### 3. 把 AI 工作台 API 从鉴权 API 中拆开
+
+新增：
+
+- `apps/admin/lib/ai-workbench-api.ts`
+- `apps/admin/lib/ai-workbench-api.spec.ts`
+- `apps/admin/lib/ai-workbench-types.ts`
+
+这是本轮 review 后当场收住的一点：
+
+- `fetchAiWorkbenchRuntime` 不应继续塞进 `auth-api.ts`
+
+原因是后续 `issue-48 / 49` 还会继续新增：
+
+- 上传提取接口
+- 真实分析接口
+- 结果读取接口
+
+如果这些请求继续往 `auth-api.ts` 堆，会让文件职责越来越混乱。所以这轮提前把 AI 工作台请求层独立出来，为后续 M10 任务留出清晰边界。
+
+### 4. 后端补一个很薄的运行时摘要接口
+
+更新：
+
+- `apps/server/src/modules/ai/ai-report.controller.ts`
+- `apps/server/test/ai-report-role-access.e2e-spec.ts`
+
+新增接口：
+
+- `GET /ai/reports/runtime`
+
+这个接口只负责返回：
+
+- 当前 Provider 摘要
+- 当前 model
+- 当前 mode
+- 当前支持的分析场景
+
+它的定位不是新业务中心，而是 AI 工作台的页面级运行时摘要。
+
+## Review 记录
+
+### 是否符合当前 Issue 与里程碑目标
+
+符合。
+
+本次只做：
+
+- AI 工作台入口
+- 独立页面壳
+- 运行时摘要读取
+- 仪表盘入口补充
+
+没有越界去做：
+
+- 文件上传
+- 文本提取预览
+- 真实分析结果渲染
+- 队列和任务中心
+
+### 是否存在可抽离的组件、公共函数、skills 或其他复用能力
+
+有一处本轮已完成的抽离：
+
+- `apps/admin/lib/ai-workbench-api.ts`
+
+这一步让后续 AI 工作台相关接口不再继续挤进 `auth-api.ts`。
+
+UI 层这轮没有再继续抽共享组件，原因是当前新增的是后台专用页面壳，业务语义还比较强，暂时不适合提前放进 `packages/ui`。
+
+### 本次最重要的边界判断
+
+本次选择“独立 AI 工作台 + 很薄的运行时摘要接口”，而不是：
+
+- 继续把 AI 功能塞在仪表盘首页
+- 或者直接开始做上传 / 分析 / 结果全链路
+
+这样做的好处是：
+
+- 教程节奏更清楚
+- 后续 issue 边界更稳定
+- 页面和接口都为下一步留了自然延伸点
+
+## 自测结果
+
+已执行：
+
+- `pnpm --filter @my-resume/admin test`
+- `pnpm --filter @my-resume/admin typecheck`
+- `pnpm --filter @my-resume/admin build`
+- `pnpm --filter @my-resume/server test:e2e -- --runInBand apps/server/test/ai-report-role-access.e2e-spec.ts`
+- `pnpm --filter @my-resume/server typecheck`
+- `pnpm --filter @my-resume/server build`
+
+结果：全部通过。
+
+补充说明：
+
+- `admin` 构建产物中已出现 `/dashboard/ai` 路由，说明 AI 工作台入口已经真正进入应用结构，而不是只停留在组件层。
+
+## 遇到的问题
+
+### 1. JSX 中直接写 `->` 会触发解析问题
+
+问题：
+
+在 JSX 文本中直接写 `->`，会让 `>` 被解析为标签边界。
+
+处理：
+
+- 改成 `{'->'}` 的显式文本写法
+
+### 2. AI 工作台请求层最开始放进了 `auth-api.ts`
+
+问题：
+
+虽然一开始这样写更快，但不利于后续 M10 继续扩展。
+
+处理：
+
+- 立即拆成独立的 `ai-workbench-api`
+- 保持鉴权请求与 AI 页面请求边界清晰
+
+## 可沉淀为教程/博客的点
+
+- 为什么 AI 能力进入后台前，应该先有独立工作台入口
+- 如何用一个很薄的运行时摘要接口支撑页面级说明
+- 什么情况下应该及时把新接口从旧 API 文件里拆出来
+- 教学型项目里，为什么“先立入口壳”比“先堆功能”更重要
+
+## 后续待办
+
+- 继续推进 `M10 / issue-48`：文件上传与文本提取预览
+- 继续推进 `M10 / issue-49`：管理员真实分析闭环
+- 继续推进 `M10 / issue-50`：viewer 缓存体验与权限收束


### PR DESCRIPTION
## Summary
- add a dedicated admin AI workbench entry page at /dashboard/ai
- expose a thin runtime summary endpoint for provider and scenario metadata
- add tests, route coverage, and the issue development log for the new entry shell

## Testing
- pnpm --filter @my-resume/admin test
- pnpm --filter @my-resume/admin typecheck
- pnpm --filter @my-resume/admin build
- pnpm --filter @my-resume/server test:e2e -- --runInBand apps/server/test/ai-report-role-access.e2e-spec.ts
- pnpm --filter @my-resume/server typecheck
- pnpm --filter @my-resume/server build
