### PR TITLE
[Feat] M10 / issue-50 viewer 缓存体验与权限收束

### DIFF
--- a/apps/admin/app/globals.css
+++ b/apps/admin/app/globals.css
@@ -258,6 +258,12 @@ textarea {
   color: var(--display-color-text);
 }
 
+.cached-report-list {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
 .analysis-section-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));

--- a/apps/admin/components/admin-ai-workbench-shell.spec.tsx
+++ b/apps/admin/components/admin-ai-workbench-shell.spec.tsx
@@ -85,6 +85,18 @@ vi.mock('./ai-analysis-panel', () => ({
   ),
 }));
 
+vi.mock('./ai-cached-reports-panel', () => ({
+  AiCachedReportsPanel: ({
+    isViewerExperience,
+  }: {
+    isViewerExperience: boolean;
+  }) => (
+    <div>
+      {isViewerExperience ? 'viewer 缓存结果面板占位' : 'admin 缓存结果面板占位'}
+    </div>
+  ),
+}));
+
 import { AdminAiWorkbenchShell } from './admin-ai-workbench-shell';
 
 const runtimeSummary = {
@@ -162,6 +174,7 @@ describe('AdminAiWorkbenchShell', () => {
     ).toBeInTheDocument();
     expect(screen.getByText('文件提取面板占位')).toBeInTheDocument();
     expect(screen.getByText('真实分析面板占位')).toBeInTheDocument();
+    expect(screen.getByText('admin 缓存结果面板占位')).toBeInTheDocument();
     expect(screen.getByText('当前分析内容：空')).toBeInTheDocument();
 
     await user.click(screen.getByRole('button', { name: '模拟提取完成' }));
@@ -180,6 +193,7 @@ describe('AdminAiWorkbenchShell', () => {
     expect(
       screen.getByText('viewer 当前只允许查看缓存结果与预设体验，不能上传文件或触发真实分析。'),
     ).toBeInTheDocument();
+    expect(screen.getByText('viewer 缓存结果面板占位')).toBeInTheDocument();
     expect(screen.getByText('文件提取只读占位')).toBeInTheDocument();
     expect(screen.getByText('真实分析只读占位')).toBeInTheDocument();
   });

--- a/apps/admin/components/admin-ai-workbench-shell.tsx
+++ b/apps/admin/components/admin-ai-workbench-shell.tsx
@@ -23,6 +23,7 @@ import {
 import { FileExtractionResult } from '../lib/ai-file-types';
 import { ThemeModeToggle } from './theme-mode-toggle';
 import { AiAnalysisPanel } from './ai-analysis-panel';
+import { AiCachedReportsPanel } from './ai-cached-reports-panel';
 import { AiFileExtractionPanel } from './ai-file-extraction-panel';
 
 const scenarioCards = {
@@ -128,6 +129,13 @@ export function AdminAiWorkbenchShell() {
   const roleMessage = isAdmin
     ? '当前账号可继续接入上传、真实分析和结果阅读。'
     : 'viewer 当前只允许查看缓存结果与预设体验，不能上传文件或触发真实分析。';
+  const cachedReportsPanel = (
+    <AiCachedReportsPanel
+      accessToken={readAccessToken() ?? ''}
+      apiBaseUrl={DEFAULT_API_BASE_URL}
+      isViewerExperience={!isAdmin}
+    />
+  );
 
   return (
     <main className="dashboard-shell ai-workbench-shell">
@@ -171,6 +179,8 @@ export function AdminAiWorkbenchShell() {
 
       <section className="dashboard-main-grid ai-workbench-grid">
         <div className="dashboard-column stack">
+          {!isAdmin ? cachedReportsPanel : null}
+
           <AiFileExtractionPanel
             accessToken={readAccessToken() ?? ''}
             apiBaseUrl={DEFAULT_API_BASE_URL}
@@ -187,6 +197,8 @@ export function AdminAiWorkbenchShell() {
             onContentChange={handleAnalysisContentChange}
             runtimeSummary={runtimeSummary}
           />
+
+          {isAdmin ? cachedReportsPanel : null}
 
           <DisplaySurfaceCard className="card stack">
             <DisplaySectionIntro
@@ -234,9 +246,9 @@ export function AdminAiWorkbenchShell() {
 
             <ul className="muted-list">
               <li>业务逻辑继续统一由 `apps/server` 承载，不写 Next Route Handlers 业务接口。</li>
-              <li>本轮先打通“上传 -&gt; 提取 -&gt; 真实分析 -&gt; 结果阅读”最小闭环。</li>
+              <li>本轮已同时收住“admin 真实分析”与“viewer 缓存体验”的页面边界。</li>
               <li>
-                后续 issue 会按“viewer 缓存体验 {'->'} 里程碑文档收束”继续推进。
+                后续 issue 会按“里程碑文档收束”继续推进。
               </li>
             </ul>
           </DisplaySurfaceCard>

--- a/apps/admin/components/ai-cached-reports-panel.spec.tsx
+++ b/apps/admin/components/ai-cached-reports-panel.spec.tsx
@@ -1,0 +1,151 @@
+'use client';
+
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { AiCachedReportsPanel } from './ai-cached-reports-panel';
+
+afterEach(() => {
+  cleanup();
+});
+
+const cachedReports = [
+  {
+    reportId: 'jd-match-demo',
+    scenario: 'jd-match',
+    locale: 'zh',
+    summary: '缓存版 JD 匹配预览',
+    generator: 'mock-cache' as const,
+    createdAt: '2026-03-27T00:00:00.000Z',
+  },
+  {
+    reportId: 'resume-review-demo',
+    scenario: 'resume-review',
+    locale: 'en',
+    summary: 'Cached resume review preview',
+    generator: 'mock-cache' as const,
+    createdAt: '2026-03-27T00:00:00.000Z',
+  },
+];
+
+const reportDetails = {
+  'jd-match-demo': {
+    reportId: 'jd-match-demo',
+    cacheKey: 'jd-match:zh:demo',
+    scenario: 'jd-match' as const,
+    locale: 'zh' as const,
+    sourceHash: 'demo',
+    inputPreview: 'NestJS React TypeScript',
+    summary: '缓存版 JD 匹配预览',
+    sections: [
+      {
+        key: 'match-overview',
+        title: '匹配概览',
+        bullets: ['当前输入已经覆盖 NestJS 与 React。'],
+      },
+    ],
+    generator: 'mock-cache' as const,
+    createdAt: '2026-03-27T00:00:00.000Z',
+  },
+  'resume-review-demo': {
+    reportId: 'resume-review-demo',
+    cacheKey: 'resume-review:en:demo',
+    scenario: 'resume-review' as const,
+    locale: 'en' as const,
+    sourceHash: 'demo',
+    inputPreview: 'Resume review for full-stack engineer',
+    summary: 'Cached resume review preview',
+    sections: [
+      {
+        key: 'strengths',
+        title: 'Strengths',
+        bullets: ['Content blocks are easy to reuse in tutorial mode.'],
+      },
+    ],
+    generator: 'mock-cache' as const,
+    createdAt: '2026-03-27T00:00:00.000Z',
+  },
+};
+
+describe('AiCachedReportsPanel', () => {
+  it('should show viewer-specific cache guidance and load first cached report', async () => {
+    const fetchReportList = vi.fn().mockResolvedValue(cachedReports);
+    const fetchReportDetail = vi
+      .fn()
+      .mockImplementation(({ reportId }: { reportId: keyof typeof reportDetails }) =>
+        Promise.resolve(reportDetails[reportId]),
+      );
+
+    render(
+      <AiCachedReportsPanel
+        accessToken="viewer-token"
+        apiBaseUrl="http://localhost:5577"
+        fetchReportDetail={fetchReportDetail}
+        fetchReportList={fetchReportList}
+        isViewerExperience
+      />,
+    );
+
+    expect(
+      screen.getByText(
+        'viewer 当前只读取缓存或预设分析结果，不能上传文件，也不能触发新的真实分析请求。',
+      ),
+    ).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(fetchReportList).toHaveBeenCalledWith({
+        accessToken: 'viewer-token',
+        apiBaseUrl: 'http://localhost:5577',
+      });
+    });
+
+    expect(await screen.findByText('缓存版 JD 匹配预览')).toBeInTheDocument();
+    expect(screen.getByText('场景：JD 匹配分析')).toBeInTheDocument();
+    expect(screen.getByText('匹配概览')).toBeInTheDocument();
+  });
+
+  it('should switch cached report detail when another report is selected', async () => {
+    const user = userEvent.setup();
+    const fetchReportList = vi.fn().mockResolvedValue(cachedReports);
+    const fetchReportDetail = vi
+      .fn()
+      .mockImplementation(({ reportId }: { reportId: keyof typeof reportDetails }) =>
+        Promise.resolve(reportDetails[reportId]),
+      );
+
+    render(
+      <AiCachedReportsPanel
+        accessToken="viewer-token"
+        apiBaseUrl="http://localhost:5577"
+        fetchReportDetail={fetchReportDetail}
+        fetchReportList={fetchReportList}
+        isViewerExperience={false}
+      />,
+    );
+
+    expect(await screen.findByText('缓存版 JD 匹配预览')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: '简历优化建议' }));
+
+    expect(await screen.findByText('Cached resume review preview')).toBeInTheDocument();
+    expect(screen.getByText('Strengths')).toBeInTheDocument();
+  });
+
+  it('should show error feedback when cached reports fail to load', async () => {
+    const fetchReportList = vi
+      .fn()
+      .mockRejectedValue(new Error('缓存报告列表加载失败'));
+
+    render(
+      <AiCachedReportsPanel
+        accessToken="viewer-token"
+        apiBaseUrl="http://localhost:5577"
+        fetchReportList={fetchReportList}
+        isViewerExperience
+      />,
+    );
+
+    expect(await screen.findByText('缓存报告列表加载失败')).toBeInTheDocument();
+  });
+});

--- a/apps/admin/components/ai-cached-reports-panel.tsx
+++ b/apps/admin/components/ai-cached-reports-panel.tsx
@@ -1,0 +1,233 @@
+'use client';
+
+import {
+  DisplayPill,
+  DisplaySectionIntro,
+  DisplaySurfaceCard,
+} from '@my-resume/ui/display';
+import { useEffect, useState } from 'react';
+
+import {
+  fetchCachedAiWorkbenchReport,
+  fetchCachedAiWorkbenchReports,
+} from '../lib/ai-workbench-api';
+import {
+  AiWorkbenchCachedReportSummary,
+  AiWorkbenchReport,
+} from '../lib/ai-workbench-types';
+
+interface AiCachedReportsPanelProps {
+  accessToken: string;
+  apiBaseUrl: string;
+  isViewerExperience: boolean;
+  fetchReportDetail?: typeof fetchCachedAiWorkbenchReport;
+  fetchReportList?: typeof fetchCachedAiWorkbenchReports;
+}
+
+const scenarioLabels = {
+  'jd-match': 'JD 匹配分析',
+  'resume-review': '简历优化建议',
+  'offer-compare': 'Offer 对比建议',
+} as const;
+
+function formatLocale(locale: AiWorkbenchReport['locale']): string {
+  return locale === 'zh' ? '中文' : 'English';
+}
+
+function formatGenerator(generator: AiWorkbenchReport['generator']): string {
+  return generator === 'mock-cache' ? '缓存 / 预设' : '真实 Provider';
+}
+
+export function AiCachedReportsPanel({
+  accessToken,
+  apiBaseUrl,
+  isViewerExperience,
+  fetchReportDetail = fetchCachedAiWorkbenchReport,
+  fetchReportList = fetchCachedAiWorkbenchReports,
+}: AiCachedReportsPanelProps) {
+  const [reports, setReports] = useState<AiWorkbenchCachedReportSummary[]>([]);
+  const [activeReportId, setActiveReportId] = useState<string | null>(null);
+  const [activeReport, setActiveReport] = useState<AiWorkbenchReport | null>(null);
+  const [loadingState, setLoadingState] = useState<'loading' | 'ready' | 'error'>(
+    'loading',
+  );
+  const [detailLoading, setDetailLoading] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadReports() {
+      try {
+        setLoadingState('loading');
+        setErrorMessage(null);
+
+        const nextReports = await fetchReportList({
+          apiBaseUrl,
+          accessToken,
+        });
+
+        if (cancelled) {
+          return;
+        }
+
+        setReports(nextReports);
+
+        if (nextReports.length === 0) {
+          setActiveReportId(null);
+          setActiveReport(null);
+          setLoadingState('ready');
+          return;
+        }
+
+        const nextActiveReportId = nextReports[0].reportId;
+        setActiveReportId(nextActiveReportId);
+
+        const detail = await fetchReportDetail({
+          apiBaseUrl,
+          accessToken,
+          reportId: nextActiveReportId,
+        });
+
+        if (cancelled) {
+          return;
+        }
+
+        setActiveReport(detail);
+        setLoadingState('ready');
+      } catch (error) {
+        if (cancelled) {
+          return;
+        }
+
+        setLoadingState('error');
+        setActiveReport(null);
+        setErrorMessage(
+          error instanceof Error ? error.message : '缓存报告加载失败，请稍后重试',
+        );
+      }
+    }
+
+    void loadReports();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [accessToken, apiBaseUrl, fetchReportDetail, fetchReportList]);
+
+  async function handleSelectReport(reportId: string) {
+    if (reportId === activeReportId) {
+      return;
+    }
+
+    setActiveReportId(reportId);
+    setDetailLoading(true);
+    setErrorMessage(null);
+
+    try {
+      const detail = await fetchReportDetail({
+        apiBaseUrl,
+        accessToken,
+        reportId,
+      });
+
+      setActiveReport(detail);
+    } catch (error) {
+      setActiveReport(null);
+      setErrorMessage(
+        error instanceof Error ? error.message : '缓存报告详情加载失败，请稍后重试',
+      );
+    } finally {
+      setDetailLoading(false);
+    }
+  }
+
+  return (
+    <section className="card stack">
+      <div>
+        <p className="eyebrow">缓存体验</p>
+        <h2>缓存报告与预设体验</h2>
+        <p className="muted">
+          当前阶段先把 viewer 的只读体验收住，让“能看缓存、不能触发真实分析”的边界更清晰。
+        </p>
+      </div>
+
+      {isViewerExperience ? (
+        <div className="readonly-box">
+          viewer 当前只读取缓存或预设分析结果，不能上传文件，也不能触发新的真实分析请求。
+        </div>
+      ) : (
+        <div className="dashboard-inline-note">
+          admin 也可在这里回看缓存或预设结果，用于对照真实分析输出。
+        </div>
+      )}
+
+      {loadingState === 'loading' ? (
+        <p className="muted">正在加载缓存报告...</p>
+      ) : null}
+
+      {errorMessage ? <p className="error-text">{errorMessage}</p> : null}
+
+      {loadingState === 'ready' && reports.length === 0 ? (
+        <p className="muted">当前还没有可阅读的缓存报告。</p>
+      ) : null}
+
+      {reports.length > 0 ? (
+        <div className="cached-report-list">
+          {reports.map((report) => (
+            <button
+              className={activeReportId === report.reportId ? 'secondary-button' : ''}
+              key={report.reportId}
+              onClick={() => void handleSelectReport(report.reportId)}
+              type="button"
+            >
+              {scenarioLabels[report.scenario]}
+            </button>
+          ))}
+        </div>
+      ) : null}
+
+      {detailLoading ? <p className="muted">正在切换缓存报告...</p> : null}
+
+      {activeReport ? (
+        <div className="preview-stack">
+          <div className="dashboard-badge-row">
+            <DisplayPill>
+              场景：{scenarioLabels[activeReport.scenario]}
+            </DisplayPill>
+            <DisplayPill>语言：{formatLocale(activeReport.locale)}</DisplayPill>
+            <DisplayPill>来源：{formatGenerator(activeReport.generator)}</DisplayPill>
+          </div>
+
+          <DisplaySurfaceCard className="analysis-summary-card">
+            <DisplaySectionIntro
+              compact
+              description={activeReport.inputPreview}
+              eyebrow="缓存摘要"
+              title="当前报告概览"
+              titleAs="h3"
+            />
+            <div className="analysis-text-block">{activeReport.summary}</div>
+          </DisplaySurfaceCard>
+
+          <div className="analysis-section-grid">
+            {activeReport.sections.map((section) => (
+              <DisplaySurfaceCard
+                as="article"
+                className="analysis-section-card"
+                key={section.key}
+              >
+                <DisplaySectionIntro compact title={section.title} titleAs="h3" />
+                <ul className="muted-list">
+                  {section.bullets.map((bullet) => (
+                    <li key={`${section.key}-${bullet}`}>{bullet}</li>
+                  ))}
+                </ul>
+              </DisplaySurfaceCard>
+            ))}
+          </div>
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/admin/lib/ai-workbench-api.spec.ts
+++ b/apps/admin/lib/ai-workbench-api.spec.ts
@@ -1,6 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
+  fetchCachedAiWorkbenchReport,
+  fetchCachedAiWorkbenchReports,
   fetchAiWorkbenchRuntime,
   triggerAiWorkbenchAnalysis,
 } from './ai-workbench-api';
@@ -118,5 +120,84 @@ describe('ai workbench api client', () => {
         content: 'NestJS React TypeScript',
       }),
     ).rejects.toThrow('Provider request failed');
+  });
+
+  it('should fetch cached report summaries for read-only viewer experience', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          reports: [
+            {
+              reportId: 'jd-match-demo',
+              scenario: 'jd-match',
+              locale: 'zh',
+              summary: '缓存版 JD 匹配预览',
+              generator: 'mock-cache',
+              createdAt: '2026-03-27T00:00:00.000Z',
+            },
+          ],
+        }),
+      }),
+    );
+
+    const response = await fetchCachedAiWorkbenchReports({
+      apiBaseUrl: 'http://localhost:5577',
+      accessToken: 'viewer-token',
+    });
+
+    expect(fetch).toHaveBeenCalledWith(
+      'http://localhost:5577/ai/reports/cache',
+      expect.objectContaining({
+        headers: {
+          Authorization: 'Bearer viewer-token',
+        },
+      }),
+    );
+    expect(response[0]?.reportId).toBe('jd-match-demo');
+  });
+
+  it('should fetch cached report detail by report id', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          reportId: 'jd-match-demo',
+          cacheKey: 'jd-match:zh:demo',
+          scenario: 'jd-match',
+          locale: 'zh',
+          sourceHash: 'demo',
+          inputPreview: 'NestJS React TypeScript',
+          summary: '缓存版 JD 匹配预览',
+          sections: [
+            {
+              key: 'match-overview',
+              title: '匹配概览',
+              bullets: ['当前输入已经覆盖 NestJS 与 React。'],
+            },
+          ],
+          generator: 'mock-cache',
+          createdAt: '2026-03-27T00:00:00.000Z',
+        }),
+      }),
+    );
+
+    const response = await fetchCachedAiWorkbenchReport({
+      apiBaseUrl: 'http://localhost:5577',
+      accessToken: 'viewer-token',
+      reportId: 'jd-match-demo',
+    });
+
+    expect(fetch).toHaveBeenCalledWith(
+      'http://localhost:5577/ai/reports/cache/jd-match-demo',
+      expect.objectContaining({
+        headers: {
+          Authorization: 'Bearer viewer-token',
+        },
+      }),
+    );
+    expect(response.sections[0]?.title).toBe('匹配概览');
   });
 });

