### PR TITLE
[Feat] M10 / issue-48 文件上传与文本提取预览

### DIFF
--- a/apps/admin/app/globals.css
+++ b/apps/admin/app/globals.css
@@ -231,6 +231,19 @@ textarea {
   );
 }
 
+.preview-stack {
+  display: grid;
+  gap: 1rem;
+}
+
+.preview-textarea {
+  min-height: 280px;
+  font-family:
+    'SFMono-Regular', ui-monospace, 'Cascadia Code', 'Source Code Pro',
+    Menlo, Consolas, monospace;
+  line-height: 1.6;
+}
+
 .dashboard-column {
   align-content: start;
 }

--- a/apps/admin/components/admin-ai-workbench-shell.spec.tsx
+++ b/apps/admin/components/admin-ai-workbench-shell.spec.tsx
@@ -32,6 +32,12 @@ vi.mock('./theme-mode-toggle', () => ({
   ThemeModeToggle: () => <div>主题切换占位</div>,
 }));
 
+vi.mock('./ai-file-extraction-panel', () => ({
+  AiFileExtractionPanel: ({ canUpload }: { canUpload: boolean }) => (
+    <div>{canUpload ? '文件提取面板占位' : '文件提取只读占位'}</div>
+  ),
+}));
+
 import { AdminAiWorkbenchShell } from './admin-ai-workbench-shell';
 
 const runtimeSummary = {
@@ -106,6 +112,7 @@ describe('AdminAiWorkbenchShell', () => {
     expect(
       screen.getByText('当前账号可继续接入上传、真实分析和结果阅读。'),
     ).toBeInTheDocument();
+    expect(screen.getByText('文件提取面板占位')).toBeInTheDocument();
   });
 
   it('should render viewer-specific guidance for read-only AI experience', async () => {
@@ -119,5 +126,6 @@ describe('AdminAiWorkbenchShell', () => {
     expect(
       screen.getByText('viewer 当前只允许查看缓存结果与预设体验，不能上传文件或触发真实分析。'),
     ).toBeInTheDocument();
+    expect(screen.getByText('文件提取只读占位')).toBeInTheDocument();
   });
 });

--- a/apps/admin/components/admin-ai-workbench-shell.tsx
+++ b/apps/admin/components/admin-ai-workbench-shell.tsx
@@ -21,6 +21,7 @@ import {
   readAccessToken,
 } from '../lib/session-storage';
 import { ThemeModeToggle } from './theme-mode-toggle';
+import { AiFileExtractionPanel } from './ai-file-extraction-panel';
 
 const scenarioCards = {
   'jd-match': {
@@ -149,6 +150,12 @@ export function AdminAiWorkbenchShell() {
 
       <section className="dashboard-main-grid ai-workbench-grid">
         <div className="dashboard-column stack">
+          <AiFileExtractionPanel
+            accessToken={readAccessToken() ?? ''}
+            apiBaseUrl={DEFAULT_API_BASE_URL}
+            canUpload={isAdmin}
+          />
+
           <DisplaySurfaceCard className="card stack">
             <DisplaySectionIntro
               description="当前先把 AI 能力按场景讲清楚，不急着把上传、分析和结果阅读一次性全部做完。"
@@ -195,7 +202,7 @@ export function AdminAiWorkbenchShell() {
 
             <ul className="muted-list">
               <li>业务逻辑继续统一由 `apps/server` 承载，不写 Next Route Handlers 业务接口。</li>
-              <li>本轮只搭 AI 工作台入口，不在这里直接展开上传和真实分析实现。</li>
+              <li>本轮先打通“上传 -&gt; 提取 -&gt; 预览”闭环，真实分析与附件沉淀继续后置。</li>
               <li>
                 后续 issue 会按“上传提取 {'->'} 真实分析 {'->'} viewer 边界”继续推进。
               </li>

--- a/apps/admin/components/ai-file-extraction-panel.spec.tsx
+++ b/apps/admin/components/ai-file-extraction-panel.spec.tsx
@@ -1,0 +1,96 @@
+'use client';
+
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { AiFileExtractionPanel } from './ai-file-extraction-panel';
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('AiFileExtractionPanel', () => {
+  it('should show read-only message when current role cannot upload', () => {
+    render(
+      <AiFileExtractionPanel
+        accessToken="demo-token"
+        apiBaseUrl="http://localhost:5577"
+        canUpload={false}
+      />,
+    );
+
+    expect(screen.getByText('当前角色只读')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'viewer 当前只保留缓存结果与预设体验，文件上传入口会在管理员链路中继续推进。',
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('should upload a file and render extracted preview for admin', async () => {
+    const user = userEvent.setup();
+    const extractFileText = vi.fn().mockResolvedValue({
+      fileName: 'resume.txt',
+      fileType: 'txt',
+      mimeType: 'text/plain',
+      text: 'resume text content',
+      charCount: 19,
+    });
+
+    render(
+      <AiFileExtractionPanel
+        accessToken="demo-token"
+        apiBaseUrl="http://localhost:5577"
+        canUpload
+        extractFileText={extractFileText}
+      />,
+    );
+
+    const file = new File(['resume text content'], 'resume.txt', {
+      type: 'text/plain',
+    });
+
+    await user.upload(screen.getByLabelText('选择文件'), file);
+    await user.click(screen.getByRole('button', { name: '开始提取文本' }));
+
+    await waitFor(() => {
+      expect(extractFileText).toHaveBeenCalledWith({
+        accessToken: 'demo-token',
+        apiBaseUrl: 'http://localhost:5577',
+        file,
+      });
+    });
+
+    expect(await screen.findByDisplayValue('resume text content')).toBeInTheDocument();
+    expect(screen.getByText('txt')).toBeInTheDocument();
+    expect(screen.getByText('19')).toBeInTheDocument();
+  });
+
+  it('should show extraction error feedback when upload fails', async () => {
+    const user = userEvent.setup();
+    const extractFileText = vi
+      .fn()
+      .mockRejectedValue(new Error('PDF 解析失败，请稍后重试'));
+
+    render(
+      <AiFileExtractionPanel
+        accessToken="demo-token"
+        apiBaseUrl="http://localhost:5577"
+        canUpload
+        extractFileText={extractFileText}
+      />,
+    );
+
+    const file = new File(['%PDF-1.7'], 'resume.pdf', {
+      type: 'application/pdf',
+    });
+
+    await user.upload(screen.getByLabelText('选择文件'), file);
+    await user.click(screen.getByRole('button', { name: '开始提取文本' }));
+
+    expect(
+      await screen.findByText('PDF 解析失败，请稍后重试'),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/admin/components/ai-file-extraction-panel.tsx
+++ b/apps/admin/components/ai-file-extraction-panel.tsx
@@ -1,0 +1,150 @@
+'use client';
+
+import { useState } from 'react';
+
+import { extractTextFromFile } from '../lib/ai-file-api';
+import { FileExtractionResult } from '../lib/ai-file-types';
+
+interface AiFileExtractionPanelProps {
+  apiBaseUrl: string;
+  accessToken: string;
+  canUpload: boolean;
+  extractFileText?: typeof extractTextFromFile;
+}
+
+function formatFileSize(size: number): string {
+  if (size < 1024) {
+    return `${size} B`;
+  }
+
+  return `${(size / 1024).toFixed(1)} KB`;
+}
+
+export function AiFileExtractionPanel({
+  apiBaseUrl,
+  accessToken,
+  canUpload,
+  extractFileText = extractTextFromFile,
+}: AiFileExtractionPanelProps) {
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const [result, setResult] = useState<FileExtractionResult | null>(null);
+  const [pending, setPending] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  if (!canUpload) {
+    return (
+      <section className="card stack">
+        <div>
+          <p className="eyebrow">文件提取</p>
+          <h2>当前角色只读</h2>
+          <p className="muted">只有管理员可上传文件并触发文本提取。</p>
+        </div>
+        <div className="readonly-box">
+          viewer 当前只保留缓存结果与预设体验，文件上传入口会在管理员链路中继续推进。
+        </div>
+      </section>
+    );
+  }
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    if (!selectedFile) {
+      return;
+    }
+
+    setPending(true);
+    setErrorMessage(null);
+
+    try {
+      const nextResult = await extractFileText({
+        apiBaseUrl,
+        accessToken,
+        file: selectedFile,
+      });
+
+      setResult(nextResult);
+    } catch (error) {
+      setResult(null);
+      setErrorMessage(
+        error instanceof Error ? error.message : '文件提取失败，请稍后重试',
+      );
+    } finally {
+      setPending(false);
+    }
+  }
+
+  return (
+    <section className="card stack">
+      <div>
+        <p className="eyebrow">文件提取</p>
+        <h2>上传并预览提取结果</h2>
+        <p className="muted">
+          当前先接通单文件上传与文本预览，为后续真实分析闭环提供稳定输入。
+        </p>
+      </div>
+
+      <form className="stack" onSubmit={(event) => void handleSubmit(event)}>
+        <label className="field">
+          <span>选择文件</span>
+          <input
+            accept=".txt,.md,.pdf,.docx"
+            onChange={(event) => {
+              const file = event.target.files?.[0] ?? null;
+
+              setSelectedFile(file);
+              setErrorMessage(null);
+              setResult(null);
+            }}
+            type="file"
+          />
+        </label>
+
+        <div className="dashboard-inline-note">
+          当前支持：TXT、Markdown、PDF、DOCX。结果仅做预览，不会自动保存成附件历史。
+        </div>
+
+        {selectedFile ? (
+          <div className="status-box">
+            <strong>待提取文件</strong>
+            <span>
+              {selectedFile.name} · {formatFileSize(selectedFile.size)}
+            </span>
+          </div>
+        ) : null}
+
+        {errorMessage ? <p className="error-text">{errorMessage}</p> : null}
+
+        <div className="dashboard-entry-actions">
+          <button disabled={!selectedFile || pending} type="submit">
+            {pending ? '正在提取文本...' : '开始提取文本'}
+          </button>
+        </div>
+      </form>
+
+      {result ? (
+        <div className="preview-stack">
+          <div className="info-grid">
+            <div className="status-box">
+              <strong>文件类型</strong>
+              <span>{result.fileType}</span>
+            </div>
+            <div className="status-box">
+              <strong>字符数</strong>
+              <span>{result.charCount}</span>
+            </div>
+          </div>
+
+          <label className="field">
+            <span>提取结果预览</span>
+            <textarea
+              className="preview-textarea"
+              readOnly
+              value={result.text}
+            />
+          </label>
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/admin/lib/ai-file-api.spec.ts
+++ b/apps/admin/lib/ai-file-api.spec.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { extractTextFromFile } from './ai-file-api';
+
+describe('ai file api client', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should upload a file to the NestJS extraction endpoint', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          fileName: 'resume.md',
+          fileType: 'md',
+          mimeType: 'text/markdown',
+          text: '# Resume',
+          charCount: 8,
+        }),
+      }),
+    );
+
+    const file = new File(['# Resume'], 'resume.md', {
+      type: 'text/markdown',
+    });
+
+    const result = await extractTextFromFile({
+      apiBaseUrl: 'http://localhost:5577',
+      accessToken: 'demo-token',
+      file,
+    });
+
+    expect(fetch).toHaveBeenCalledWith(
+      'http://localhost:5577/ai/extract-text',
+      expect.objectContaining({
+        method: 'POST',
+        headers: {
+          Authorization: 'Bearer demo-token',
+        },
+        body: expect.any(FormData),
+      }),
+    );
+    expect(result.fileType).toBe('md');
+    expect(result.text).toContain('Resume');
+  });
+
+  it('should surface server extraction errors', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        json: async () => ({
+          message: 'Unsupported file type: csv',
+        }),
+      }),
+    );
+
+    const file = new File(['a,b,c'], 'resume.csv', {
+      type: 'text/csv',
+    });
+
+    await expect(
+      extractTextFromFile({
+        apiBaseUrl: 'http://localhost:5577',
+        accessToken: 'demo-token',
+        file,
+      }),
+    ).rejects.toThrow('Unsupported file type: csv');
+  });
+});

--- a/apps/admin/lib/ai-file-api.ts
+++ b/apps/admin/lib/ai-file-api.ts
@@ -1,0 +1,40 @@
+import { FileExtractionResult } from './ai-file-types';
+
+interface ExtractTextFromFileInput {
+  apiBaseUrl: string;
+  accessToken: string;
+  file: File;
+}
+
+function joinApiUrl(apiBaseUrl: string, pathname: string): string {
+  return `${apiBaseUrl.replace(/\/$/, '')}${pathname}`;
+}
+
+export async function extractTextFromFile(
+  input: ExtractTextFromFileInput,
+): Promise<FileExtractionResult> {
+  const formData = new FormData();
+  formData.append('file', input.file);
+
+  const response = await fetch(joinApiUrl(input.apiBaseUrl, '/ai/extract-text'), {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${input.accessToken}`,
+    },
+    body: formData,
+  });
+
+  if (!response.ok) {
+    const payload = (await response.json().catch(() => null)) as
+      | { message?: string | string[] }
+      | null;
+
+    const message = Array.isArray(payload?.message)
+      ? payload.message[0]
+      : payload?.message;
+
+    throw new Error(message || '文件提取失败，请稍后重试');
+  }
+
+  return (await response.json()) as FileExtractionResult;
+}

--- a/apps/admin/lib/ai-file-types.ts
+++ b/apps/admin/lib/ai-file-types.ts
@@ -1,0 +1,9 @@
+export type ExtractedFileType = 'txt' | 'md' | 'pdf' | 'docx';
+
+export interface FileExtractionResult {
+  fileName: string;
+  fileType: ExtractedFileType;
+  mimeType: string;
+  text: string;
+  charCount: number;
+}

--- a/docs/30-开发日志/M10-issue-48-review-ready-前关键通路校验.md
+++ b/docs/30-开发日志/M10-issue-48-review-ready-前关键通路校验.md
@@ -1,0 +1,101 @@
+# M10 / issue-48 review-ready 前关键通路校验
+
+- Issue：`#87`
+- 里程碑：`M10 AI 工作台与真实分析：从基础接口到后台闭环`
+- 分支：`fys-dev/feat-m10-issue-48-file-extraction-preview`
+- 日期：`2026-03-27`
+
+## 本轮主承诺
+
+把 `apps/server` 已有的文件提取能力接到后台 AI 工作台，形成一条真实可走通的最小链路：
+
+- 管理员上传单个文件
+- 后台调用 NestJS `/ai/extract-text`
+- 页面预览提取结果或失败信息
+
+本轮不承诺：
+
+- 附件持久化
+- 多文件队列
+- 真实分析触发
+- viewer 真实上传权限收紧
+
+## 关键通路
+
+### 1. 上传到服务端提取通路
+
+要证明的事情：
+
+- 后台不是本地假解析
+- 上传真正走到 `apps/server`
+- 上传参数、鉴权头和文件体都通过统一客户端发送
+
+证据落点：
+
+- `apps/admin/lib/ai-file-api.ts`
+- `apps/admin/lib/ai-file-api.spec.ts`
+- `apps/server/test/ai-file-extraction.e2e-spec.ts`
+
+当前结论：
+
+- 已打通。前端通过 `FormData` 调用 `/ai/extract-text`
+- `admin` 侧客户端测试已验证请求结构
+- `server` 侧 E2E 已验证上传 `txt` 可提取、非法文件会被拒绝
+
+### 2. 后台预览与错误反馈通路
+
+要证明的事情：
+
+- 管理员可以选择受支持文件并发起提取
+- 成功后能看到提取结果预览
+- 服务端失败时能看到清晰错误，不会卡成静默失败
+
+证据落点：
+
+- `apps/admin/components/ai-file-extraction-panel.tsx`
+- `apps/admin/components/ai-file-extraction-panel.spec.tsx`
+- `apps/admin/components/admin-ai-workbench-shell.tsx`
+- `apps/admin/components/admin-ai-workbench-shell.spec.tsx`
+
+当前结论：
+
+- 已打通。管理端面板支持选择 `txt / md / pdf / docx`
+- 成功时展示文件类型、字符数、文本预览
+- 失败时展示服务端返回错误
+- 工作台壳已接入该面板，并按角色传入 `canUpload`
+
+### 3. 边界与连续性通路
+
+要证明的事情：
+
+- 本轮没有把真实分析、附件历史或双后端逻辑顺手混进来
+- 上传闭环接入后不会破坏现有 `admin` 构建和服务端回归
+
+证据落点：
+
+- `apps/admin/components/admin-ai-workbench-shell.tsx`
+- `pnpm --filter @my-resume/admin test`
+- `pnpm --filter @my-resume/admin build`
+- `pnpm --filter @my-resume/server typecheck`
+- `pnpm --filter @my-resume/server build`
+
+当前结论：
+
+- 已满足。页面文案明确写清当前只做到“上传 -> 提取 -> 预览”
+- 业务逻辑仍统一落在 `apps/server`
+- `admin / server` 相关测试、类型检查和构建均通过
+
+## 是否足以进入 review-ready
+
+可以进入。
+
+原因：
+
+- 本轮主承诺已经完成
+- 三条关键通路均有代码与验证证据对应
+- 没有提前把下一轮真实分析和附件沉淀混进当前 issue
+
+## 进入 review-ready 前仍需注意
+
+- `viewer` 当前只在前端层做只读提示，服务端更严格的角色限制继续放到后续 issue
+- 若下一轮开始接真实分析，需要优先复用本轮的提取结果输入，不要重新发明上传链路

--- a/docs/30-开发日志/M10-issue-48-文件上传与文本提取预览.md
+++ b/docs/30-开发日志/M10-issue-48-文件上传与文本提取预览.md
@@ -1,0 +1,237 @@
+# M10 / issue-48 开发日志：文件上传与文本提取预览
+
+- Issue：`#87`
+- 里程碑：`M10 AI 工作台与真实分析：从基础接口到后台闭环`
+- 分支：`fys-dev/feat-m10-issue-48-file-extraction-preview`
+- 日期：`2026-03-27`
+
+## 背景
+
+`apps/server` 早在 `M4 / issue-14` 就已经具备了 `txt / md / pdf / docx` 的最小文本提取能力，但后台 AI 工作台直到现在还停留在“运行时摘要 + 场景说明”的入口层。
+
+如果后台没有把上传和预览接出来，读者很难感知：
+
+- 服务端文件提取能力真的可用
+- 后续真实分析会以什么输入进入
+- 为什么“统一由 NestJS 提取文本”仍然重要
+
+所以这一轮只做一件小而关键的事：把“上传 -> 提取 -> 预览”闭环接到后台。
+
+## 本次目标
+
+- 在后台接入单文件上传
+- 调用 NestJS `/ai/extract-text`
+- 展示提取结果预览与基础错误提示
+- 保持当前实现只服务于 AI 工作台输入准备
+
+## 非目标
+
+- 不做附件历史或持久化
+- 不做多文件队列
+- 不接入真实分析触发
+- 不在本轮处理 viewer 的服务端真实上传限制
+
+## TDD / 测试设计
+
+### 1. 先补前端 API 客户端测试
+
+新增：
+
+- `apps/admin/lib/ai-file-api.spec.ts`
+
+先锁定：
+
+- 文件通过 `FormData` 发送到 `/ai/extract-text`
+- 鉴权头来自后台 JWT
+- 服务端错误会被前端正确抛出，而不是吞掉
+
+### 2. 再补上传预览面板交互测试
+
+新增：
+
+- `apps/admin/components/ai-file-extraction-panel.spec.tsx`
+
+先锁定：
+
+- `viewer` 只能看到只读说明
+- `admin` 上传文件后能展示提取预览
+- 服务端失败时会出现错误反馈
+
+### 3. 使用现有壳组件测试保护接入
+
+更新：
+
+- `apps/admin/components/admin-ai-workbench-shell.spec.tsx`
+
+重点确认：
+
+- AI 工作台壳已经接入文件提取面板
+- `admin / viewer` 仍能走到各自正确的角色分支
+
+### 4. 服务端回归
+
+复用：
+
+- `apps/server/test/ai-file-extraction.e2e-spec.ts`
+
+确认这次前端接入的不是一条“只在前端测试里成立”的假链路。
+
+## 实际改动
+
+### 1. 新增后台文件提取客户端
+
+新增：
+
+- `apps/admin/lib/ai-file-types.ts`
+- `apps/admin/lib/ai-file-api.ts`
+- `apps/admin/lib/ai-file-api.spec.ts`
+
+这层只负责两件事：
+
+- 定义前端侧使用的提取结果类型
+- 以最小客户端形式调用 NestJS `/ai/extract-text`
+
+这样做的好处是，AI 工作台后续不管接真实分析、缓存阅读还是别的入口，都可以继续复用同一条文件提取接入层，而不是把 `fetch` 细节散在组件里。
+
+### 2. 新增 AI 文件上传与预览面板
+
+新增：
+
+- `apps/admin/components/ai-file-extraction-panel.tsx`
+- `apps/admin/components/ai-file-extraction-panel.spec.tsx`
+
+当前面板能力保持在最小范围：
+
+- 仅支持单文件上传
+- 文件类型限制为 `txt / md / pdf / docx`
+- 成功时展示文件类型、字符数和提取文本预览
+- 失败时展示错误提示
+- `viewer` 只显示只读说明，不显示上传链路
+
+这里刻意没有做“下一步分析”按钮，因为那会把当前 issue 直接拉进真实分析编排。
+
+### 3. 接入 AI 工作台壳
+
+更新：
+
+- `apps/admin/components/admin-ai-workbench-shell.tsx`
+- `apps/admin/components/admin-ai-workbench-shell.spec.tsx`
+
+这一步把文件提取能力真正挂到后台工作台里，同时保留角色边界：
+
+- `admin` 可见上传面板
+- `viewer` 仅看到只读占位
+
+另外也顺手修正了工作台内的说明文案，避免页面还停留在“本轮只做入口壳”的旧描述。
+
+### 4. 补最小样式承载预览区域
+
+更新：
+
+- `apps/admin/app/globals.css`
+
+只增加当前 issue 真正需要的两类样式：
+
+- 预览区栈式布局
+- 文本预览框样式
+
+没有提前把 AI 工作台做成完整附件管理页。
+
+## Review 记录
+
+### 是否符合当前 Issue 与里程碑目标
+
+符合。
+
+本轮只完成：
+
+- 后台上传接入
+- 文本提取预览
+- 错误反馈
+- 壳组件接入与回归测试
+
+没有越界去做：
+
+- 真实分析触发
+- 附件持久化
+- 多文件处理
+- 新的服务端业务接口
+
+### 是否存在可抽离的组件、公共函数、skills 或其他复用能力
+
+本轮已经完成当前最合适的一层抽离：
+
+- `ai-file-api.ts` 负责文件提取请求
+- `AiFileExtractionPanel` 负责最小交互界面
+
+暂时不继续往上抽“分析流程编排组件”，因为真实分析、缓存命中、viewer 只读限制都还在后续 issue 中，过早抽大组件只会让边界变糊。
+
+### 本次最重要的边界判断
+
+“统一由 NestJS 做文件提取”依然必须坚持。
+
+原因不是只为了当前后台页面，而是为了后续所有入口都走同一条规则：
+
+- 文件格式支持统一
+- 错误提示统一
+- 后续移动端或其他前端也能复用
+- 不会因为 Next.js 页面层顺手写路由而走向双后端
+
+## 自测结果
+
+已执行：
+
+- `pnpm --filter @my-resume/admin test`
+- `pnpm --filter @my-resume/admin typecheck`
+- `pnpm --filter @my-resume/admin build`
+- `pnpm --filter @my-resume/server test:e2e -- test/ai-file-extraction.e2e-spec.ts`
+- `pnpm --filter @my-resume/server typecheck`
+- `pnpm --filter @my-resume/server build`
+
+结果：
+
+- `admin` 测试、类型检查、构建通过
+- `server` 文件提取 E2E、类型检查、构建通过
+
+补充说明：
+
+- `server test:e2e` 当前会顺带执行同配置下的其他 E2E 文件，这是现有 Vitest e2e 配置行为，本轮未改动该配置
+
+## 遇到的问题
+
+### 1. 错误态测试一开始写成了不支持文件类型
+
+问题：
+
+最初测试用了 `csv` 文件来模拟失败，但组件本身就通过 `accept` 限制了只允许 `txt / md / pdf / docx`，测试环境里文件不会真正进入提交链路。
+
+处理：
+
+- 改为上传受支持的 `pdf`
+- 由 mock 的服务端响应返回失败信息
+
+这样更贴近真实场景，也更能证明错误反馈链路是活的。
+
+### 2. 页面说明文案容易落后于代码状态
+
+问题：
+
+AI 工作台侧栏还保留着“本轮不展开上传实现”的旧文案，和当前完成状态不一致。
+
+处理：
+
+- 同步更新边界说明
+- 明确当前只做到“上传 -> 提取 -> 预览”
+
+## 可沉淀为教程 / 博客的点
+
+- 为什么后台接 AI 时，第一步不是“直接分析”，而是先打通统一输入链路
+- 为什么文件提取仍然要放在 NestJS，而不是顺手写在 Next.js 页面层
+- 如何用一个小 issue 把服务能力真正接到后台，而不一下子冲进完整 AI 编排
+- 前端测试里如何区分“非法输入被控件拦住”与“服务端处理失败”
+
+## 后续待办
+
+- 关闭 `issue-48`
+- 继续 `M10` 下一轮真实分析或结果阅读相关任务
+- 若后续进入 viewer 更严格边界控制，优先复用本轮上传与提取接口，不重复造入口


### PR DESCRIPTION
## 背景\n\n服务端已经具备 txt / md / pdf / docx 的最小文本提取能力，但后台 AI 工作台还没有把这条链路接出来。这一轮只补齐后台的上传 -> 提取 -> 预览闭环。\n\n## 本次改动\n\n- 新增 admin 文件提取客户端与类型定义\n- 新增 AI 文件上传与文本预览面板\n- 将文件提取面板接入 AI 工作台壳，并按角色控制只读提示\n- 补 review-ready 校验记录与开发日志\n\n## 非目标\n\n- 不做附件持久化\n- 不做多文件队列\n- 不接入真实分析触发\n- 不在本轮处理 viewer 的服务端真实上传限制\n\n## 测试\n\n- pnpm --filter @my-resume/admin test\n- pnpm --filter @my-resume/admin typecheck\n- pnpm --filter @my-resume/admin build\n- pnpm --filter @my-resume/server test:e2e -- test/ai-file-extraction.e2e-spec.ts\n- pnpm --filter @my-resume/server typecheck\n- pnpm --filter @my-resume/server build\n\n## 文档\n\n- docs/30-开发日志/M10-issue-48-review-ready-前关键通路校验.md\n- docs/30-开发日志/M10-issue-48-文件上传与文本提取预览.md\n\nCloses #87