### PR TITLE
[Feat] M10 / issue-49 管理员真实分析闭环

### DIFF
--- a/apps/admin/app/globals.css
+++ b/apps/admin/app/globals.css
@@ -23,6 +23,14 @@ input {
   background: var(--display-color-control-bg);
 }
 
+select {
+  width: 100%;
+  border: 1px solid var(--display-color-border);
+  border-radius: var(--display-radius-control);
+  padding: 0.85rem 0.9rem;
+  background: var(--display-color-control-bg);
+}
+
 textarea {
   width: 100%;
   border: 1px solid var(--display-color-border);
@@ -236,6 +244,26 @@ textarea {
   gap: 1rem;
 }
 
+.analysis-summary-card,
+.analysis-section-card {
+  display: grid;
+  gap: 0.85rem;
+  padding: 1rem;
+  border-radius: 20px;
+}
+
+.analysis-text-block {
+  white-space: pre-wrap;
+  line-height: 1.7;
+  color: var(--display-color-text);
+}
+
+.analysis-section-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+}
+
 .preview-textarea {
   min-height: 280px;
   font-family:
@@ -258,6 +286,14 @@ textarea {
     var(--display-color-surface-muted) 84%,
     transparent
   );
+}
+
+@media (max-width: 960px) {
+  .analysis-section-grid,
+  .dashboard-main-grid,
+  .scenario-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
 }
 
 .workflow-list {

--- a/apps/admin/components/admin-ai-workbench-shell.spec.tsx
+++ b/apps/admin/components/admin-ai-workbench-shell.spec.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const {
@@ -33,8 +34,54 @@ vi.mock('./theme-mode-toggle', () => ({
 }));
 
 vi.mock('./ai-file-extraction-panel', () => ({
-  AiFileExtractionPanel: ({ canUpload }: { canUpload: boolean }) => (
-    <div>{canUpload ? '文件提取面板占位' : '文件提取只读占位'}</div>
+  AiFileExtractionPanel: ({
+    canUpload,
+    onExtractedText,
+  }: {
+    canUpload: boolean;
+    onExtractedText?: (result: {
+      fileName: string;
+      fileType: 'txt';
+      mimeType: string;
+      text: string;
+      charCount: number;
+    }) => void;
+  }) =>
+    canUpload ? (
+      <div>
+        <span>文件提取面板占位</span>
+        <button
+          onClick={() =>
+            onExtractedText?.({
+              fileName: 'resume.txt',
+              fileType: 'txt',
+              mimeType: 'text/plain',
+              text: 'resume text content',
+              charCount: 19,
+            })
+          }
+          type="button"
+        >
+          模拟提取完成
+        </button>
+      </div>
+    ) : (
+      <div>文件提取只读占位</div>
+    ),
+}));
+
+vi.mock('./ai-analysis-panel', () => ({
+  AiAnalysisPanel: ({
+    canAnalyze,
+    content,
+  }: {
+    canAnalyze: boolean;
+    content: string;
+  }) => (
+    <div>
+      <span>{canAnalyze ? '真实分析面板占位' : '真实分析只读占位'}</span>
+      <span>{`当前分析内容：${content || '空'}`}</span>
+    </div>
   ),
 }));
 
@@ -95,6 +142,7 @@ describe('AdminAiWorkbenchShell', () => {
   });
 
   it('should render runtime summary and scenario cards for admin', async () => {
+    const user = userEvent.setup();
     readAccessTokenMock.mockReturnValue('admin-token');
     fetchCurrentUserMock.mockResolvedValue(adminUser);
     fetchAiWorkbenchRuntimeMock.mockResolvedValue(runtimeSummary);
@@ -113,6 +161,12 @@ describe('AdminAiWorkbenchShell', () => {
       screen.getByText('当前账号可继续接入上传、真实分析和结果阅读。'),
     ).toBeInTheDocument();
     expect(screen.getByText('文件提取面板占位')).toBeInTheDocument();
+    expect(screen.getByText('真实分析面板占位')).toBeInTheDocument();
+    expect(screen.getByText('当前分析内容：空')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: '模拟提取完成' }));
+
+    expect(screen.getByText('当前分析内容：resume text content')).toBeInTheDocument();
   });
 
   it('should render viewer-specific guidance for read-only AI experience', async () => {
@@ -127,5 +181,6 @@ describe('AdminAiWorkbenchShell', () => {
       screen.getByText('viewer 当前只允许查看缓存结果与预设体验，不能上传文件或触发真实分析。'),
     ).toBeInTheDocument();
     expect(screen.getByText('文件提取只读占位')).toBeInTheDocument();
+    expect(screen.getByText('真实分析只读占位')).toBeInTheDocument();
   });
 });

--- a/apps/admin/components/admin-ai-workbench-shell.tsx
+++ b/apps/admin/components/admin-ai-workbench-shell.tsx
@@ -20,7 +20,9 @@ import {
   clearAccessToken,
   readAccessToken,
 } from '../lib/session-storage';
+import { FileExtractionResult } from '../lib/ai-file-types';
 import { ThemeModeToggle } from './theme-mode-toggle';
+import { AiAnalysisPanel } from './ai-analysis-panel';
 import { AiFileExtractionPanel } from './ai-file-extraction-panel';
 
 const scenarioCards = {
@@ -45,6 +47,10 @@ export function AdminAiWorkbenchShell() {
   const [currentUser, setCurrentUser] = useState<AuthUserView | null>(null);
   const [runtimeSummary, setRuntimeSummary] =
     useState<AiWorkbenchRuntimeSummary | null>(null);
+  const [analysisContent, setAnalysisContent] = useState('');
+  const [analysisHelperMessage, setAnalysisHelperMessage] = useState<
+    string | null
+  >(null);
 
   useEffect(() => {
     const accessToken = readAccessToken();
@@ -76,6 +82,21 @@ export function AdminAiWorkbenchShell() {
         setStatus('unauthorized');
       });
   }, []);
+
+  function handleExtractedText(result: FileExtractionResult) {
+    setAnalysisContent(result.text);
+    setAnalysisHelperMessage(
+      `已将 ${result.fileName} 的提取结果同步到分析输入区，可直接继续编辑或触发分析。`,
+    );
+  }
+
+  function handleAnalysisContentChange(nextContent: string) {
+    setAnalysisContent(nextContent);
+
+    if (analysisHelperMessage) {
+      setAnalysisHelperMessage(null);
+    }
+  }
 
   if (status === 'loading') {
     return (
@@ -154,6 +175,17 @@ export function AdminAiWorkbenchShell() {
             accessToken={readAccessToken() ?? ''}
             apiBaseUrl={DEFAULT_API_BASE_URL}
             canUpload={isAdmin}
+            onExtractedText={handleExtractedText}
+          />
+
+          <AiAnalysisPanel
+            accessToken={readAccessToken() ?? ''}
+            apiBaseUrl={DEFAULT_API_BASE_URL}
+            canAnalyze={isAdmin}
+            content={analysisContent}
+            helperMessage={analysisHelperMessage}
+            onContentChange={handleAnalysisContentChange}
+            runtimeSummary={runtimeSummary}
           />
 
           <DisplaySurfaceCard className="card stack">
@@ -202,9 +234,9 @@ export function AdminAiWorkbenchShell() {
 
             <ul className="muted-list">
               <li>业务逻辑继续统一由 `apps/server` 承载，不写 Next Route Handlers 业务接口。</li>
-              <li>本轮先打通“上传 -&gt; 提取 -&gt; 预览”闭环，真实分析与附件沉淀继续后置。</li>
+              <li>本轮先打通“上传 -&gt; 提取 -&gt; 真实分析 -&gt; 结果阅读”最小闭环。</li>
               <li>
-                后续 issue 会按“上传提取 {'->'} 真实分析 {'->'} viewer 边界”继续推进。
+                后续 issue 会按“viewer 缓存体验 {'->'} 里程碑文档收束”继续推进。
               </li>
             </ul>
           </DisplaySurfaceCard>

--- a/apps/admin/components/ai-analysis-panel.spec.tsx
+++ b/apps/admin/components/ai-analysis-panel.spec.tsx
@@ -1,0 +1,156 @@
+'use client';
+
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useState } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { AiAnalysisPanel } from './ai-analysis-panel';
+
+afterEach(() => {
+  cleanup();
+});
+
+const runtimeSummary = {
+  provider: 'qiniu',
+  model: 'deepseek-v3',
+  mode: 'live',
+  supportedScenarios: ['jd-match', 'resume-review', 'offer-compare'] as const,
+};
+
+function ControlledAnalysisPanel(props: {
+  canAnalyze: boolean;
+  helperMessage?: string | null;
+  triggerAnalysis?: typeof import('../lib/ai-workbench-api').triggerAiWorkbenchAnalysis;
+  initialContent?: string;
+}) {
+  const [content, setContent] = useState(props.initialContent ?? '');
+
+  return (
+    <AiAnalysisPanel
+      accessToken="demo-token"
+      apiBaseUrl="http://localhost:5577"
+      canAnalyze={props.canAnalyze}
+      content={content}
+      helperMessage={props.helperMessage}
+      onContentChange={setContent}
+      runtimeSummary={runtimeSummary}
+      triggerAnalysis={props.triggerAnalysis}
+    />
+  );
+}
+
+describe('AiAnalysisPanel', () => {
+  it('should show read-only message when current role cannot trigger analysis', () => {
+    render(<ControlledAnalysisPanel canAnalyze={false} />);
+
+    expect(screen.getByText('当前角色只读')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'viewer 当前只保留缓存报告体验，真实分析触发入口会在管理员链路中继续开放。',
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('should trigger live analysis and render returned report sections', async () => {
+    const user = userEvent.setup();
+    const triggerAnalysis = vi.fn().mockResolvedValue({
+      cached: false,
+      report: {
+        reportId: 'resume-review-demo',
+        cacheKey: 'resume-review:zh:demo',
+        scenario: 'resume-review',
+        locale: 'zh',
+        sourceHash: 'demo',
+        inputPreview: 'NestJS React TypeScript',
+        summary: '建议继续补充量化结果与职责边界。',
+        sections: [
+          {
+            key: 'analysis-result',
+            title: '分析结果',
+            bullets: ['补充量化成果。', '突出主导模块。'],
+          },
+          {
+            key: 'provider',
+            title: 'Provider 信息',
+            bullets: ['qiniu / deepseek-v3'],
+          },
+        ],
+        generator: 'ai-provider',
+        createdAt: '2026-03-27T00:00:00.000Z',
+      },
+    });
+
+    render(
+      <ControlledAnalysisPanel
+        canAnalyze
+        helperMessage="已将 resume.pdf 的提取结果同步到分析输入区。"
+        initialContent="NestJS React TypeScript"
+        triggerAnalysis={triggerAnalysis}
+      />,
+    );
+
+    expect(
+      screen.getByText('已将 resume.pdf 的提取结果同步到分析输入区。'),
+    ).toBeInTheDocument();
+
+    await user.selectOptions(screen.getByLabelText('分析场景'), 'resume-review');
+    await user.selectOptions(screen.getByLabelText('输出语言'), 'zh');
+    await user.click(screen.getByRole('button', { name: '开始真实分析' }));
+
+    await waitFor(() => {
+      expect(triggerAnalysis).toHaveBeenCalledWith({
+        accessToken: 'demo-token',
+        apiBaseUrl: 'http://localhost:5577',
+        scenario: 'resume-review',
+        locale: 'zh',
+        content: 'NestJS React TypeScript',
+      });
+    });
+
+    expect(
+      await screen.findByText('建议继续补充量化结果与职责边界。'),
+    ).toBeInTheDocument();
+    expect(screen.getByText('场景：简历优化建议')).toBeInTheDocument();
+    expect(screen.getByText('Provider：qiniu / deepseek-v3')).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: '分析结果', level: 3 }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('补充量化成果。')).toBeInTheDocument();
+  });
+
+  it('should show error feedback when live analysis fails', async () => {
+    const user = userEvent.setup();
+    const triggerAnalysis = vi
+      .fn()
+      .mockRejectedValue(new Error('Provider request failed'));
+
+    render(
+      <ControlledAnalysisPanel
+        canAnalyze
+        initialContent="NestJS React TypeScript"
+        triggerAnalysis={triggerAnalysis}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: '开始真实分析' }));
+
+    expect(await screen.findByText('Provider request failed')).toBeInTheDocument();
+  });
+
+  it('should guard against empty input before triggering analysis', async () => {
+    const user = userEvent.setup();
+    const triggerAnalysis = vi.fn();
+
+    render(
+      <ControlledAnalysisPanel canAnalyze triggerAnalysis={triggerAnalysis} />,
+    );
+
+    await user.click(screen.getByRole('button', { name: '开始真实分析' }));
+
+    expect(
+      await screen.findByText('请先输入分析内容，或先通过文件提取生成输入文本。'),
+    ).toBeInTheDocument();
+    expect(triggerAnalysis).not.toHaveBeenCalled();
+  });
+});

--- a/apps/admin/components/ai-analysis-panel.tsx
+++ b/apps/admin/components/ai-analysis-panel.tsx
@@ -1,0 +1,260 @@
+'use client';
+
+import {
+  DisplayPill,
+  DisplaySectionIntro,
+  DisplaySurfaceCard,
+} from '@my-resume/ui/display';
+import { useState } from 'react';
+
+import {
+  triggerAiWorkbenchAnalysis,
+} from '../lib/ai-workbench-api';
+import {
+  AiWorkbenchLocale,
+  AiWorkbenchReport,
+  AiWorkbenchRuntimeSummary,
+  AiWorkbenchScenario,
+} from '../lib/ai-workbench-types';
+
+interface AiAnalysisPanelProps {
+  accessToken: string;
+  apiBaseUrl: string;
+  canAnalyze: boolean;
+  content: string;
+  helperMessage?: string | null;
+  onContentChange: (value: string) => void;
+  runtimeSummary: AiWorkbenchRuntimeSummary;
+  triggerAnalysis?: typeof triggerAiWorkbenchAnalysis;
+}
+
+const scenarioOptions: Array<{
+  value: AiWorkbenchScenario;
+  label: string;
+}> = [
+  {
+    value: 'jd-match',
+    label: 'JD 匹配分析',
+  },
+  {
+    value: 'resume-review',
+    label: '简历优化建议',
+  },
+  {
+    value: 'offer-compare',
+    label: 'Offer 对比建议',
+  },
+];
+
+const localeOptions: Array<{
+  value: AiWorkbenchLocale;
+  label: string;
+}> = [
+  {
+    value: 'zh',
+    label: '中文',
+  },
+  {
+    value: 'en',
+    label: 'English',
+  },
+];
+
+function formatScenario(scenario: AiWorkbenchScenario): string {
+  return (
+    scenarioOptions.find((item) => item.value === scenario)?.label ?? scenario
+  );
+}
+
+function formatLocale(locale: AiWorkbenchLocale): string {
+  return locale === 'zh' ? '中文' : 'English';
+}
+
+function formatGenerator(generator: AiWorkbenchReport['generator']): string {
+  return generator === 'ai-provider' ? '真实 Provider' : '缓存结果';
+}
+
+export function AiAnalysisPanel({
+  accessToken,
+  apiBaseUrl,
+  canAnalyze,
+  content,
+  helperMessage,
+  onContentChange,
+  runtimeSummary,
+  triggerAnalysis = triggerAiWorkbenchAnalysis,
+}: AiAnalysisPanelProps) {
+  const [scenario, setScenario] = useState<AiWorkbenchScenario>('resume-review');
+  const [locale, setLocale] = useState<AiWorkbenchLocale>('zh');
+  const [pending, setPending] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [report, setReport] = useState<AiWorkbenchReport | null>(null);
+
+  if (!canAnalyze) {
+    return (
+      <section className="card stack">
+        <div>
+          <p className="eyebrow">真实分析</p>
+          <h2>当前角色只读</h2>
+          <p className="muted">只有管理员可触发真实分析并写入新的报告结果。</p>
+        </div>
+        <div className="readonly-box">
+          viewer 当前只保留缓存报告体验，真实分析触发入口会在管理员链路中继续开放。
+        </div>
+      </section>
+    );
+  }
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    const normalizedContent = content.trim();
+
+    if (!normalizedContent) {
+      setErrorMessage('请先输入分析内容，或先通过文件提取生成输入文本。');
+      setReport(null);
+      return;
+    }
+
+    setPending(true);
+    setErrorMessage(null);
+
+    try {
+      const result = await triggerAnalysis({
+        apiBaseUrl,
+        accessToken,
+        scenario,
+        locale,
+        content: normalizedContent,
+      });
+
+      setReport(result.report);
+    } catch (error) {
+      setReport(null);
+      setErrorMessage(
+        error instanceof Error ? error.message : '真实分析触发失败，请稍后重试',
+      );
+    } finally {
+      setPending(false);
+    }
+  }
+
+  return (
+    <section className="card stack">
+      <div>
+        <p className="eyebrow">真实分析</p>
+        <h2>输入内容并触发真实分析</h2>
+        <p className="muted">
+          当前阶段先保留同步最小闭环，让管理员直接验证 Provider、场景和结果结构。
+        </p>
+      </div>
+
+      <form className="stack" onSubmit={(event) => void handleSubmit(event)}>
+        <div className="form-grid">
+          <label className="field">
+            <span>分析场景</span>
+            <select
+              onChange={(event) =>
+                setScenario(event.target.value as AiWorkbenchScenario)
+              }
+              value={scenario}
+            >
+              {scenarioOptions.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label className="field">
+            <span>输出语言</span>
+            <select
+              onChange={(event) =>
+                setLocale(event.target.value as AiWorkbenchLocale)
+              }
+              value={locale}
+            >
+              {localeOptions.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+
+        <label className="field">
+          <span>分析输入</span>
+          <textarea
+            className="preview-textarea"
+            onChange={(event) => onContentChange(event.target.value)}
+            placeholder="可直接粘贴 JD、简历段落或 offer 信息；也可以先从上方文件提取区同步文本。"
+            value={content}
+          />
+        </label>
+
+        {helperMessage ? (
+          <div className="dashboard-inline-note">{helperMessage}</div>
+        ) : null}
+
+        {errorMessage ? <p className="error-text">{errorMessage}</p> : null}
+
+        <div className="dashboard-entry-actions">
+          <button disabled={pending} type="submit">
+            {pending ? '正在生成分析...' : '开始真实分析'}
+          </button>
+        </div>
+      </form>
+
+      {report ? (
+        <div className="preview-stack">
+          <div className="stack">
+            <DisplaySectionIntro
+              compact
+              description="当前展示的是管理员刚触发的同步分析结果，后续再继续扩展历史记录与更完整的结果阅读。"
+              eyebrow="分析结果"
+              title="最近一次结果"
+            />
+            <div className="dashboard-badge-row">
+              <DisplayPill>场景：{formatScenario(report.scenario)}</DisplayPill>
+              <DisplayPill>语言：{formatLocale(report.locale)}</DisplayPill>
+              <DisplayPill>来源：{formatGenerator(report.generator)}</DisplayPill>
+              <DisplayPill>
+                Provider：{runtimeSummary.provider} / {runtimeSummary.model}
+              </DisplayPill>
+            </div>
+          </div>
+
+          <DisplaySurfaceCard className="analysis-summary-card">
+            <DisplaySectionIntro
+              compact
+              description={report.inputPreview}
+              eyebrow="摘要"
+              title="模型返回摘要"
+              titleAs="h3"
+            />
+            <div className="analysis-text-block">{report.summary}</div>
+          </DisplaySurfaceCard>
+
+          <div className="analysis-section-grid">
+            {report.sections.map((section) => (
+              <DisplaySurfaceCard
+                as="article"
+                className="analysis-section-card"
+                key={section.key}
+              >
+                <DisplaySectionIntro compact title={section.title} titleAs="h3" />
+                <ul className="muted-list">
+                  {section.bullets.map((bullet) => (
+                    <li key={`${section.key}-${bullet}`}>{bullet}</li>
+                  ))}
+                </ul>
+              </DisplaySurfaceCard>
+            ))}
+          </div>
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/admin/components/ai-file-extraction-panel.spec.tsx
+++ b/apps/admin/components/ai-file-extraction-panel.spec.tsx
@@ -30,6 +30,7 @@ describe('AiFileExtractionPanel', () => {
 
   it('should upload a file and render extracted preview for admin', async () => {
     const user = userEvent.setup();
+    const onExtractedText = vi.fn();
     const extractFileText = vi.fn().mockResolvedValue({
       fileName: 'resume.txt',
       fileType: 'txt',
@@ -44,6 +45,7 @@ describe('AiFileExtractionPanel', () => {
         apiBaseUrl="http://localhost:5577"
         canUpload
         extractFileText={extractFileText}
+        onExtractedText={onExtractedText}
       />,
     );
 
@@ -65,6 +67,13 @@ describe('AiFileExtractionPanel', () => {
     expect(await screen.findByDisplayValue('resume text content')).toBeInTheDocument();
     expect(screen.getByText('txt')).toBeInTheDocument();
     expect(screen.getByText('19')).toBeInTheDocument();
+    expect(onExtractedText).toHaveBeenCalledWith({
+      fileName: 'resume.txt',
+      fileType: 'txt',
+      mimeType: 'text/plain',
+      text: 'resume text content',
+      charCount: 19,
+    });
   });
 
   it('should show extraction error feedback when upload fails', async () => {

--- a/apps/admin/components/ai-file-extraction-panel.tsx
+++ b/apps/admin/components/ai-file-extraction-panel.tsx
@@ -10,6 +10,7 @@ interface AiFileExtractionPanelProps {
   accessToken: string;
   canUpload: boolean;
   extractFileText?: typeof extractTextFromFile;
+  onExtractedText?: (result: FileExtractionResult) => void;
 }
 
 function formatFileSize(size: number): string {
@@ -25,6 +26,7 @@ export function AiFileExtractionPanel({
   accessToken,
   canUpload,
   extractFileText = extractTextFromFile,
+  onExtractedText,
 }: AiFileExtractionPanelProps) {
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
   const [result, setResult] = useState<FileExtractionResult | null>(null);
@@ -64,6 +66,7 @@ export function AiFileExtractionPanel({
       });
 
       setResult(nextResult);
+      onExtractedText?.(nextResult);
     } catch (error) {
       setResult(null);
       setErrorMessage(

--- a/apps/admin/lib/ai-workbench-api.spec.ts
+++ b/apps/admin/lib/ai-workbench-api.spec.ts
@@ -1,6 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { fetchAiWorkbenchRuntime } from './ai-workbench-api';
+import {
+  fetchAiWorkbenchRuntime,
+  triggerAiWorkbenchAnalysis,
+} from './ai-workbench-api';
 
 describe('ai workbench api client', () => {
   beforeEach(() => {
@@ -37,5 +40,83 @@ describe('ai workbench api client', () => {
     expect(response.provider).toBe('qiniu');
     expect(response.model).toBe('deepseek-v3');
     expect(response.supportedScenarios).toContain('jd-match');
+  });
+
+  it('should trigger live analysis with scenario, locale and content', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          cached: false,
+          report: {
+            reportId: 'resume-review-demo',
+            cacheKey: 'resume-review:zh:demo',
+            scenario: 'resume-review',
+            locale: 'zh',
+            sourceHash: 'demo',
+            inputPreview: 'NestJS React TypeScript',
+            summary: '真实分析摘要',
+            sections: [
+              {
+                key: 'analysis-result',
+                title: '分析结果',
+                bullets: ['建议补充量化成果。'],
+              },
+            ],
+            generator: 'ai-provider',
+            createdAt: '2026-03-27T00:00:00.000Z',
+          },
+        }),
+      }),
+    );
+
+    const response = await triggerAiWorkbenchAnalysis({
+      apiBaseUrl: 'http://localhost:5577',
+      accessToken: 'demo-token',
+      scenario: 'resume-review',
+      locale: 'zh',
+      content: 'NestJS React TypeScript',
+    });
+
+    expect(fetch).toHaveBeenCalledWith(
+      'http://localhost:5577/ai/reports/analyze',
+      expect.objectContaining({
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer demo-token',
+        },
+        body: JSON.stringify({
+          scenario: 'resume-review',
+          content: 'NestJS React TypeScript',
+          locale: 'zh',
+        }),
+      }),
+    );
+    expect(response.report.generator).toBe('ai-provider');
+    expect(response.report.sections[0]?.title).toBe('分析结果');
+  });
+
+  it('should surface server analysis errors', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        json: async () => ({
+          message: 'Provider request failed',
+        }),
+      }),
+    );
+
+    await expect(
+      triggerAiWorkbenchAnalysis({
+        apiBaseUrl: 'http://localhost:5577',
+        accessToken: 'demo-token',
+        scenario: 'jd-match',
+        locale: 'zh',
+        content: 'NestJS React TypeScript',
+      }),
+    ).rejects.toThrow('Provider request failed');
   });
 });

--- a/apps/admin/lib/ai-workbench-api.ts
+++ b/apps/admin/lib/ai-workbench-api.ts
@@ -1,8 +1,19 @@
-import { AiWorkbenchRuntimeSummary } from './ai-workbench-types';
+import {
+  AiWorkbenchLocale,
+  AiWorkbenchRuntimeSummary,
+  AiWorkbenchScenario,
+  TriggerAiWorkbenchAnalysisResult,
+} from './ai-workbench-types';
 
 interface FetchAiWorkbenchRuntimeInput {
   apiBaseUrl: string;
   accessToken: string;
+}
+
+interface TriggerAiWorkbenchAnalysisInput extends FetchAiWorkbenchRuntimeInput {
+  scenario: AiWorkbenchScenario;
+  content: string;
+  locale: AiWorkbenchLocale;
 }
 
 function joinApiUrl(apiBaseUrl: string, pathname: string): string {
@@ -23,4 +34,35 @@ export async function fetchAiWorkbenchRuntime(
   }
 
   return (await response.json()) as AiWorkbenchRuntimeSummary;
+}
+
+export async function triggerAiWorkbenchAnalysis(
+  input: TriggerAiWorkbenchAnalysisInput,
+): Promise<TriggerAiWorkbenchAnalysisResult> {
+  const response = await fetch(joinApiUrl(input.apiBaseUrl, '/ai/reports/analyze'), {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${input.accessToken}`,
+    },
+    body: JSON.stringify({
+      scenario: input.scenario,
+      content: input.content,
+      locale: input.locale,
+    }),
+  });
+
+  if (!response.ok) {
+    const payload = (await response.json().catch(() => null)) as
+      | { message?: string | string[] }
+      | null;
+
+    const message = Array.isArray(payload?.message)
+      ? payload.message[0]
+      : payload?.message;
+
+    throw new Error(message || '真实分析触发失败，请稍后重试');
+  }
+
+  return (await response.json()) as TriggerAiWorkbenchAnalysisResult;
 }

--- a/apps/admin/lib/ai-workbench-types.ts
+++ b/apps/admin/lib/ai-workbench-types.ts
@@ -7,5 +7,32 @@ export interface AiWorkbenchRuntimeSummary {
   provider: string;
   model: string;
   mode: string;
-  supportedScenarios: AiWorkbenchScenario[];
+  supportedScenarios: readonly AiWorkbenchScenario[];
+}
+
+export type AiWorkbenchLocale = 'zh' | 'en';
+export type AiWorkbenchReportGenerator = 'mock-cache' | 'ai-provider';
+
+export interface AiWorkbenchReportSection {
+  key: string;
+  title: string;
+  bullets: string[];
+}
+
+export interface AiWorkbenchReport {
+  reportId: string;
+  cacheKey: string;
+  scenario: AiWorkbenchScenario;
+  locale: AiWorkbenchLocale;
+  sourceHash: string;
+  inputPreview: string;
+  summary: string;
+  sections: AiWorkbenchReportSection[];
+  generator: AiWorkbenchReportGenerator;
+  createdAt: string;
+}
+
+export interface TriggerAiWorkbenchAnalysisResult {
+  cached: boolean;
+  report: AiWorkbenchReport;
 }

--- a/docs/30-开发日志/M10-issue-49-review-ready-前关键通路校验.md
+++ b/docs/30-开发日志/M10-issue-49-review-ready-前关键通路校验.md
@@ -1,0 +1,107 @@
+# M10 / issue-49 review-ready 前关键通路校验
+
+- Issue：`#91`
+- 里程碑：`M10 AI 工作台与真实分析：从基础接口到后台闭环`
+- 分支：`fys-dev/feat-m10-issue-49-admin-live-analysis`
+- 日期：`2026-03-27`
+
+## 本轮主承诺
+
+把后台 AI 工作台从“上传与预览输入”推进到“管理员真实分析与结果阅读”：
+
+- 管理员可手动输入分析内容
+- 文件提取结果可接力到分析输入区
+- 页面可触发 `apps/server` 的 `/ai/reports/analyze`
+- 页面可阅读返回的 Provider 结果结构与错误反馈
+
+本轮不承诺：
+
+- Redis / BullMQ 队列
+- 分析历史持久化
+- 复杂 Prompt 编排系统
+- viewer 真实缓存体验收束
+
+## 关键通路
+
+### 1. 输入接力到真实分析通路
+
+要证明的事情：
+
+- 分析输入不只靠手打
+- 上一轮文件提取结果能直接成为这一轮真实分析输入
+- 业务链路仍是前端壳调用 NestJS，而不是前端自己处理分析逻辑
+
+证据落点：
+
+- `apps/admin/components/ai-file-extraction-panel.tsx`
+- `apps/admin/components/admin-ai-workbench-shell.tsx`
+- `apps/admin/components/admin-ai-workbench-shell.spec.tsx`
+
+当前结论：
+
+- 已打通。文件提取成功后会把结果同步进分析输入区
+- 工作台壳已验证这条接力链路
+- AI 业务触发仍只通过 `apps/server`
+
+### 2. 管理员真实分析与结果阅读通路
+
+要证明的事情：
+
+- `admin` 能用当前输入触发真实分析
+- 页面能展示场景、语言、Provider 和结果结构
+- 分析失败时不会静默失败
+
+证据落点：
+
+- `apps/admin/lib/ai-workbench-api.ts`
+- `apps/admin/lib/ai-workbench-api.spec.ts`
+- `apps/admin/components/ai-analysis-panel.tsx`
+- `apps/admin/components/ai-analysis-panel.spec.tsx`
+- `apps/server/test/ai-report-role-access.e2e-spec.ts`
+
+当前结论：
+
+- 已打通。前端已能调用 `/ai/reports/analyze`
+- 管理员面板可展示结果摘要、Provider 信息和分段结果
+- API 客户端与组件测试都覆盖了失败反馈
+- `server` E2E 已证明管理员触发与 viewer 禁止触发边界仍成立
+
+### 3. 最小同步闭环与后续连续性通路
+
+要证明的事情：
+
+- 当前轮次只做同步最小闭环，不提前走向队列和历史系统
+- 页面和服务端构建没有被这次接入破坏
+- 人工验证能说明这轮不是“只在测试里通过”
+
+证据落点：
+
+- `apps/admin/components/ai-analysis-panel.tsx`
+- `pnpm --filter @my-resume/admin test`
+- `pnpm --filter @my-resume/admin typecheck`
+- `pnpm --filter @my-resume/admin build`
+- `pnpm --filter @my-resume/server test:e2e -- test/ai-report-role-access.e2e-spec.ts`
+- `pnpm --filter @my-resume/server typecheck`
+- `pnpm --filter @my-resume/server build`
+- 本地人工验证：管理员登录后在 `http://localhost:5566/dashboard/ai` 成功触发真实分析并看到结果
+
+当前结论：
+
+- 已满足。当前页面明确保留同步触发方案
+- 自动化验证与人工验证都已成立
+- 后续可继续在同一入口上接 viewer 缓存体验，而不必返工本轮输入与分析链路
+
+## 是否足以进入 review-ready
+
+可以进入。
+
+原因：
+
+- 本轮主承诺已经完成
+- 三条关键通路都有代码、测试和人工验证支撑
+- 没有把 `issue-50` 的 viewer 缓存体验提前做进来
+
+## 进入 review-ready 前仍需注意
+
+- `admin typecheck` 与 `next build` 不适合并行执行，`.next/types` 会被并行重建影响
+- 真实 Provider 返回的是长文本，当前已改成正文块展示；后续若继续做结构化结果，可考虑更细的段落拆分而不是继续堆长字符串

--- a/docs/30-开发日志/M10-issue-49-管理员真实分析闭环.md
+++ b/docs/30-开发日志/M10-issue-49-管理员真实分析闭环.md
@@ -1,0 +1,262 @@
+# M10 / issue-49 开发日志：管理员真实分析闭环
+
+- Issue：`#91`
+- 里程碑：`M10 AI 工作台与真实分析：从基础接口到后台闭环`
+- 分支：`fys-dev/feat-m10-issue-49-admin-live-analysis`
+- 日期：`2026-03-27`
+
+## 背景
+
+`issue-47` 先搭起了后台 AI 工作台壳，`issue-48` 又把“上传 -> 提取 -> 预览”输入链路接了出来。
+
+但如果后台还不能真正触发分析，这条线就仍然停留在“工作台入口 + 输入准备”阶段，M10 也很难算形成闭环。
+
+所以这一轮只往前推一小步，但这一步很关键：
+
+- 让管理员基于当前输入触发真实分析
+- 把服务端返回结果真正展示在页面里
+- 保持业务逻辑继续只在 `apps/server`
+
+## 本次目标
+
+- 让 `admin` 能基于手动输入或提取文本触发真实分析
+- 展示 Provider / model / 场景与结果结构
+- 让错误反馈可见、输入链路可接力
+
+## 非目标
+
+- 不引入 Redis / BullMQ 队列
+- 不做分析历史持久化
+- 不做复杂 Prompt 编排系统
+- 不在本轮做 viewer 缓存体验收束
+
+## TDD / 测试设计
+
+### 1. 先补分析 API 客户端测试
+
+更新：
+
+- `apps/admin/lib/ai-workbench-api.spec.ts`
+
+先锁定：
+
+- `/ai/reports/analyze` 的请求地址、鉴权头和请求体
+- 服务端错误信息会被正确抛出
+
+### 2. 再补分析面板测试
+
+新增：
+
+- `apps/admin/components/ai-analysis-panel.spec.tsx`
+
+先锁定：
+
+- `viewer` 只读提示
+- 管理员触发真实分析后可看到结果
+- 失败状态会显示错误
+- 空输入不会直接发请求
+
+### 3. 用工作台壳测试保护输入接力
+
+更新：
+
+- `apps/admin/components/admin-ai-workbench-shell.spec.tsx`
+- `apps/admin/components/ai-file-extraction-panel.spec.tsx`
+
+重点确认：
+
+- 文件提取面板可把结果交给分析输入区
+- 工作台壳已经同时承接“提取入口”和“真实分析入口”
+
+### 4. 服务端回归
+
+复用：
+
+- `apps/server/test/ai-report-role-access.e2e-spec.ts`
+
+目的不是重写服务端，而是证明这次前端接入的管理员触发链路，确实还挂在现有服务端权限边界之上。
+
+## 实际改动
+
+### 1. 扩展 AI 工作台客户端契约
+
+更新：
+
+- `apps/admin/lib/ai-workbench-types.ts`
+- `apps/admin/lib/ai-workbench-api.ts`
+- `apps/admin/lib/ai-workbench-api.spec.ts`
+
+这一步补了两层东西：
+
+- 前端对分析结果结构的类型描述
+- 触发 `/ai/reports/analyze` 的最小 API 客户端
+
+这样页面侧就不需要直接拼请求，也不用在组件里手写错误解析。
+
+### 2. 新增真实分析面板
+
+新增：
+
+- `apps/admin/components/ai-analysis-panel.tsx`
+- `apps/admin/components/ai-analysis-panel.spec.tsx`
+
+当前面板只做当前阶段真正需要的事情：
+
+- 选择分析场景
+- 选择输出语言
+- 输入或接收分析内容
+- 触发真实分析
+- 展示结果摘要、Provider 信息和结果分段
+- 显示失败信息
+
+这里刻意没有继续做“历史记录列表”“重新打开旧结果”“多任务并发态”等能力，避免把同步最小闭环再次扩张成一个半成品工作流系统。
+
+### 3. 把文件提取结果接到分析输入区
+
+更新：
+
+- `apps/admin/components/ai-file-extraction-panel.tsx`
+- `apps/admin/components/ai-file-extraction-panel.spec.tsx`
+- `apps/admin/components/admin-ai-workbench-shell.tsx`
+- `apps/admin/components/admin-ai-workbench-shell.spec.tsx`
+
+本轮最关键的不是单独再加一个分析面板，而是把上轮输入链路接上来：
+
+- 文件提取成功后，结果会同步进分析输入区
+- 管理员可以直接在此基础上继续编辑，再触发真实分析
+
+这样 `issue-48` 和 `issue-49` 之间形成了真正连续的教学主线，而不是两个互不相干的功能块。
+
+### 4. 微调结果阅读样式
+
+更新：
+
+- `apps/admin/app/globals.css`
+
+原本真实分析结果会把整段 AI 返回内容塞进标题区域。自动化测试能通过，但人工验证时会发现页面阅读体验很差。
+
+所以这轮顺手收了一步：
+
+- 长文本改为正文块展示
+- 结果卡片与分段卡片增加最小样式承载
+- `select` 样式和分析区布局补齐
+
+这属于当前 issue 内必要的可读性修正，不是 UI 大改。
+
+## Review 记录
+
+### 是否符合当前 Issue 与里程碑目标
+
+符合。
+
+本轮只完成：
+
+- 管理员真实分析触发
+- 结果阅读
+- 文件提取到分析输入的接力
+- 错误反馈与最小样式承载
+
+没有越界去做：
+
+- 队列与异步任务
+- 分析历史持久化
+- viewer 缓存体验页面
+- 新的服务端业务接口扩张
+
+### 是否存在可抽离的组件、公共函数、skills 或其他复用能力
+
+本轮已经完成当前最合适的一层抽离：
+
+- `ai-workbench-api.ts` 继续承载工作台 API 调用
+- `AiAnalysisPanel` 作为独立分析入口组件
+- `AiFileExtractionPanel` 通过回调与分析区接力
+
+暂时不继续抽“更高阶 AI 编排组件”，因为后续 `issue-50` 还会继续调整 viewer 边界与缓存体验，过早抽大组件只会让共享边界变虚。
+
+### 本次最重要的边界判断
+
+当前阶段先做同步最小闭环，而不是直接上队列，是合理的。
+
+原因：
+
+- 先证明“管理员真实分析入口真的能工作”
+- 再考虑异步任务、缓存命中、历史列表这些更复杂结构
+- 对教程型仓库来说，先有一条完整短链路，比一开始铺开完整编排更适合教学
+
+## 自测结果
+
+已执行：
+
+- `pnpm --filter @my-resume/admin test`
+- `pnpm --filter @my-resume/admin typecheck`
+- `pnpm --filter @my-resume/admin build`
+- `pnpm --filter @my-resume/server test:e2e -- test/ai-report-role-access.e2e-spec.ts`
+- `pnpm --filter @my-resume/server typecheck`
+- `pnpm --filter @my-resume/server build`
+
+结果：
+
+- `admin` 自动化测试、类型检查、构建通过
+- `server` 真实分析权限回归、类型检查、构建通过
+
+补充说明：
+
+- `admin typecheck` 与 `next build` 并行运行时会因为 `.next/types` 重建互相影响，因此最终结果以顺序执行为准
+
+### 人工验证
+
+本地临时启动：
+
+- `apps/server`：`http://localhost:5577`
+- `apps/admin`：`http://localhost:5566`
+
+实际验证过程：
+
+- 使用 `admin / admin123456` 登录后台
+- 进入 `http://localhost:5566/dashboard/ai`
+- 手动输入 `NestJS React TypeScript 简历优化`
+- 触发真实分析
+- 页面成功展示：
+  - 当前 Provider / model
+  - 场景与语言
+  - 真实返回结果正文
+  - Provider 信息与下一步分段
+
+## 遇到的问题
+
+### 1. 真实分析长文本一开始被当成标题渲染
+
+问题：
+
+自动化测试能过，但人工验证时会看到整段 AI 返回内容被塞进 `h3`，阅读体验很差。
+
+处理：
+
+- 改成标题 + 正文块结构
+- 保留结果分段卡片
+
+这次调整说明，当前流程里的人工校验确实有价值，不只是补形式。
+
+### 2. `admin typecheck` 与 `build` 并行时会互踩 `.next/types`
+
+问题：
+
+并行跑两条命令时，`typecheck` 会因为 `.next` 目录正在重建而报 `TS6053`。
+
+处理：
+
+- 改为顺序执行
+- 记录到本轮日志中，避免后续误判为业务代码回退
+
+## 可沉淀为教程 / 博客的点
+
+- 为什么 AI 工作台的第二步不是“上队列”，而是先把管理员真实分析链路接通
+- 如何把文件提取输入平滑接到真实分析入口，而不是做成两个割裂模块
+- 为什么坚持把 AI 业务逻辑继续收敛在 NestJS，而不顺手放进 Next.js
+- 自动化测试之外，人工校验如何发现“结果可读性”这类不会直接体现在测试里的问题
+
+## 后续待办
+
+- 关闭 `issue-49`
+- 继续 `issue-50`：viewer 缓存体验与权限收束
+- 最后进入 `issue-51`：M10 教程大纲与里程碑收束


### PR DESCRIPTION
## 背景

上一轮已经把后台 AI 工作台的上传 -> 提取 -> 预览输入链路接出来，但管理员还不能真正触发分析。
这一轮把 AI 工作台推进到“输入 -> 真实分析 -> 结果阅读”的最小同步闭环。

## 本次改动

- 扩展 AI 工作台客户端契约，并接入 /ai/reports/analyze
- 新增 AiAnalysisPanel，支持场景、语言、输入、错误反馈与结果阅读
- 把文件提取结果接力到分析输入区
- 补 review-ready 校验记录与开发日志

## 非目标

- 不引入 Redis / BullMQ 队列
- 不做分析历史持久化
- 不做复杂 Prompt 编排系统
- 不在本轮处理 viewer 缓存体验收束

## 测试

- pnpm --filter @my-resume/admin test
- pnpm --filter @my-resume/admin typecheck
- pnpm --filter @my-resume/admin build
- pnpm --filter @my-resume/server test:e2e -- test/ai-report-role-access.e2e-spec.ts
- pnpm --filter @my-resume/server typecheck
- pnpm --filter @my-resume/server build

## 人工验证

- 启动 apps/server 与 apps/admin
- 使用 admin / admin123456 登录后台
- 进入 http://localhost:5566/dashboard/ai
- 输入 NestJS React TypeScript 简历优化 后成功拿到真实 Provider 结果

## 文档

- docs/30-开发日志/M10-issue-49-review-ready-前关键通路校验.md
- docs/30-开发日志/M10-issue-49-管理员真实分析闭环.md

Closes #91
