### PR TITLE
[Feature] M12 / issue-117 AI 简历智能分析与结构化草稿应用

### DIFF
--- a/apps/admin/components/ai-analysis-panel.spec.tsx
+++ b/apps/admin/components/ai-analysis-panel.spec.tsx
@@ -6,10 +6,50 @@ import { useState } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { AiAnalysisPanel } from './ai-analysis-panel';
+import type { StandardResume } from '../lib/resume-types';
 
 afterEach(() => {
   cleanup();
 });
+
+function createTestResume(): StandardResume {
+  return {
+    meta: {
+      slug: 'standard-resume',
+      version: 1,
+      defaultLocale: 'zh',
+      locales: ['zh', 'en'],
+    },
+    profile: {
+      fullName: {
+        zh: '付寅生',
+        en: 'Yinsheng Fu',
+      },
+      headline: {
+        zh: '前端工程师',
+        en: 'Frontend Engineer',
+      },
+      summary: {
+        zh: '原始中文摘要',
+        en: 'Original English summary',
+      },
+      location: {
+        zh: '成都',
+        en: 'Chengdu',
+      },
+      email: 'demo@example.com',
+      phone: '123456789',
+      website: 'https://example.com',
+      links: [],
+      interests: [],
+    },
+    education: [],
+    experiences: [],
+    projects: [],
+    skills: [],
+    highlights: [],
+  };
+}
 
 const runtimeSummary = {
   provider: 'qiniu',
@@ -20,7 +60,9 @@ const runtimeSummary = {
 
 function ControlledAnalysisPanel(props: {
   canAnalyze: boolean;
+  generateResumeOptimization?: typeof import('../lib/ai-workbench-api').generateAiResumeOptimization;
   helperMessage?: string | null;
+  saveDraft?: typeof import('../lib/resume-draft-api').updateDraftResume;
   triggerAnalysis?: typeof import('../lib/ai-workbench-api').triggerAiWorkbenchAnalysis;
   initialContent?: string;
 }) {
@@ -35,6 +77,8 @@ function ControlledAnalysisPanel(props: {
       helperMessage={props.helperMessage}
       onContentChange={setContent}
       runtimeSummary={runtimeSummary}
+      generateResumeOptimization={props.generateResumeOptimization}
+      saveDraft={props.saveDraft}
       triggerAnalysis={props.triggerAnalysis}
     />
   );
@@ -152,5 +196,102 @@ describe('AiAnalysisPanel', () => {
       await screen.findByText('请先输入分析内容，或先通过文件提取生成输入文本。'),
     ).toBeInTheDocument();
     expect(triggerAnalysis).not.toHaveBeenCalled();
+  });
+
+  it('should generate a structured suggestion and apply it to the draft', async () => {
+    const user = userEvent.setup();
+    const generateResumeOptimization = vi.fn().mockResolvedValue({
+      summary: '已生成结构化建议稿',
+      focusAreas: ['强化摘要', '补强项目亮点'],
+      changedModules: ['profile', 'projects'],
+      suggestedResume: {
+        ...createTestResume(),
+        profile: {
+          ...createTestResume().profile,
+          summary: {
+            zh: '新的中文摘要',
+            en: 'New English summary',
+          },
+        },
+      },
+      providerSummary: {
+        provider: 'qiniu',
+        model: 'deepseek-v3',
+        mode: 'openai-compatible',
+      },
+    });
+    const saveDraft = vi.fn().mockResolvedValue({
+      status: 'draft',
+      resume: createTestResume(),
+      updatedAt: '2026-03-30T00:00:00.000Z',
+    });
+
+    render(
+      <ControlledAnalysisPanel
+        canAnalyze
+        generateResumeOptimization={generateResumeOptimization}
+        initialContent="请根据 React 和 Next.js 岗位优化当前简历"
+        saveDraft={saveDraft}
+      />,
+    );
+
+    await user.selectOptions(screen.getByLabelText('分析场景'), 'resume-review');
+    await user.click(screen.getByRole('button', { name: '生成结构化简历建议' }));
+
+    await waitFor(() => {
+      expect(generateResumeOptimization).toHaveBeenCalledWith({
+        apiBaseUrl: 'http://localhost:5577',
+        accessToken: 'demo-token',
+        instruction: '请根据 React 和 Next.js 岗位优化当前简历',
+        locale: 'zh',
+      });
+    });
+
+    expect(await screen.findByText('已生成结构化建议稿')).toBeInTheDocument();
+    expect(screen.getByText('模块：profile')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: '一键应用到当前草稿' }));
+
+    await waitFor(() => {
+      expect(saveDraft).toHaveBeenCalledWith({
+        apiBaseUrl: 'http://localhost:5577',
+        accessToken: 'demo-token',
+        resume: expect.objectContaining({
+          profile: expect.objectContaining({
+            summary: {
+              zh: '新的中文摘要',
+              en: 'New English summary',
+            },
+          }),
+        }),
+      });
+    });
+
+    expect(
+      await screen.findByText(
+        'AI 建议稿已应用到当前草稿。公开站内容不会自动变化，仍需手动发布。',
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('should restrict structured suggestion to resume-review scenario', async () => {
+    const user = userEvent.setup();
+    const generateResumeOptimization = vi.fn();
+
+    render(
+      <ControlledAnalysisPanel
+        canAnalyze
+        generateResumeOptimization={generateResumeOptimization}
+        initialContent="请根据 offer 内容给出建议"
+      />,
+    );
+
+    await user.selectOptions(screen.getByLabelText('分析场景'), 'offer-compare');
+    await user.click(screen.getByRole('button', { name: '生成结构化简历建议' }));
+
+    expect(
+      await screen.findByText('结构化简历建议当前只支持“简历优化建议”场景。'),
+    ).toBeInTheDocument();
+    expect(generateResumeOptimization).not.toHaveBeenCalled();
   });
 });

--- a/apps/admin/components/ai-analysis-panel.tsx
+++ b/apps/admin/components/ai-analysis-panel.tsx
@@ -8,14 +8,17 @@ import {
 import { useState } from 'react';
 
 import {
+  generateAiResumeOptimization,
   triggerAiWorkbenchAnalysis,
 } from '../lib/ai-workbench-api';
 import {
+  AiResumeOptimizationResult,
   AiWorkbenchLocale,
   AiWorkbenchReport,
   AiWorkbenchRuntimeSummary,
   AiWorkbenchScenario,
 } from '../lib/ai-workbench-types';
+import { updateDraftResume } from '../lib/resume-draft-api';
 
 interface AiAnalysisPanelProps {
   accessToken: string;
@@ -25,6 +28,8 @@ interface AiAnalysisPanelProps {
   helperMessage?: string | null;
   onContentChange: (value: string) => void;
   runtimeSummary: AiWorkbenchRuntimeSummary;
+  generateResumeOptimization?: typeof generateAiResumeOptimization;
+  saveDraft?: typeof updateDraftResume;
   triggerAnalysis?: typeof triggerAiWorkbenchAnalysis;
 }
 
@@ -82,6 +87,8 @@ export function AiAnalysisPanel({
   helperMessage,
   onContentChange,
   runtimeSummary,
+  generateResumeOptimization = generateAiResumeOptimization,
+  saveDraft = updateDraftResume,
   triggerAnalysis = triggerAiWorkbenchAnalysis,
 }: AiAnalysisPanelProps) {
   const [scenario, setScenario] = useState<AiWorkbenchScenario>('resume-review');
@@ -89,6 +96,16 @@ export function AiAnalysisPanel({
   const [pending, setPending] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [report, setReport] = useState<AiWorkbenchReport | null>(null);
+  const [suggestionPending, setSuggestionPending] = useState(false);
+  const [suggestionErrorMessage, setSuggestionErrorMessage] = useState<string | null>(
+    null,
+  );
+  const [suggestion, setSuggestion] =
+    useState<AiResumeOptimizationResult | null>(null);
+  const [applyPending, setApplyPending] = useState(false);
+  const [applyFeedbackMessage, setApplyFeedbackMessage] = useState<string | null>(
+    null,
+  );
 
   if (!canAnalyze) {
     return (
@@ -118,6 +135,7 @@ export function AiAnalysisPanel({
 
     setPending(true);
     setErrorMessage(null);
+    setApplyFeedbackMessage(null);
 
     try {
       const result = await triggerAnalysis({
@@ -136,6 +154,72 @@ export function AiAnalysisPanel({
       );
     } finally {
       setPending(false);
+    }
+  }
+
+  async function handleGenerateSuggestion() {
+    const normalizedContent = content.trim();
+
+    if (!normalizedContent) {
+      setSuggestionErrorMessage('请先输入 JD 或优化方向，再生成结构化建议。');
+      setSuggestion(null);
+      return;
+    }
+
+    if (scenario !== 'resume-review') {
+      setSuggestionErrorMessage('结构化简历建议当前只支持“简历优化建议”场景。');
+      setSuggestion(null);
+      return;
+    }
+
+    setSuggestionPending(true);
+    setSuggestionErrorMessage(null);
+    setApplyFeedbackMessage(null);
+
+    try {
+      const result = await generateResumeOptimization({
+        apiBaseUrl,
+        accessToken,
+        instruction: normalizedContent,
+        locale,
+      });
+
+      setSuggestion(result);
+    } catch (error) {
+      setSuggestion(null);
+      setSuggestionErrorMessage(
+        error instanceof Error ? error.message : '结构化简历建议生成失败，请稍后重试',
+      );
+    } finally {
+      setSuggestionPending(false);
+    }
+  }
+
+  async function handleApplySuggestion() {
+    if (!suggestion) {
+      return;
+    }
+
+    setApplyPending(true);
+    setSuggestionErrorMessage(null);
+    setApplyFeedbackMessage(null);
+
+    try {
+      await saveDraft({
+        apiBaseUrl,
+        accessToken,
+        resume: suggestion.suggestedResume,
+      });
+
+      setApplyFeedbackMessage(
+        'AI 建议稿已应用到当前草稿。公开站内容不会自动变化，仍需手动发布。',
+      );
+    } catch (error) {
+      setSuggestionErrorMessage(
+        error instanceof Error ? error.message : 'AI 建议稿应用失败，请稍后重试',
+      );
+    } finally {
+      setApplyPending(false);
     }
   }
 
@@ -199,10 +283,23 @@ export function AiAnalysisPanel({
         ) : null}
 
         {errorMessage ? <p className="error-text">{errorMessage}</p> : null}
+        {suggestionErrorMessage ? (
+          <p className="error-text">{suggestionErrorMessage}</p>
+        ) : null}
+        {applyFeedbackMessage ? (
+          <p className="dashboard-inline-note">{applyFeedbackMessage}</p>
+        ) : null}
 
         <div className="dashboard-entry-actions">
           <button disabled={pending} type="submit">
             {pending ? '正在生成分析...' : '开始真实分析'}
+          </button>
+          <button
+            disabled={suggestionPending || applyPending}
+            onClick={() => void handleGenerateSuggestion()}
+            type="button"
+          >
+            {suggestionPending ? '正在生成建议稿...' : '生成结构化简历建议'}
           </button>
         </div>
       </form>
@@ -253,6 +350,65 @@ export function AiAnalysisPanel({
               </DisplaySurfaceCard>
             ))}
           </div>
+        </div>
+      ) : null}
+
+      {suggestion ? (
+        <div className="preview-stack">
+          <div className="stack">
+            <DisplaySectionIntro
+              compact
+              description="服务端已把 AI 返回的结构化 patch 合并回当前 StandardResume，并完成校验。"
+              eyebrow="结构化建议"
+              title="可一键应用的草稿建议"
+            />
+            <div className="dashboard-badge-row">
+              {suggestion.changedModules.map((module) => (
+                <DisplayPill key={module}>模块：{module}</DisplayPill>
+              ))}
+              <DisplayPill>
+                Provider：{suggestion.providerSummary.provider} /{' '}
+                {suggestion.providerSummary.model}
+              </DisplayPill>
+            </div>
+          </div>
+
+          <DisplaySurfaceCard className="analysis-summary-card">
+            <DisplaySectionIntro
+              compact
+              description="当前开源版先只做结构化改写建议和一键应用草稿，不继续扩张到历史与多版本管理。"
+              eyebrow="建议摘要"
+              title="AI 建议稿说明"
+              titleAs="h3"
+            />
+            <div className="analysis-text-block">{suggestion.summary}</div>
+            {suggestion.focusAreas.length > 0 ? (
+              <ul className="muted-list">
+                {suggestion.focusAreas.map((item) => (
+                  <li key={item}>{item}</li>
+                ))}
+              </ul>
+            ) : null}
+          </DisplaySurfaceCard>
+
+          <DisplaySurfaceCard className="card stack">
+            <DisplaySectionIntro
+              compact
+              description="一键应用会覆盖当前草稿，但不会自动发布到公开站。"
+              eyebrow="草稿应用"
+              title="将建议稿写回当前草稿"
+              titleAs="h3"
+            />
+            <div className="dashboard-entry-actions">
+              <button
+                disabled={applyPending}
+                onClick={() => void handleApplySuggestion()}
+                type="button"
+              >
+                {applyPending ? '正在应用到草稿...' : '一键应用到当前草稿'}
+              </button>
+            </div>
+          </DisplaySurfaceCard>
         </div>
       ) : null}
     </section>

--- a/apps/admin/lib/ai-workbench-api.spec.ts
+++ b/apps/admin/lib/ai-workbench-api.spec.ts
@@ -4,6 +4,7 @@ import {
   fetchCachedAiWorkbenchReport,
   fetchCachedAiWorkbenchReports,
   fetchAiWorkbenchRuntime,
+  generateAiResumeOptimization,
   triggerAiWorkbenchAnalysis,
 } from './ai-workbench-api';
 
@@ -199,5 +200,84 @@ describe('ai workbench api client', () => {
       }),
     );
     expect(response.sections[0]?.title).toBe('匹配概览');
+  });
+
+  it('should request structured resume optimization with bearer token', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          summary: '已生成结构化建议',
+          focusAreas: ['强化摘要', '补强项目亮点'],
+          changedModules: ['profile', 'projects'],
+          suggestedResume: {
+            meta: {
+              slug: 'standard-resume',
+              version: 1,
+              defaultLocale: 'zh',
+              locales: ['zh', 'en'],
+            },
+            profile: {
+              fullName: {
+                zh: '付寅生',
+                en: 'Yinsheng Fu',
+              },
+              headline: {
+                zh: '前端工程师',
+                en: 'Frontend Engineer',
+              },
+              summary: {
+                zh: '新的中文摘要',
+                en: 'New English summary',
+              },
+              location: {
+                zh: '成都',
+                en: 'Chengdu',
+              },
+              email: 'demo@example.com',
+              phone: '123456789',
+              website: 'https://example.com',
+              links: [],
+              interests: [],
+            },
+            education: [],
+            experiences: [],
+            projects: [],
+            skills: [],
+            highlights: [],
+          },
+          providerSummary: {
+            provider: 'qiniu',
+            model: 'deepseek-v3',
+            mode: 'openai-compatible',
+          },
+        }),
+      }),
+    );
+
+    const response = await generateAiResumeOptimization({
+      apiBaseUrl: 'http://localhost:5577',
+      accessToken: 'demo-token',
+      instruction: '请根据 React 和 Next.js 岗位优化当前简历',
+      locale: 'zh',
+    });
+
+    expect(fetch).toHaveBeenCalledWith(
+      'http://localhost:5577/ai/reports/resume-optimize',
+      expect.objectContaining({
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer demo-token',
+        },
+        body: JSON.stringify({
+          instruction: '请根据 React 和 Next.js 岗位优化当前简历',
+          locale: 'zh',
+        }),
+      }),
+    );
+    expect(response.changedModules).toEqual(['profile', 'projects']);
+    expect(response.suggestedResume.profile.summary.zh).toBe('新的中文摘要');
   });
 });