--- a/apps/admin/lib/ai-workbench-api.ts
+++ b/apps/admin/lib/ai-workbench-api.ts
@@ -1,5 +1,7 @@
 import {
+  AiWorkbenchCachedReportSummary,
   AiWorkbenchLocale,
+  AiWorkbenchReport,
   AiWorkbenchRuntimeSummary,
   AiWorkbenchScenario,
   TriggerAiWorkbenchAnalysisResult,
@@ -65,4 +67,45 @@ export async function triggerAiWorkbenchAnalysis(
   }
 
   return (await response.json()) as TriggerAiWorkbenchAnalysisResult;
+}
+
+export async function fetchCachedAiWorkbenchReports(
+  input: FetchAiWorkbenchRuntimeInput,
+): Promise<AiWorkbenchCachedReportSummary[]> {
+  const response = await fetch(joinApiUrl(input.apiBaseUrl, '/ai/reports/cache'), {
+    headers: {
+      Authorization: `Bearer ${input.accessToken}`,
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error('缓存报告列表加载失败');
+  }
+
+  const payload = (await response.json()) as {
+    reports: AiWorkbenchCachedReportSummary[];
+  };
+
+  return payload.reports;
+}
+
+export async function fetchCachedAiWorkbenchReport(
+  input: FetchAiWorkbenchRuntimeInput & {
+    reportId: string;
+  },
+): Promise<AiWorkbenchReport> {
+  const response = await fetch(
+    joinApiUrl(input.apiBaseUrl, `/ai/reports/cache/${input.reportId}`),
+    {
+      headers: {
+        Authorization: `Bearer ${input.accessToken}`,
+      },
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error('缓存报告详情加载失败');
+  }
+
+  return (await response.json()) as AiWorkbenchReport;
 }

--- a/apps/admin/lib/ai-workbench-types.ts
+++ b/apps/admin/lib/ai-workbench-types.ts
@@ -32,6 +32,15 @@ export interface AiWorkbenchReport {
   createdAt: string;
 }
 
+export interface AiWorkbenchCachedReportSummary {
+  reportId: string;
+  scenario: AiWorkbenchScenario;
+  locale: AiWorkbenchLocale;
+  summary: string;
+  generator: AiWorkbenchReportGenerator;
+  createdAt: string;
+}
+
 export interface TriggerAiWorkbenchAnalysisResult {
   cached: boolean;
   report: AiWorkbenchReport;

--- a/docs/30-开发日志/M10-issue-50-review-ready-前关键通路校验.md
+++ b/docs/30-开发日志/M10-issue-50-review-ready-前关键通路校验.md
@@ -1,0 +1,102 @@
+# M10 / issue-50 review-ready 前关键通路校验
+
+- Issue：`#89`
+- 里程碑：`M10 AI 工作台与真实分析：从基础接口到后台闭环`
+- 分支：`fys-dev/feat-m10-issue-50-viewer-cache-boundary`
+- 日期：`2026-03-27`
+
+## 本轮主承诺
+
+把 `viewer` 的 AI 体验边界真正收住：
+
+- viewer 只能阅读缓存或预设分析结果
+- viewer 不能上传文件
+- viewer 不能触发真实分析
+- 页面级提示能把这层边界讲清楚
+
+本轮不承诺：
+
+- 新角色模型
+- 复杂权限系统改造
+- auth 主模型改写
+- 新的 AI 历史系统
+
+## 关键通路
+
+### 1. viewer 缓存读取通路
+
+要证明的事情：
+
+- viewer 登录后不只是看到“只读占位”
+- 页面能真正从现有缓存接口读取列表与详情
+- 缓存结果可阅读、可切换
+
+证据落点：
+
+- `apps/admin/lib/ai-workbench-api.ts`
+- `apps/admin/lib/ai-workbench-api.spec.ts`
+- `apps/admin/components/ai-cached-reports-panel.tsx`
+- `apps/admin/components/ai-cached-reports-panel.spec.tsx`
+
+当前结论：
+
+- 已打通。前端已接入 `/ai/reports/cache` 与 `/ai/reports/cache/:reportId`
+- 缓存报告面板可加载首条报告并切换详情
+- viewer 进入页面后可获得真实只读体验，不再只有说明文字
+
+### 2. viewer 禁止触发通路
+
+要证明的事情：
+
+- viewer 仍不能上传文件
+- viewer 仍不能触发真实分析
+- 页面顺序和提示语能把“能做什么、不能做什么”讲清楚
+
+证据落点：
+
+- `apps/admin/components/admin-ai-workbench-shell.tsx`
+- `apps/admin/components/admin-ai-workbench-shell.spec.tsx`
+- `apps/server/test/ai-report-role-access.e2e-spec.ts`
+
+当前结论：
+
+- 已满足。viewer 会优先看到缓存结果面板
+- 上传面板和真实分析面板都保持只读提示
+- `server` 侧回归继续证明 viewer 读缓存可以、触发新请求不行
+
+### 3. admin / viewer 边界连续性通路
+
+要证明的事情：
+
+- 新增 viewer 缓存体验后，不会把上一轮 admin 真实分析闭环带坏
+- 页面边界更清晰，而不是把两套体验混成一页无差别入口
+
+证据落点：
+
+- `pnpm --filter @my-resume/admin test`
+- `pnpm --filter @my-resume/admin typecheck`
+- `pnpm --filter @my-resume/admin build`
+- `pnpm --filter @my-resume/server test:e2e -- test/ai-report-role-access.e2e-spec.ts`
+- `pnpm --filter @my-resume/server typecheck`
+- `pnpm --filter @my-resume/server build`
+
+当前结论：
+
+- 已满足。`admin` 仍保留上传与真实分析入口
+- `viewer` 则收敛到缓存体验
+- `admin / server` 自动化验证全部通过
+
+## 是否足以进入 review-ready
+
+可以进入。
+
+原因：
+
+- 本轮主承诺已经完成
+- 三条关键通路均有对应代码与测试
+- 没有把 M10 里程碑最后的文档收束任务混进当前 issue
+
+## 进入 review-ready 前仍需注意
+
+- 当前缓存报告列表默认按第一条报告进入详情，后续若缓存结果继续增长，可再考虑更明确的筛选与排序，但这不属于当前 issue
+- 这一轮没有新增人工验证，原因是 viewer 权限边界与缓存读取已被页面测试和服务端 E2E 双层覆盖

--- a/docs/30-开发日志/M10-issue-50-viewer-缓存体验与权限收束.md
+++ b/docs/30-开发日志/M10-issue-50-viewer-缓存体验与权限收束.md
@@ -1,0 +1,229 @@
+# M10 / issue-50 开发日志：viewer 缓存体验与权限收束
+
+- Issue：`#89`
+- 里程碑：`M10 AI 工作台与真实分析：从基础接口到后台闭环`
+- 分支：`fys-dev/feat-m10-issue-50-viewer-cache-boundary`
+- 日期：`2026-03-27`
+
+## 背景
+
+`issue-49` 已经把管理员真实分析闭环接通了，但如果到这里就停下，M10 仍然有一个明显缺口：
+
+- admin 已能上传、分析、阅读结果
+- viewer 还只是“不能做”的说明，没有真正“能体验什么”的页面闭环
+
+这会带来两个问题：
+
+- AI 成本控制边界不够直观
+- 教程表达容易重新滑回“只有管理员能玩，viewer 只是占位”的状态
+
+所以这一轮要做的是，把 viewer 的只读缓存体验真正落在页面上。
+
+## 本次目标
+
+- 让 viewer 只能读取缓存或预设分析结果
+- 禁止 viewer 上传文件和触发真实分析
+- 在页面级把边界讲清楚
+
+## 非目标
+
+- 不新增角色
+- 不做复杂权限系统改造
+- 不改写现有 auth 主模型
+- 不做新的分析历史系统
+
+## TDD / 测试设计
+
+### 1. 先补缓存报告客户端测试
+
+更新：
+
+- `apps/admin/lib/ai-workbench-api.spec.ts`
+
+先锁定：
+
+- `/ai/reports/cache` 列表读取
+- `/ai/reports/cache/:reportId` 详情读取
+
+### 2. 再补缓存结果面板测试
+
+新增：
+
+- `apps/admin/components/ai-cached-reports-panel.spec.tsx`
+
+先锁定：
+
+- viewer 提示文案
+- 首条缓存报告自动加载
+- 切换另一条缓存报告时可更新详情
+- 加载失败时有错误反馈
+
+### 3. 用工作台壳测试保护角色差异
+
+更新：
+
+- `apps/admin/components/admin-ai-workbench-shell.spec.tsx`
+
+重点确认：
+
+- `admin` 仍看到真实分析链路
+- `viewer` 先看到缓存体验入口
+- `viewer` 继续只能看到上传 / 分析的只读提示
+
+### 4. 服务端权限回归
+
+复用：
+
+- `apps/server/test/ai-report-role-access.e2e-spec.ts`
+
+目的是继续证明：
+
+- viewer 读缓存可以
+- viewer 触发新请求不行
+
+## 实际改动
+
+### 1. 扩展 AI 工作台缓存客户端
+
+更新：
+
+- `apps/admin/lib/ai-workbench-types.ts`
+- `apps/admin/lib/ai-workbench-api.ts`
+- `apps/admin/lib/ai-workbench-api.spec.ts`
+
+这一步把 viewer 真正需要的两类读取能力补到了前端契约里：
+
+- 缓存报告列表
+- 缓存报告详情
+
+这样缓存体验就不需要靠硬编码假数据，而是继续走 `apps/server` 的统一业务接口。
+
+### 2. 新增缓存结果面板
+
+新增：
+
+- `apps/admin/components/ai-cached-reports-panel.tsx`
+- `apps/admin/components/ai-cached-reports-panel.spec.tsx`
+
+当前面板做的事情很聚焦：
+
+- 读取缓存报告列表
+- 自动打开第一条缓存报告
+- 点击切换其他缓存报告
+- 展示场景、语言、来源和分段结果
+- 在 viewer / admin 两种语义下显示不同的顶部说明
+
+这样 viewer 终于有一条真正可用的只读体验主线，而不是只看到“权限不足”的空盒子。
+
+### 3. 调整 AI 工作台页面顺序与提示
+
+更新：
+
+- `apps/admin/components/admin-ai-workbench-shell.tsx`
+- `apps/admin/components/admin-ai-workbench-shell.spec.tsx`
+- `apps/admin/app/globals.css`
+
+这轮一个重要的教学判断，是不只加一个新面板，而是把 viewer 的页面顺序也一起收住：
+
+- viewer 先看到“缓存结果体验”
+- 再看到上传与真实分析的只读提示
+
+这样体验顺序更自然，也更符合当前成本控制策略：
+
+- 先告诉 viewer “你可以看什么”
+- 再说明 “你不能触发什么”
+
+后台说明文案也同步收口到更准确的状态，避免继续保留上一轮只适用于 `issue-49` 的描述。
+
+## Review 记录
+
+### 是否符合当前 Issue 与里程碑目标
+
+符合。
+
+本轮只完成：
+
+- viewer 缓存读取体验
+- 页面级边界收束
+- 现有权限回归验证
+
+没有越界去做：
+
+- auth 模型扩张
+- 新角色体系
+- 分析历史持久化
+- M10 里程碑文档收束
+
+### 是否存在可抽离的组件、公共函数、skills 或其他复用能力
+
+本轮已经完成当前最合适的一层抽离：
+
+- 缓存读取客户端继续留在 `ai-workbench-api.ts`
+- 缓存结果体验沉淀为 `AiCachedReportsPanel`
+
+暂时不继续抽更高层的“只读 AI 页面模板”，因为当前后台仍然只有单个 AI 工作台页面，过早抽象会让教程变虚。
+
+### 本次最重要的边界判断
+
+viewer 体验不能只停留在“不允许”，必须落成“允许看什么”。
+
+这是这轮最重要的教学价值：
+
+- 成本控制不是只靠禁止按钮
+- 还要给出一条可演示、可解释、可复用的只读体验链路
+
+## 自测结果
+
+已执行：
+
+- `pnpm --filter @my-resume/admin test`
+- `pnpm --filter @my-resume/admin typecheck`
+- `pnpm --filter @my-resume/admin build`
+- `pnpm --filter @my-resume/server test:e2e -- test/ai-report-role-access.e2e-spec.ts`
+- `pnpm --filter @my-resume/server typecheck`
+- `pnpm --filter @my-resume/server build`
+
+结果：
+
+- `admin` 页面测试、类型检查、构建通过
+- `server` viewer / admin AI 权限回归、类型检查、构建通过
+
+补充说明：
+
+- 本轮没有额外做人工点击验证，因为页面缓存体验、viewer 只读边界与服务端权限回归都已被双层自动化覆盖
+
+## 遇到的问题
+
+### 1. 如果只加缓存面板，不调整页面顺序，viewer 体验仍然会显得别扭
+
+问题：
+
+如果 viewer 进来先看到两个只读占位，再看到缓存结果面板，虽然功能上成立，但教学表达还是会偏向“先被拒绝，再告诉你还能干什么”。
+
+处理：
+
+- 把 viewer 的缓存面板放到工作台主列最前面
+- 让 viewer 先看到体验入口
+
+### 2. viewer 缓存体验和 admin 真实分析容易写成两套完全割裂的页面
+
+问题：
+
+如果完全分成两套页面，教程会更碎，后续也更难解释为什么两者仍属于同一个 AI 工作台。
+
+处理：
+
+- 仍保留单一工作台壳
+- 只在页面内按角色切换体验顺序和入口可用性
+
+## 可沉淀为教程 / 博客的点
+
+- AI 成本控制为什么不能只靠“禁用按钮”
+- 如何给 viewer 设计一条真正可用的缓存体验链路
+- 为什么单一 AI 工作台壳比拆成两套页面更适合当前教程型仓库
+- 如何用页面顺序表达角色边界，而不只是靠文案解释
+
+## 后续待办
+
+- 关闭 `issue-50`
+- 进入 `issue-51`：M10 教程大纲与里程碑收束


### PR DESCRIPTION
## 背景

M10 如果只把 admin 真实分析链路接通，而不把 viewer 的只读体验边界收住，AI 成本控制和教程表达都会再次变乱。
这一轮把 viewer 的缓存体验真正落到页面上。

## 本次改动

- 扩展缓存报告列表与详情客户端
- 新增 AiCachedReportsPanel，承接 viewer 的只读缓存体验
- 调整 AI 工作台壳内的 viewer / admin 页面顺序与提示
- 补 review-ready 校验记录与开发日志

## 非目标

- 不新增角色
- 不做复杂权限系统改造
- 不改写现有 auth 主模型
- 不做新的分析历史系统

## 测试

- pnpm --filter @my-resume/admin test
- pnpm --filter @my-resume/admin typecheck
- pnpm --filter @my-resume/admin build
- pnpm --filter @my-resume/server test:e2e -- test/ai-report-role-access.e2e-spec.ts
- pnpm --filter @my-resume/server typecheck
- pnpm --filter @my-resume/server build

## 文档

- docs/30-开发日志/M10-issue-50-review-ready-前关键通路校验.md
- docs/30-开发日志/M10-issue-50-viewer-缓存体验与权限收束.md

Closes #89