--- a/apps/admin/lib/ai-workbench-api.ts
+++ b/apps/admin/lib/ai-workbench-api.ts
@@ -1,4 +1,5 @@
 import {
+  AiResumeOptimizationResult,
   AiWorkbenchCachedReportSummary,
   AiWorkbenchLocale,
   AiWorkbenchReport,
@@ -15,6 +16,11 @@ interface FetchAiWorkbenchRuntimeInput {
 interface TriggerAiWorkbenchAnalysisInput extends FetchAiWorkbenchRuntimeInput {
   scenario: AiWorkbenchScenario;
   content: string;
+  locale: AiWorkbenchLocale;
+}
+
+interface GenerateAiResumeOptimizationInput extends FetchAiWorkbenchRuntimeInput {
+  instruction: string;
   locale: AiWorkbenchLocale;
 }
 
@@ -67,6 +73,39 @@ export async function triggerAiWorkbenchAnalysis(
   }
 
   return (await response.json()) as TriggerAiWorkbenchAnalysisResult;
+}
+
+export async function generateAiResumeOptimization(
+  input: GenerateAiResumeOptimizationInput,
+): Promise<AiResumeOptimizationResult> {
+  const response = await fetch(
+    joinApiUrl(input.apiBaseUrl, '/ai/reports/resume-optimize'),
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${input.accessToken}`,
+      },
+      body: JSON.stringify({
+        instruction: input.instruction,
+        locale: input.locale,
+      }),
+    },
+  );
+
+  if (!response.ok) {
+    const payload = (await response.json().catch(() => null)) as
+      | { message?: string | string[] }
+      | null;
+
+    const message = Array.isArray(payload?.message)
+      ? payload.message[0]
+      : payload?.message;
+
+    throw new Error(message || '结构化简历建议生成失败，请稍后重试');
+  }
+
+  return (await response.json()) as AiResumeOptimizationResult;
 }
 
 export async function fetchCachedAiWorkbenchReports(

--- a/apps/admin/lib/ai-workbench-types.ts
+++ b/apps/admin/lib/ai-workbench-types.ts
@@ -1,3 +1,5 @@
+import type { StandardResume } from './resume-types';
+
 export type AiWorkbenchScenario =
   | 'jd-match'
   | 'resume-review'
@@ -44,4 +46,22 @@ export interface AiWorkbenchCachedReportSummary {
 export interface TriggerAiWorkbenchAnalysisResult {
   cached: boolean;
   report: AiWorkbenchReport;
+}
+
+export type AiResumeOptimizationChangedModule =
+  | 'profile'
+  | 'experiences'
+  | 'projects'
+  | 'highlights';
+
+export interface AiResumeOptimizationResult {
+  summary: string;
+  focusAreas: string[];
+  changedModules: AiResumeOptimizationChangedModule[];
+  suggestedResume: StandardResume;
+  providerSummary: {
+    provider: string;
+    model: string;
+    mode: string;
+  };
 }

--- a/apps/server/src/modules/ai/ai-report.controller.ts
+++ b/apps/server/src/modules/ai/ai-report.controller.ts
@@ -13,6 +13,10 @@ import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { RoleCapabilitiesGuard } from '../auth/guards/role-capabilities.guard';
 import { AiService } from './ai.service';
 import {
+  AiResumeOptimizationService,
+  GenerateResumeOptimizationInput,
+} from './ai-resume-optimization.service';
+import {
   AnalysisLocale,
   AnalysisScenario,
   AnalysisReportCacheService,
@@ -23,6 +27,8 @@ interface CacheReportBody {
   content: string;
   locale?: AnalysisLocale;
 }
+
+interface ResumeOptimizationBody extends GenerateResumeOptimizationInput {}
 
 const SUPPORTED_SCENARIOS: AnalysisScenario[] = [
   'jd-match',
@@ -36,6 +42,8 @@ export class AiReportController {
   constructor(
     @Inject(AiService)
     private readonly aiService: AiService,
+    @Inject(AiResumeOptimizationService)
+    private readonly aiResumeOptimizationService: AiResumeOptimizationService,
     @Inject(AnalysisReportCacheService)
     private readonly analysisReportCacheService: AnalysisReportCacheService,
   ) {}
@@ -87,6 +95,13 @@ export class AiReportController {
         providerSummary: this.aiService.getProviderSummary(),
       }),
     };
+  }
+
+  @Post('resume-optimize')
+  @UseGuards(RoleCapabilitiesGuard)
+  @RequireCapability('canTriggerAiAnalysis')
+  async optimizeResume(@Body() body: ResumeOptimizationBody) {
+    return this.aiResumeOptimizationService.generateSuggestion(body);
   }
 
   private buildAnalysisPrompt(body: CacheReportBody): string {

--- a/apps/server/src/modules/ai/ai-resume-optimization.service.spec.ts
+++ b/apps/server/src/modules/ai/ai-resume-optimization.service.spec.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { ResumePublicationService } from '../resume/resume-publication.service';
+import { createExampleStandardResume } from '../resume/domain/standard-resume';
+import { AiService } from './ai.service';
+import { AiResumeOptimizationService } from './ai-resume-optimization.service';
+
+describe('AiResumeOptimizationService', () => {
+  it('should build a valid suggested resume in mock mode', async () => {
+    const resume = createExampleStandardResume();
+    const aiService = {
+      getProviderSummary: () => ({
+        provider: 'mock',
+        model: 'mock-resume',
+        mode: 'mock',
+      }),
+      generateText: vi.fn(),
+    } as unknown as AiService;
+    const resumePublicationService = {
+      getDraft: vi.fn().mockResolvedValue({
+        status: 'draft',
+        resume,
+        updatedAt: '2026-03-30T00:00:00.000Z',
+      }),
+    } as unknown as ResumePublicationService;
+
+    const service = new AiResumeOptimizationService(
+      aiService,
+      resumePublicationService,
+    );
+
+    const result = await service.generateSuggestion({
+      instruction: '请针对 Next.js React TypeScript 岗位优化这份简历',
+      locale: 'zh',
+    });
+
+    expect(result.providerSummary.mode).toBe('mock');
+    expect(result.summary.length).toBeGreaterThan(0);
+    expect(result.focusAreas.length).toBeGreaterThan(0);
+    expect(result.changedModules).toContain('profile');
+    expect(result.suggestedResume.profile.summary.zh).toContain('Next.js');
+  });
+
+  it('should parse provider JSON and merge it into the current resume draft', async () => {
+    const resume = createExampleStandardResume();
+    const aiService = {
+      getProviderSummary: () => ({
+        provider: 'qiniu',
+        model: 'deepseek-v3',
+        mode: 'openai-compatible',
+      }),
+      generateText: vi.fn().mockResolvedValue({
+        provider: 'qiniu',
+        model: 'deepseek-v3',
+        text: JSON.stringify({
+          summary: '已生成结构化建议',
+          focusAreas: ['强化摘要', '补强项目亮点'],
+          patch: {
+            profile: {
+              summary: {
+                zh: '新的中文摘要',
+                en: 'New English summary',
+              },
+            },
+            projects: [
+              {
+                index: 0,
+                summary: {
+                  zh: '新的项目摘要',
+                  en: 'New project summary',
+                },
+              },
+            ],
+          },
+        }),
+      }),
+    } as unknown as AiService;
+    const resumePublicationService = {
+      getDraft: vi.fn().mockResolvedValue({
+        status: 'draft',
+        resume,
+        updatedAt: '2026-03-30T00:00:00.000Z',
+      }),
+    } as unknown as ResumePublicationService;
+
+    const service = new AiResumeOptimizationService(
+      aiService,
+      resumePublicationService,
+    );
+
+    const result = await service.generateSuggestion({
+      instruction: '请增强当前简历中与 React 和 Next.js 相关的表达',
+      locale: 'zh',
+    });
+
+    expect(result.summary).toBe('已生成结构化建议');
+    expect(result.focusAreas).toEqual(['强化摘要', '补强项目亮点']);
+    expect(result.suggestedResume.profile.summary.zh).toBe('新的中文摘要');
+    expect(result.suggestedResume.projects[0]?.summary.zh).toBe('新的项目摘要');
+    expect(result.suggestedResume.profile.email).toBe(resume.profile.email);
+  });
+
+  it('should reject invalid provider payloads', async () => {
+    const resume = createExampleStandardResume();
+    const aiService = {
+      getProviderSummary: () => ({
+        provider: 'qiniu',
+        model: 'deepseek-v3',
+        mode: 'openai-compatible',
+      }),
+      generateText: vi.fn().mockResolvedValue({
+        provider: 'qiniu',
+        model: 'deepseek-v3',
+        text: '{"summary": "", "focusAreas": [], "patch": {}}',
+      }),
+    } as unknown as AiService;
+    const resumePublicationService = {
+      getDraft: vi.fn().mockResolvedValue({
+        status: 'draft',
+        resume,
+        updatedAt: '2026-03-30T00:00:00.000Z',
+      }),
+    } as unknown as ResumePublicationService;
+
+    const service = new AiResumeOptimizationService(
+      aiService,
+      resumePublicationService,
+    );
+
+    await expect(
+      service.generateSuggestion({
+        instruction: '请帮我优化简历',
+        locale: 'zh',
+      }),
+    ).rejects.toThrow('AI 返回的 summary 无效');
+  });
+});

--- a/apps/server/src/modules/ai/ai-resume-optimization.service.ts
+++ b/apps/server/src/modules/ai/ai-resume-optimization.service.ts
@@ -1,0 +1,671 @@
+import {
+  BadGatewayException,
+  BadRequestException,
+  Inject,
+  Injectable,
+} from '@nestjs/common';
+
+import { ResumePublicationService } from '../resume/resume-publication.service';
+import {
+  getStandardResumeModuleKeys,
+  isLocalizedText,
+  type LocalizedText,
+  type ResumeHighlightItem,
+  type StandardResume,
+  validateStandardResume,
+} from '../resume/domain/standard-resume';
+import { AiService } from './ai.service';
+import { type AnalysisLocale } from './analysis-report-cache.service';
+
+type ResumeOptimizationModule =
+  | 'profile'
+  | 'experiences'
+  | 'projects'
+  | 'highlights';
+
+interface ResumeOptimizationProfilePatch {
+  headline?: LocalizedText;
+  summary?: LocalizedText;
+}
+
+interface ResumeOptimizationExperiencePatch {
+  index: number;
+  summary?: LocalizedText;
+  highlights?: LocalizedText[];
+}
+
+interface ResumeOptimizationProjectPatch {
+  index: number;
+  summary?: LocalizedText;
+  highlights?: LocalizedText[];
+}
+
+interface ResumeOptimizationPatch {
+  profile?: ResumeOptimizationProfilePatch;
+  experiences?: ResumeOptimizationExperiencePatch[];
+  projects?: ResumeOptimizationProjectPatch[];
+  highlights?: ResumeHighlightItem[];
+}
+
+interface ResumeOptimizationProviderPayload {
+  summary: string;
+  focusAreas: string[];
+  patch: ResumeOptimizationPatch;
+}
+
+export interface GenerateResumeOptimizationInput {
+  instruction: string;
+  locale?: AnalysisLocale;
+}
+
+export interface GenerateResumeOptimizationResult {
+  summary: string;
+  focusAreas: string[];
+  changedModules: ResumeOptimizationModule[];
+  suggestedResume: StandardResume;
+  providerSummary: {
+    provider: string;
+    model: string;
+    mode: string;
+  };
+}
+
+function cloneResume(resume: StandardResume): StandardResume {
+  return JSON.parse(JSON.stringify(resume)) as StandardResume;
+}
+
+function normalizeInstruction(instruction: string): string {
+  return instruction.replace(/\s+/g, ' ').trim();
+}
+
+function extractKeywords(
+  instruction: string,
+  locale: AnalysisLocale,
+  limit = 3,
+): string[] {
+  const englishMatches = instruction.match(/[A-Za-z0-9.+#-]{2,}/g) ?? [];
+  const chineseMatches = instruction.match(/[\u4e00-\u9fa5]{2,}/g) ?? [];
+  const combined = [...englishMatches, ...chineseMatches].map((item) =>
+    item.trim(),
+  );
+  const unique = Array.from(new Set(combined));
+
+  if (unique.length > 0) {
+    return unique.slice(0, limit);
+  }
+
+  return locale === 'en'
+    ? ['resume', 'impact', 'delivery']
+    : ['简历', '成果', '交付'];
+}
+
+function extractJsonObject(rawText: string): string {
+  const fencedMatch = rawText.match(/```(?:json)?\s*([\s\S]*?)```/i);
+
+  if (fencedMatch?.[1]) {
+    return fencedMatch[1].trim();
+  }
+
+  const firstBrace = rawText.indexOf('{');
+  const lastBrace = rawText.lastIndexOf('}');
+
+  if (firstBrace === -1 || lastBrace === -1 || lastBrace <= firstBrace) {
+    throw new BadGatewayException('AI 未返回可解析的 JSON 结果');
+  }
+
+  return rawText.slice(firstBrace, lastBrace + 1).trim();
+}
+
+function isLocalizedTextArray(value: unknown): value is LocalizedText[] {
+  return Array.isArray(value) && value.every((item) => isLocalizedText(item));
+}
+
+function isResumeHighlightArray(value: unknown): value is ResumeHighlightItem[] {
+  return (
+    Array.isArray(value) &&
+    value.every((item) => {
+      if (!item || typeof item !== 'object') {
+        return false;
+      }
+
+      const candidate = item as Record<string, unknown>;
+
+      return (
+        isLocalizedText(candidate.title) && isLocalizedText(candidate.description)
+      );
+    })
+  );
+}
+
+function validatePatch(
+  patch: unknown,
+  resume: StandardResume,
+): ResumeOptimizationPatch {
+  if (!patch || typeof patch !== 'object') {
+    return {};
+  }
+
+  const candidate = patch as Record<string, unknown>;
+  const nextPatch: ResumeOptimizationPatch = {};
+
+  if (candidate.profile && typeof candidate.profile === 'object') {
+    const profilePatch = candidate.profile as Record<string, unknown>;
+    const nextProfilePatch: ResumeOptimizationProfilePatch = {};
+
+    if (profilePatch.headline) {
+      if (!isLocalizedText(profilePatch.headline)) {
+        throw new BadGatewayException('AI 返回的 profile.headline 结构无效');
+      }
+
+      nextProfilePatch.headline = profilePatch.headline;
+    }
+
+    if (profilePatch.summary) {
+      if (!isLocalizedText(profilePatch.summary)) {
+        throw new BadGatewayException('AI 返回的 profile.summary 结构无效');
+      }
+
+      nextProfilePatch.summary = profilePatch.summary;
+    }
+
+    if (Object.keys(nextProfilePatch).length > 0) {
+      nextPatch.profile = nextProfilePatch;
+    }
+  }
+
+  if (candidate.experiences) {
+    if (!Array.isArray(candidate.experiences)) {
+      throw new BadGatewayException('AI 返回的 experiences patch 结构无效');
+    }
+
+    nextPatch.experiences = candidate.experiences.flatMap((item) => {
+      if (!item || typeof item !== 'object') {
+        throw new BadGatewayException('AI 返回的 experiences item 结构无效');
+      }
+
+      const currentItem = item as Record<string, unknown>;
+      const index = currentItem.index;
+
+      if (typeof index !== 'number' || !Number.isInteger(index)) {
+        throw new BadGatewayException('AI 返回的 experiences index 无效');
+      }
+
+      if (index < 0 || index >= resume.experiences.length) {
+        return [];
+      }
+
+      const nextItem: ResumeOptimizationExperiencePatch = {
+        index,
+      };
+
+      if (currentItem.summary) {
+        if (!isLocalizedText(currentItem.summary)) {
+          throw new BadGatewayException('AI 返回的 experiences.summary 结构无效');
+        }
+
+        nextItem.summary = currentItem.summary;
+      }
+
+      if (currentItem.highlights) {
+        if (!isLocalizedTextArray(currentItem.highlights)) {
+          throw new BadGatewayException(
+            'AI 返回的 experiences.highlights 结构无效',
+          );
+        }
+
+        nextItem.highlights = currentItem.highlights;
+      }
+
+      return Object.keys(nextItem).length > 1 ? [nextItem] : [];
+    });
+  }
+
+  if (candidate.projects) {
+    if (!Array.isArray(candidate.projects)) {
+      throw new BadGatewayException('AI 返回的 projects patch 结构无效');
+    }
+
+    nextPatch.projects = candidate.projects.flatMap((item) => {
+      if (!item || typeof item !== 'object') {
+        throw new BadGatewayException('AI 返回的 projects item 结构无效');
+      }
+
+      const currentItem = item as Record<string, unknown>;
+      const index = currentItem.index;
+
+      if (typeof index !== 'number' || !Number.isInteger(index)) {
+        throw new BadGatewayException('AI 返回的 projects index 无效');
+      }
+
+      if (index < 0 || index >= resume.projects.length) {
+        return [];
+      }
+
+      const nextItem: ResumeOptimizationProjectPatch = {
+        index,
+      };
+
+      if (currentItem.summary) {
+        if (!isLocalizedText(currentItem.summary)) {
+          throw new BadGatewayException('AI 返回的 projects.summary 结构无效');
+        }
+
+        nextItem.summary = currentItem.summary;
+      }
+
+      if (currentItem.highlights) {
+        if (!isLocalizedTextArray(currentItem.highlights)) {
+          throw new BadGatewayException(
+            'AI 返回的 projects.highlights 结构无效',
+          );
+        }
+
+        nextItem.highlights = currentItem.highlights;
+      }
+
+      return Object.keys(nextItem).length > 1 ? [nextItem] : [];
+    });
+  }
+
+  if (candidate.highlights) {
+    if (!isResumeHighlightArray(candidate.highlights)) {
+      throw new BadGatewayException('AI 返回的 highlights 结构无效');
+    }
+
+    nextPatch.highlights = candidate.highlights;
+  }
+
+  return nextPatch;
+}
+
+function validateProviderPayload(
+  payload: unknown,
+  resume: StandardResume,
+): ResumeOptimizationProviderPayload {
+  if (!payload || typeof payload !== 'object') {
+    throw new BadGatewayException('AI 未返回结构化简历建议');
+  }
+
+  const candidate = payload as Record<string, unknown>;
+
+  if (typeof candidate.summary !== 'string' || !candidate.summary.trim()) {
+    throw new BadGatewayException('AI 返回的 summary 无效');
+  }
+
+  if (
+    !Array.isArray(candidate.focusAreas) ||
+    candidate.focusAreas.some((item) => typeof item !== 'string')
+  ) {
+    throw new BadGatewayException('AI 返回的 focusAreas 无效');
+  }
+
+  return {
+    summary: candidate.summary.trim(),
+    focusAreas: candidate.focusAreas
+      .map((item) => item.trim())
+      .filter((item) => item.length > 0)
+      .slice(0, 4),
+    patch: validatePatch(candidate.patch, resume),
+  };
+}
+
+function applyPatch(
+  resume: StandardResume,
+  patch: ResumeOptimizationPatch,
+): StandardResume {
+  const nextResume = cloneResume(resume);
+
+  if (patch.profile?.headline) {
+    nextResume.profile.headline = patch.profile.headline;
+  }
+
+  if (patch.profile?.summary) {
+    nextResume.profile.summary = patch.profile.summary;
+  }
+
+  patch.experiences?.forEach((item) => {
+    if (item.summary) {
+      nextResume.experiences[item.index]!.summary = item.summary;
+    }
+
+    if (item.highlights) {
+      nextResume.experiences[item.index]!.highlights = item.highlights;
+    }
+  });
+
+  patch.projects?.forEach((item) => {
+    if (item.summary) {
+      nextResume.projects[item.index]!.summary = item.summary;
+    }
+
+    if (item.highlights) {
+      nextResume.projects[item.index]!.highlights = item.highlights;
+    }
+  });
+
+  if (patch.highlights) {
+    nextResume.highlights = patch.highlights;
+  }
+
+  return nextResume;
+}
+
+function detectChangedModules(
+  previousResume: StandardResume,
+  nextResume: StandardResume,
+): ResumeOptimizationModule[] {
+  return getStandardResumeModuleKeys().filter((moduleKey) => {
+    if (
+      moduleKey !== 'profile' &&
+      moduleKey !== 'experiences' &&
+      moduleKey !== 'projects' &&
+      moduleKey !== 'highlights'
+    ) {
+      return false;
+    }
+
+    return (
+      JSON.stringify(previousResume[moduleKey]) !==
+      JSON.stringify(nextResume[moduleKey])
+    );
+  }) as ResumeOptimizationModule[];
+}
+
+function buildMockSuggestion(
+  resume: StandardResume,
+  instruction: string,
+  locale: AnalysisLocale,
+): ResumeOptimizationProviderPayload {
+  const keywords = extractKeywords(instruction, locale, 3);
+  const firstKeyword = keywords[0] ?? (locale === 'en' ? 'impact' : '成果');
+  const zhFocus = keywords.join('、');
+  const enFocus = keywords.join(', ');
+  const currentHeadlineZh = resume.profile.headline.zh.trim();
+  const currentHeadlineEn = resume.profile.headline.en.trim();
+
+  return {
+    summary:
+      locale === 'en'
+        ? `Generated a deterministic resume refinement draft that emphasizes ${enFocus} while preserving the current resume structure.`
+        : `已生成一份稳定的结构化简历建议稿，重点围绕 ${zhFocus} 强化当前简历表达，同时保持现有数据结构不变。`,
+    focusAreas:
+      locale === 'en'
+        ? [
+            `Clarify fit around ${firstKeyword}`,
+            'Rewrite profile summary with stronger positioning',
+            'Tighten the first experience and project highlights',
+          ]
+        : [
+            `突出与 ${firstKeyword} 相关的匹配信号`,
+            '重写个人摘要，让定位更聚焦',
+            '补强首段经历与项目亮点描述',
+          ],
+    patch: {
+      profile: {
+        headline: {
+          zh: currentHeadlineZh
+            ? `${currentHeadlineZh} · 面向目标岗位优化`
+            : '面向目标岗位优化的前端工程师',
+          en: currentHeadlineEn
+            ? `${currentHeadlineEn} · Targeted Resume Edition`
+            : 'Frontend Engineer · Targeted Resume Edition',
+        },
+        summary: {
+          zh: `本次草稿围绕 ${zhFocus} 重新收束个人定位，强调与目标岗位更相关的技术关键词、交付结果与协作方式，同时保留当前真实经历和项目事实。`,
+          en: `This draft refines the positioning around ${enFocus}, highlighting stronger technical signals, delivery outcomes, and collaboration patterns while preserving the current factual experience and project history.`,
+        },
+      },
+      experiences:
+        resume.experiences.length > 0
+          ? [
+              {
+                index: 0,
+                summary: {
+                  zh: `围绕 ${zhFocus} 重新强调该阶段的业务落地、团队协作与工程交付价值，让经历更贴近目标岗位关注点。`,
+                  en: `Refocused this experience around ${enFocus}, making the delivery impact, collaboration scope, and engineering value easier to map to the target role.`,
+                },
+                highlights: [
+                  {
+                    zh: `以 ${zhFocus} 为主线补强亮点描述，优先强调可迁移的交付成果与职责边界。`,
+                    en: `Reframed the highlights around ${enFocus}, prioritizing transferable impact and ownership boundaries.`,
+                  },
+                  ...resume.experiences[0]!.highlights.slice(0, 2),
+                ],
+              },
+            ]
+          : [],
+      projects:
+        resume.projects.length > 0
+          ? [
+              {
+                index: 0,
+                summary: {
+                  zh: `项目描述改为更聚焦 ${zhFocus} 的表达方式，突出技术方案、业务结果与个人贡献的对应关系。`,
+                  en: `Project wording now emphasizes ${enFocus}, making the link between technical decisions, business impact, and individual contribution clearer.`,
+                },
+                highlights: [
+                  {
+                    zh: `补一条与 ${zhFocus} 直接相关的成果描述，方便后续投递时快速贴近岗位要求。`,
+                    en: `Added a highlight tied to ${enFocus} so the project reads closer to the target role during future applications.`,
+                  },
+                  ...resume.projects[0]!.highlights.slice(0, 2),
+                ],
+              },
+            ]
+          : [],
+      highlights: [
+        {
+          title: {
+            zh: 'AI 优化建议版',
+            en: 'AI-Optimized Edition',
+          },
+          description: {
+            zh: `当前草稿已根据 ${zhFocus} 重新组织核心表达，更适合在目标岗位场景下展示已有经验与成果。`,
+            en: `The current draft has been reorganized around ${enFocus} to present existing experience and outcomes more clearly for the target role.`,
+          },
+        },
+        ...resume.highlights.slice(0, 2),
+      ],
+    },
+  };
+}
+
+@Injectable()
+export class AiResumeOptimizationService {
+  constructor(
+    @Inject(AiService)
+    private readonly aiService: AiService,
+    @Inject(ResumePublicationService)
+    private readonly resumePublicationService: ResumePublicationService,
+  ) {}
+
+  async generateSuggestion(
+    input: GenerateResumeOptimizationInput,
+  ): Promise<GenerateResumeOptimizationResult> {
+    const instruction = normalizeInstruction(input.instruction);
+    const locale = input.locale ?? 'zh';
+
+    if (!instruction) {
+      throw new BadRequestException('Instruction is required');
+    }
+
+    const draft = await this.resumePublicationService.getDraft();
+    const providerSummary = this.aiService.getProviderSummary();
+
+    const payload =
+      providerSummary.mode === 'mock'
+        ? buildMockSuggestion(draft.resume, instruction, locale)
+        : await this.generateProviderSuggestion(draft.resume, instruction, locale);
+
+    const suggestedResume = applyPatch(draft.resume, payload.patch);
+    const validationResult = validateStandardResume(suggestedResume);
+
+    if (!validationResult.valid) {
+      throw new BadGatewayException(
+        validationResult.errors[0] ?? 'AI 建议稿未通过当前简历结构校验',
+      );
+    }
+
+    return {
+      summary: payload.summary,
+      focusAreas: payload.focusAreas,
+      changedModules: detectChangedModules(draft.resume, suggestedResume),
+      suggestedResume,
+      providerSummary,
+    };
+  }
+
+  private async generateProviderSuggestion(
+    resume: StandardResume,
+    instruction: string,
+    locale: AnalysisLocale,
+  ): Promise<ResumeOptimizationProviderPayload> {
+    const result = await this.aiService.generateText({
+      systemPrompt:
+        locale === 'en'
+          ? 'You are a resume optimization assistant. Output valid JSON only.'
+          : '你是一个简历优化助手。你只能输出合法 JSON，不要输出 Markdown。',
+      temperature: 0.2,
+      prompt: this.buildPrompt(resume, instruction, locale),
+    });
+
+    const jsonText = extractJsonObject(result.text);
+
+    try {
+      const payload = JSON.parse(jsonText) as unknown;
+
+      return validateProviderPayload(payload, resume);
+    } catch (error) {
+      if (error instanceof BadGatewayException) {
+        throw error;
+      }
+
+      throw new BadGatewayException(
+        error instanceof Error
+          ? `AI 返回的结构化建议无法解析：${error.message}`
+          : 'AI 返回的结构化建议无法解析',
+      );
+    }
+  }
+
+  private buildPrompt(
+    resume: StandardResume,
+    instruction: string,
+    locale: AnalysisLocale,
+  ): string {
+    const editableResumeContext = {
+      profile: {
+        headline: resume.profile.headline,
+        summary: resume.profile.summary,
+      },
+      experiences: resume.experiences.map((item, index) => ({
+        index,
+        companyName: item.companyName,
+        role: item.role,
+        summary: item.summary,
+        highlights: item.highlights,
+      })),
+      projects: resume.projects.map((item, index) => ({
+        index,
+        name: item.name,
+        role: item.role,
+        summary: item.summary,
+        highlights: item.highlights,
+      })),
+      highlights: resume.highlights,
+    };
+
+    const schema = {
+      summary: locale === 'en' ? 'string' : '字符串',
+      focusAreas: ['string'],
+      patch: {
+        profile: {
+          headline: {
+            zh: 'string',
+            en: 'string',
+          },
+          summary: {
+            zh: 'string',
+            en: 'string',
+          },
+        },
+        experiences: [
+          {
+            index: 0,
+            summary: {
+              zh: 'string',
+              en: 'string',
+            },
+            highlights: [
+              {
+                zh: 'string',
+                en: 'string',
+              },
+            ],
+          },
+        ],
+        projects: [
+          {
+            index: 0,
+            summary: {
+              zh: 'string',
+              en: 'string',
+            },
+            highlights: [
+              {
+                zh: 'string',
+                en: 'string',
+              },
+            ],
+          },
+        ],
+        highlights: [
+          {
+            title: {
+              zh: 'string',
+              en: 'string',
+            },
+            description: {
+              zh: 'string',
+              en: 'string',
+            },
+          },
+        ],
+      },
+    };
+
+    if (locale === 'en') {
+      return [
+        'Task: optimize the current resume draft for the instruction below.',
+        'Important rules:',
+        '1. Keep all factual data stable. Do not invent new companies, projects, dates, links, email, phone, or skills.',
+        '2. Only rewrite narrative fields in the allowed patch structure.',
+        '3. Every localized field must include both zh and en strings.',
+        '4. Use existing experience/project indexes only.',
+        '5. Return JSON only and match the schema exactly.',
+        '',
+        `Instruction:\n${instruction}`,
+        '',
+        `Editable resume context:\n${JSON.stringify(editableResumeContext, null, 2)}`,
+        '',
+        `Required JSON schema:\n${JSON.stringify(schema, null, 2)}`,
+      ].join('\n');
+    }
+
+    return [
+      '任务：基于下面的输入，优化当前简历草稿。',
+      '重要规则：',
+      '1. 保持事实信息稳定，不要虚构新的公司、项目、日期、链接、邮箱、电话或技能。',
+      '2. 只能改写允许的 narrative 字段，并严格使用 patch 结构。',
+      '3. 每个多语言字段都必须同时返回 zh 和 en。',
+      '4. experiences / projects 只能使用现有 index。',
+      '5. 只能输出 JSON，不要输出 Markdown 和解释文字。',
+      '',
+      `输入内容：\n${instruction}`,
+      '',
+      `当前可编辑上下文：\n${JSON.stringify(editableResumeContext, null, 2)}`,
+      '',
+      `必须匹配的 JSON 结构：\n${JSON.stringify(schema, null, 2)}`,
+    ].join('\n');
+  }
+}

--- a/apps/server/src/modules/ai/ai.module.ts
+++ b/apps/server/src/modules/ai/ai.module.ts
@@ -1,17 +1,19 @@
 import { Module } from '@nestjs/common';
 
 import { AuthModule } from '../auth/auth.module';
+import { ResumeModule } from '../resume/resume.module';
 import { AiFileController } from './ai-file.controller';
 import { AiReportController } from './ai-report.controller';
 import { AnalysisReportCacheService } from './analysis-report-cache.service';
 import { resolveAiRuntimeConfig } from './config/ai-config';
+import { AiResumeOptimizationService } from './ai-resume-optimization.service';
 import { AiService } from './ai.service';
 import { FileExtractionService } from './file-extraction.service';
 import { AI_FETCH, AI_PROVIDER_INSTANCE, AI_RUNTIME_CONFIG } from './ai.tokens';
 import { createAiProvider } from './providers/ai-provider.factory';
 
 @Module({
-  imports: [AuthModule],
+  imports: [AuthModule, ResumeModule],
   controllers: [AiFileController, AiReportController],
   providers: [
     {
@@ -28,9 +30,15 @@ import { createAiProvider } from './providers/ai-provider.factory';
       useFactory: createAiProvider,
     },
     AiService,
+    AiResumeOptimizationService,
     AnalysisReportCacheService,
     FileExtractionService,
   ],
-  exports: [AiService, AnalysisReportCacheService, FileExtractionService],
+  exports: [
+    AiService,
+    AiResumeOptimizationService,
+    AnalysisReportCacheService,
+    FileExtractionService,
+  ],
 })
 export class AiModule {}

--- a/apps/server/test/ai-report-role-access.e2e-spec.ts
+++ b/apps/server/test/ai-report-role-access.e2e-spec.ts
@@ -1,17 +1,59 @@
+import { mkdtempSync, rmSync } from 'fs';
 import { INestApplication } from '@nestjs/common';
+import { tmpdir } from 'os';
+import { join } from 'path';
 import { Test, TestingModule } from '@nestjs/testing';
 import request from 'supertest';
 import { App } from 'supertest/types';
 
+import type { DatabaseClient } from './../src/database/database.client';
+import { DATABASE_CLIENT } from './../src/database/database.tokens';
 import { AppModule } from './../src/app.module';
+
+async function prepareResumeTables(client: DatabaseClient) {
+  await client.execute(`
+    CREATE TABLE IF NOT EXISTS resume_drafts (
+      resume_key text PRIMARY KEY NOT NULL,
+      schema_version integer NOT NULL,
+      resume_json text NOT NULL,
+      updated_at integer NOT NULL
+    );
+  `);
+
+  await client.execute(`
+    CREATE TABLE IF NOT EXISTS resume_publication_snapshots (
+      id text PRIMARY KEY NOT NULL,
+      resume_key text NOT NULL,
+      schema_version integer NOT NULL,
+      resume_json text NOT NULL,
+      published_at integer NOT NULL
+    );
+  `);
+
+  await client.execute(`
+    CREATE INDEX IF NOT EXISTS resume_publication_snapshots_resume_key_published_at_idx
+    ON resume_publication_snapshots (resume_key, published_at);
+  `);
+
+  await client.execute('DELETE FROM resume_publication_snapshots;');
+  await client.execute('DELETE FROM resume_drafts;');
+}
 
 describe('AI report role access (e2e)', () => {
   let app: INestApplication<App>;
+  let previousDatabaseUrl: string | undefined;
+  let tempDirectory: string;
 
   beforeEach(async () => {
+    previousDatabaseUrl = process.env.DATABASE_URL;
+    tempDirectory = mkdtempSync(join(tmpdir(), 'my-resume-ai-role-e2e-'));
+    process.env.DATABASE_URL = `file:${join(tempDirectory, 'ai-report-role-access.db')}`;
+
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports: [AppModule],
     }).compile();
+
+    await prepareResumeTables(moduleFixture.get<DatabaseClient>(DATABASE_CLIENT));
 
     app = moduleFixture.createNestApplication();
     await app.init();
@@ -19,6 +61,17 @@ describe('AI report role access (e2e)', () => {
 
   afterEach(async () => {
     await app.close();
+
+    if (previousDatabaseUrl) {
+      process.env.DATABASE_URL = previousDatabaseUrl;
+    } else {
+      delete process.env.DATABASE_URL;
+    }
+
+    rmSync(tempDirectory, {
+      force: true,
+      recursive: true,
+    });
   });
 
   it('should allow viewer to read cached reports but forbid new trigger actions', async () => {

--- a/apps/server/test/ai-report-role-access.e2e-spec.ts
+++ b/apps/server/test/ai-report-role-access.e2e-spec.ts
@@ -73,6 +73,15 @@ describe('AI report role access (e2e)', () => {
         locale: 'zh',
       })
       .expect(403);
+
+    await request(app.getHttpServer())
+      .post('/ai/reports/resume-optimize')
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send({
+        instruction: '请帮我优化简历，重点突出 React 与 Next.js 能力',
+        locale: 'zh',
+      })
+      .expect(403);
   });
 
   it('should allow admin to trigger analysis and write cached ai results', async () => {
@@ -109,5 +118,18 @@ describe('AI report role access (e2e)', () => {
 
     expect(response.body.report.generator).toBe('ai-provider');
     expect(response.body.report.summary.length).toBeGreaterThan(0);
+
+    const optimizeResponse = await request(app.getHttpServer())
+      .post('/ai/reports/resume-optimize')
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send({
+        instruction: '请根据 React 与 Next.js 相关岗位方向优化当前简历',
+        locale: 'zh',
+      })
+      .expect(201);
+
+    expect(optimizeResponse.body.summary.length).toBeGreaterThan(0);
+    expect(optimizeResponse.body.changedModules).toContain('profile');
+    expect(optimizeResponse.body.suggestedResume.meta.slug).toBe('standard-resume');
   });
 });

--- a/docs/30-开发日志/M12-issue-117-AI-简历智能分析与结构化草稿应用.md
+++ b/docs/30-开发日志/M12-issue-117-AI-简历智能分析与结构化草稿应用.md
@@ -1,0 +1,257 @@
+# M12 / issue-117 开发日志：AI 简历智能分析与结构化草稿应用
+
+- Issue：`#117`
+- 里程碑：`M12 开源版收尾与智能简历改写`
+- 分支：`fys-dev/feat-m12-issue-117-ai-resume-optimization`
+- 日期：`2026-03-30`
+
+## 背景
+
+`M10` 结束后，AI 工作台已经具备：
+
+- 运行时摘要
+- 文件提取预览
+- 管理员真实分析
+- viewer 缓存只读体验
+
+但 AI 能力还偏独立，没有真正回到简历主线本身。对于开源版来说，这会带来一个明显缺口：
+
+- 可以分析
+- 可以看结果
+- 但分析结果还不能反向作用到当前草稿
+
+所以这轮选择收一条最小但完整的闭环：
+
+- 基于当前草稿和输入内容生成结构化改写建议
+- 服务端回填成当前项目支持的 `StandardResume`
+- 后台支持管理员一键把建议稿应用到草稿
+
+## 本次目标
+
+- 新增面向当前草稿的 AI 智能分析接口
+- 返回结构化建议与完整 `StandardResume` 建议稿
+- 后台支持“一键应用到当前草稿”
+- 保持当前范围只服务于开源版最小可用闭环
+
+## 非目标
+
+- 不做多版本简历系统
+- 不做 AI 历史持久化
+- 不做异步任务队列
+- 不做复杂 Prompt 编排系统
+- 不扩展 viewer 新能力
+
+## TDD / 测试设计
+
+### 1. 先锁服务端结构化建议逻辑
+
+新增：
+
+- `apps/server/src/modules/ai/ai-resume-optimization.service.spec.ts`
+
+验证：
+
+- mock 模式下也能稳定生成建议稿
+- Provider JSON patch 可被解析并合并到当前草稿
+- 非法结构化结果会被拒绝
+
+### 2. 再锁角色边界 E2E
+
+更新：
+
+- `apps/server/test/ai-report-role-access.e2e-spec.ts`
+
+验证：
+
+- `admin` 可调用新接口
+- `viewer` 继续被禁止
+- 返回结果里包含 `changedModules` 与完整 `suggestedResume`
+
+### 3. 最后锁后台生成与一键应用
+
+更新 / 新增：
+
+- `apps/admin/lib/ai-workbench-api.spec.ts`
+- `apps/admin/components/ai-analysis-panel.spec.tsx`
+
+验证：
+
+- 后台能请求结构化建议接口
+- 只能在 `resume-review` 场景下生成结构化建议
+- 建议稿可一键应用到当前草稿
+- 应用后仍维持“保存草稿，不自动发布”的边界
+
+## 实际改动
+
+### 1. 服务端新增结构化建议服务
+
+新增：
+
+- `apps/server/src/modules/ai/ai-resume-optimization.service.ts`
+- `apps/server/src/modules/ai/ai-resume-optimization.service.spec.ts`
+
+这一层做了三件事：
+
+- 读取当前草稿
+- 让 AI 返回结构化 patch，而不是直接自由生成整份简历
+- 将 patch 合并回当前草稿，生成完整 `StandardResume` 建议稿
+
+这样做的价值是：
+
+- 结构更稳
+- 风险更可控
+- 更适合当前开源版的教学节奏
+
+### 2. 新增 AI 简历智能分析接口
+
+更新：
+
+- `apps/server/src/modules/ai/ai-report.controller.ts`
+- `apps/server/src/modules/ai/ai.module.ts`
+
+新增接口：
+
+- `POST /ai/reports/resume-optimize`
+
+当前接口输入：
+
+- `instruction`
+- `locale`
+
+当前接口输出：
+
+- `summary`
+- `focusAreas`
+- `changedModules`
+- `suggestedResume`
+- `providerSummary`
+
+也就是说，这一轮不只是返回“分析报告”，而是第一次返回一个可直接应用的、通过当前项目结构校验的建议稿。
+
+### 3. 后台接入结构化建议与一键应用
+
+更新：
+
+- `apps/admin/lib/ai-workbench-types.ts`
+- `apps/admin/lib/ai-workbench-api.ts`
+- `apps/admin/lib/ai-workbench-api.spec.ts`
+- `apps/admin/components/ai-analysis-panel.tsx`
+- `apps/admin/components/ai-analysis-panel.spec.tsx`
+
+后台当前新增两步动作：
+
+- 生成结构化简历建议
+- 一键应用到当前草稿
+
+这里刻意没有新开一张“AI 改写页”，而是继续放在 AI 工作台现有的分析面板内。这样读者更容易理解：
+
+- 同样的输入内容
+- 一条线用于“看分析结果”
+- 一条线用于“生成结构化建议稿并写回草稿”
+
+## Review 记录
+
+### 是否符合当前 Issue 与里程碑目标
+
+符合。
+
+本轮只完成：
+
+- AI 简历智能分析接口
+- 结构化建议稿生成
+- 后台一键应用到草稿
+- admin / viewer 权限边界回归
+
+没有越界去做：
+
+- 多版本简历
+- 历史记录
+- 异步任务系统
+- viewer 新入口
+
+### 是否存在可抽离的组件、公共函数、skills 或其他复用能力
+
+本轮已经完成当前最合适的一层抽离：
+
+- `AiResumeOptimizationService`：统一承接草稿读取、结构化 patch 解析、建议稿生成与校验
+- `generateAiResumeOptimization`：后台最小 API 客户端
+
+刻意没有继续把“AI 改写工作流”抽成更大的编排层，因为当前开源版只需要证明这条最小闭环成立，不需要提前做历史、重试和复杂工作流抽象。
+
+### 本次最重要的边界判断
+
+这轮不是让 AI 直接自由生成一份全新的简历，而是让 AI 返回结构化 patch，再由服务端合并回当前草稿。
+
+这个边界非常关键。因为它保证了：
+
+- 当前事实信息更稳定
+- 当前项目的 `StandardResume` 结构不被破坏
+- 一键应用到草稿的风险可控
+
+## 自测结果
+
+已执行：
+
+- `pnpm --filter @my-resume/server typecheck`
+- `pnpm --filter @my-resume/admin typecheck`
+- `pnpm --filter @my-resume/server test -- ai-resume-optimization.service.spec.ts`
+- `pnpm --filter @my-resume/admin exec vitest run components/ai-analysis-panel.spec.tsx lib/ai-workbench-api.spec.ts`
+- `pnpm --filter @my-resume/server test:e2e -- test/ai-report-role-access.e2e-spec.ts`
+- `pnpm --filter @my-resume/server build`
+- `pnpm --filter @my-resume/admin build`
+
+结果：
+
+- 服务端类型检查通过
+- 后台类型检查通过
+- 服务端结构化建议单测通过
+- 后台结构化建议与一键应用测试通过
+- admin / viewer 权限边界 E2E 通过
+- `server / admin` 构建通过
+
+补充说明：
+
+- `apps/admin` 全量测试在本地并发运行时仍有历史上的超时波动，本轮改动相关的定向测试均已通过
+- 当前构建结果中已包含 `/dashboard/ai` 页面更新，说明功能不只停留在测试层
+
+## 遇到的问题
+
+### 1. 直接让 AI 输出整份简历风险太高
+
+问题：
+
+如果这一轮直接让 AI 自由生成整份 `StandardResume`，很容易出现：
+
+- 结构不稳定
+- 事实信息漂移
+- 一键应用风险过高
+
+处理：
+
+- 改为“AI 返回结构化 patch”
+- 服务端再统一合并回当前草稿
+- 最终再走现有简历结构校验
+
+### 2. mock 模式下也要保证闭环可验证
+
+问题：
+
+当前开源仓库不一定每个人都有真实 API Key，如果 mock 模式下新接口不可用，这条能力就很难在开源环境中被验证。
+
+处理：
+
+- 在 `mock` 模式下补 deterministic suggestion
+- 让这条链路在没有真实 Provider 时仍然可演示、可测试、可讲解
+
+## 可沉淀为教程 / 博客的点
+
+- 为什么开源版 AI 改写不应该一开始就做“自由生成整份简历”
+- 为什么“结构化 patch + 服务端合并”更适合当前阶段
+- 如何把 AI 分析结果真正接回当前简历草稿，而不是只停留在报告展示
+- 如何在保持单后端原则的同时，把 AI 改写能力接进后台工作台
+
+## 后续待办
+
+- 可在后续里程碑中继续补“改写前后 diff 展示”
+- 可在个人产品线中扩展多版本简历、历史记录与任务队列
+- 开源版当前先停在“结构化建议 + 一键应用草稿”即可


### PR DESCRIPTION
## Summary
- 新增 `POST /ai/reports/resume-optimize`，基于当前草稿和输入内容生成结构化简历建议
- 服务端将 AI 返回的结构化 patch 合并回当前 `StandardResume`，并通过现有结构校验
- 后台新增“生成结构化简历建议 / 一键应用到当前草稿”闭环
- 补充本轮开发日志，记录边界、测试与设计取舍

## Testing
- `pnpm --filter @my-resume/server typecheck`
- `pnpm --filter @my-resume/admin typecheck`
- `pnpm --filter @my-resume/server test -- ai-resume-optimization.service.spec.ts`
- `pnpm --filter @my-resume/admin exec vitest run components/ai-analysis-panel.spec.tsx lib/ai-workbench-api.spec.ts`
- `pnpm --filter @my-resume/server test:e2e -- test/ai-report-role-access.e2e-spec.ts`
- `pnpm --filter @my-resume/server build`
- `pnpm --filter @my-resume/admin build`

## Issue
- Closes #117
