### PR TITLE
[Feature] M12 / issue-AI 分析结果契约稳定化

### DIFF
--- a/apps/admin/components/ai-analysis-panel.spec.tsx
+++ b/apps/admin/components/ai-analysis-panel.spec.tsx
@@ -108,6 +108,23 @@ describe('AiAnalysisPanel', () => {
         sourceHash: 'demo',
         inputPreview: 'NestJS React TypeScript',
         summary: '建议继续补充量化结果与职责边界。',
+        score: {
+          value: 76,
+          label: '基础匹配良好',
+          reason: '已有核心技术关键词，但成果与职责边界仍需补强。',
+        },
+        strengths: ['已覆盖 NestJS、React、TypeScript 等岗位基础关键词。'],
+        gaps: ['缺少体现业务结果的量化成果。'],
+        risks: ['如果没有主导范围说明，容易被理解为参与而非负责。'],
+        suggestions: [
+          {
+            key: 'experience-impact',
+            title: '补强经历成果描述',
+            module: 'experiences',
+            reason: '工作经历是最能证明能力与影响范围的模块。',
+            actions: ['补一条量化结果', '补一条主导职责描述'],
+          },
+        ],
         sections: [
           {
             key: 'analysis-result',
@@ -157,10 +174,22 @@ describe('AiAnalysisPanel', () => {
     ).toBeInTheDocument();
     expect(screen.getByText('场景：简历优化建议')).toBeInTheDocument();
     expect(screen.getByText('Provider：qiniu / deepseek-v3')).toBeInTheDocument();
+    expect(screen.getByText('评分：76 / 100')).toBeInTheDocument();
+    expect(screen.getByText('基础匹配良好')).toBeInTheDocument();
     expect(
-      screen.getByRole('heading', { name: '分析结果', level: 3 }),
+      screen.getByText('已有核心技术关键词，但成果与职责边界仍需补强。'),
     ).toBeInTheDocument();
-    expect(screen.getByText('补充量化成果。')).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: '已有优势', level: 3 }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('已覆盖 NestJS、React、TypeScript 等岗位基础关键词。'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: '建议动作', level: 3 }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('建议模块：experiences')).toBeInTheDocument();
+    expect(screen.getByText('补一条量化结果')).toBeInTheDocument();
   });
 
   it('should show error feedback when live analysis fails', async () => {

--- a/apps/admin/components/ai-analysis-panel.tsx
+++ b/apps/admin/components/ai-analysis-panel.tsx
@@ -79,6 +79,10 @@ function formatGenerator(generator: AiWorkbenchReport['generator']): string {
   return generator === 'ai-provider' ? '真实 Provider' : '缓存结果';
 }
 
+function formatScore(report: AiWorkbenchReport): string {
+  return `评分：${report.score.value} / 100`;
+}
+
 export function AiAnalysisPanel({
   accessToken,
   apiBaseUrl,
@@ -327,21 +331,111 @@ export function AiAnalysisPanel({
             <DisplaySectionIntro
               compact
               description={report.inputPreview}
-              eyebrow="摘要"
-              title="模型返回摘要"
+              eyebrow="结论层"
+              title="模型判断摘要"
               titleAs="h3"
             />
             <div className="analysis-text-block">{report.summary}</div>
+            <div className="info-grid">
+              <div className="status-box">
+                <strong>{formatScore(report)}</strong>
+                <span>{report.score.label}</span>
+              </div>
+              <div className="status-box">
+                <strong>判断理由</strong>
+                <span>{report.score.reason}</span>
+              </div>
+            </div>
           </DisplaySurfaceCard>
 
           <div className="analysis-section-grid">
+            <DisplaySurfaceCard as="article" className="analysis-section-card">
+              <DisplaySectionIntro
+                compact
+                description="这里展示当前输入已经具备的优势，帮助用户判断“哪些内容不该被误改”。"
+                title="已有优势"
+                titleAs="h3"
+              />
+              <ul className="muted-list">
+                {report.strengths.map((item) => (
+                  <li key={item}>{item}</li>
+                ))}
+              </ul>
+            </DisplaySurfaceCard>
+
+            <DisplaySurfaceCard as="article" className="analysis-section-card">
+              <DisplaySectionIntro
+                compact
+                description="这些缺口是 AI 判断当前输入还不够有说服力的地方。"
+                title="待补缺口"
+                titleAs="h3"
+              />
+              <ul className="muted-list">
+                {report.gaps.map((item) => (
+                  <li key={item}>{item}</li>
+                ))}
+              </ul>
+            </DisplaySurfaceCard>
+
+            <DisplaySurfaceCard as="article" className="analysis-section-card">
+              <DisplaySectionIntro
+                compact
+                description="风险提示不是为了制造焦虑，而是提前告诉用户“不改会发生什么”。"
+                title="风险提示"
+                titleAs="h3"
+              />
+              <ul className="muted-list">
+                {report.risks.map((item) => (
+                  <li key={item}>{item}</li>
+                ))}
+              </ul>
+            </DisplaySurfaceCard>
+
+            <DisplaySurfaceCard as="article" className="analysis-section-card">
+              <DisplaySectionIntro
+                compact
+                description="建议动作会尽量指向简历模块，为后续 diff / apply 做准备。"
+                title="建议动作"
+                titleAs="h3"
+              />
+              <div className="stack">
+                {report.suggestions.map((item) => (
+                  <DisplaySurfaceCard
+                    as="section"
+                    className="card stack"
+                    key={item.key}
+                  >
+                    <DisplaySectionIntro
+                      compact
+                      description={item.reason}
+                      eyebrow={
+                        item.module ? `建议模块：${item.module}` : '建议模块：通用判断'
+                      }
+                      title={item.title}
+                      titleAs="h4"
+                    />
+                    <ul className="muted-list">
+                      {item.actions.map((action) => (
+                        <li key={`${item.key}-${action}`}>{action}</li>
+                      ))}
+                    </ul>
+                  </DisplaySurfaceCard>
+                ))}
+              </div>
+            </DisplaySurfaceCard>
+
             {report.sections.map((section) => (
               <DisplaySurfaceCard
                 as="article"
                 className="analysis-section-card"
-                key={section.key}
+                key={`legacy-${section.key}`}
               >
-                <DisplaySectionIntro compact title={section.title} titleAs="h3" />
+                <DisplaySectionIntro
+                  compact
+                  description="兼容缓存阅读面板的过渡结构。"
+                  title={section.title}
+                  titleAs="h3"
+                />
                 <ul className="muted-list">
                   {section.bullets.map((bullet) => (
                     <li key={`${section.key}-${bullet}`}>{bullet}</li>

--- a/apps/admin/lib/ai-workbench-types.ts
+++ b/apps/admin/lib/ai-workbench-types.ts
@@ -14,6 +14,31 @@ export interface AiWorkbenchRuntimeSummary {
 
 export type AiWorkbenchLocale = 'zh' | 'en';
 export type AiWorkbenchReportGenerator = 'mock-cache' | 'ai-provider';
+export type AiAnalysisSuggestionModule =
+  | 'profile'
+  | 'experiences'
+  | 'projects'
+  | 'highlights';
+
+export interface AiWorkbenchScore {
+  /**
+   * 面向用户的快速分值信号，用于帮助判断“当前内容离目标还差多少”。
+   */
+  value: number;
+  label: string;
+  reason: string;
+}
+
+export interface AiWorkbenchSuggestion {
+  key: string;
+  title: string;
+  module?: AiAnalysisSuggestionModule;
+  /**
+   * reason 直接面向用户解释“为什么建议改这里”。
+   */
+  reason: string;
+  actions: string[];
+}
 
 export interface AiWorkbenchReportSection {
   key: string;
@@ -29,6 +54,11 @@ export interface AiWorkbenchReport {
   sourceHash: string;
   inputPreview: string;
   summary: string;
+  score: AiWorkbenchScore;
+  strengths: string[];
+  gaps: string[];
+  risks: string[];
+  suggestions: AiWorkbenchSuggestion[];
   sections: AiWorkbenchReportSection[];
   generator: AiWorkbenchReportGenerator;
   createdAt: string;

--- a/apps/server/src/modules/ai/ai-report.controller.ts
+++ b/apps/server/src/modules/ai/ai-report.controller.ts
@@ -80,10 +80,7 @@ export class AiReportController {
   @RequireCapability('canTriggerAiAnalysis')
   async analyzeReport(@Body() body: CacheReportBody) {
     const result = await this.aiService.generateText({
-      systemPrompt:
-        body.locale === 'en'
-          ? 'You are a concise resume analysis assistant.'
-          : '你是一个简洁的简历分析助手。',
+      systemPrompt: this.buildAnalysisSystemPrompt(body.locale ?? 'zh'),
       prompt: this.buildAnalysisPrompt(body),
     });
 
@@ -106,9 +103,81 @@ export class AiReportController {
 
   private buildAnalysisPrompt(body: CacheReportBody): string {
     if (body.locale === 'en') {
-      return `Scenario: ${body.scenario}\nPlease give a short analysis for the following content:\n${body.content}`;
+      return [
+        `Scenario: ${body.scenario}`,
+        'Task: analyze the current input for interview readiness and job-fit communication.',
+        'Return JSON only. Do not wrap it in markdown.',
+        'JSON shape:',
+        JSON.stringify(
+          {
+            summary: 'string',
+            score: {
+              value: 78,
+              label: 'string',
+              reason: 'string',
+            },
+            strengths: ['string'],
+            gaps: ['string'],
+            risks: ['string'],
+            suggestions: [
+              {
+                key: 'string',
+                title: 'string',
+                module: 'profile | experiences | projects | highlights | null',
+                reason: 'string',
+                actions: ['string'],
+              },
+            ],
+          },
+          null,
+          2,
+        ),
+        'Keep the output concise and product-friendly.',
+        `Input:\n${body.content}`,
+      ].join('\n');
     }
 
-    return `分析场景：${body.scenario}\n请基于以下内容给出简短分析：\n${body.content}`;
+    return [
+      `分析场景：${body.scenario}`,
+      '任务：从“更好投递、面试更有说服力、拿到 offer 更稳”这三个角度分析当前输入。',
+      '请只返回 JSON，不要输出 markdown，不要输出代码块。',
+      'JSON 结构：',
+      JSON.stringify(
+        {
+          summary: 'string',
+          score: {
+            value: 78,
+            label: 'string',
+            reason: 'string',
+          },
+          strengths: ['string'],
+          gaps: ['string'],
+          risks: ['string'],
+          suggestions: [
+            {
+              key: 'string',
+              title: 'string',
+              module: 'profile | experiences | projects | highlights | null',
+              reason: 'string',
+              actions: ['string'],
+            },
+          ],
+        },
+        null,
+        2,
+      ),
+      '要求：strengths 说明已有优势，gaps 说明当前缺口，risks 说明不修改会带来的投递或面试风险，suggestions 给出可执行动作。',
+      `输入内容：\n${body.content}`,
+    ].join('\n');
+  }
+
+  private buildAnalysisSystemPrompt(locale: AnalysisLocale): string {
+    /**
+     * analyze 接口后续会成为“分析 -> 建议稿 -> diff -> apply”的上游输入，
+     * 所以这里强制要求结构化 JSON，而不是让前端从自由文本里猜字段。
+     */
+    return locale === 'en'
+      ? 'You are a resume analysis assistant. Output valid JSON only.'
+      : '你是一个简历分析助手。只输出合法 JSON。';
   }
 }

--- a/apps/server/src/modules/ai/analysis-report-cache.service.spec.ts
+++ b/apps/server/src/modules/ai/analysis-report-cache.service.spec.ts
@@ -22,6 +22,11 @@ describe('AnalysisReportCacheService', () => {
     expect(second.cached).toBe(true);
     expect(second.report.reportId).toBe(first.report.reportId);
     expect(second.report.summary).toBe(first.report.summary);
+    expect(first.report.score.value).toBeGreaterThan(0);
+    expect(first.report.strengths.length).toBeGreaterThan(0);
+    expect(first.report.gaps.length).toBeGreaterThan(0);
+    expect(first.report.risks.length).toBeGreaterThan(0);
+    expect(first.report.suggestions.length).toBeGreaterThan(0);
   });
 
   it('should create different cache keys for different scenarios', () => {
@@ -52,6 +57,7 @@ describe('AnalysisReportCacheService', () => {
 
     expect(report.reportId).toBe(created.report.reportId);
     expect(report.locale).toBe('en');
+    expect(report.score.label.length).toBeGreaterThan(0);
   });
 
   it('should expose seeded demo reports for viewer read-only experience', () => {
@@ -59,5 +65,53 @@ describe('AnalysisReportCacheService', () => {
 
     expect(reports.length).toBeGreaterThanOrEqual(3);
     expect(reports[0]).toHaveProperty('reportId');
+  });
+
+  it('should normalize generated analysis into a stable structured contract', () => {
+    const report = service.storeGeneratedReport({
+      scenario: 'resume-review',
+      content: 'React Next.js TypeScript dashboard experience',
+      locale: 'zh',
+      generatedText: JSON.stringify({
+        summary: '当前简历已经具备 React 与 Next.js 相关基础，但成果表达还不够聚焦。',
+        score: {
+          value: 78,
+          label: '具备竞争力',
+          reason: '已有核心关键词，但缺少量化成果与主导范围说明。',
+        },
+        strengths: ['已覆盖 React、Next.js、TypeScript 等目标岗位关键词。'],
+        gaps: ['缺少能够直接映射业务结果的量化描述。'],
+        risks: ['如果只列技术栈，容易被理解为使用过但未形成主导能力。'],
+        suggestions: [
+          {
+            key: 'profile-summary',
+            title: '先优化个人摘要',
+            module: 'profile',
+            reason: '摘要是 HR 和面试官最快读取的入口，应先突出定位与结果。',
+            actions: ['补一条面向岗位的定位句', '加入一条代表性结果描述'],
+          },
+        ],
+      }),
+      providerSummary: {
+        provider: 'qiniu',
+        model: 'deepseek-v3',
+        mode: 'openai-compatible',
+      },
+    });
+
+    expect(report.summary).toContain('当前简历已经具备 React 与 Next.js');
+    expect(report.score).toEqual({
+      value: 78,
+      label: '具备竞争力',
+      reason: '已有核心关键词，但缺少量化成果与主导范围说明。',
+    });
+    expect(report.strengths).toContain(
+      '已覆盖 React、Next.js、TypeScript 等目标岗位关键词。',
+    );
+    expect(report.suggestions[0]).toMatchObject({
+      key: 'profile-summary',
+      module: 'profile',
+      title: '先优化个人摘要',
+    });
   });
 });

--- a/apps/server/src/modules/ai/analysis-report-cache.service.ts
+++ b/apps/server/src/modules/ai/analysis-report-cache.service.ts
@@ -1,4 +1,5 @@
 import {
+  BadGatewayException,
   BadRequestException,
   Injectable,
   NotFoundException,
@@ -7,11 +8,53 @@ import { createHash } from 'node:crypto';
 
 export type AnalysisScenario = 'jd-match' | 'resume-review' | 'offer-compare';
 export type AnalysisLocale = 'zh' | 'en';
+export type AnalysisSuggestionModule =
+  | 'profile'
+  | 'experiences'
+  | 'projects'
+  | 'highlights';
 
 export interface AnalysisReportSection {
   key: string;
   title: string;
   bullets: string[];
+}
+
+export interface AnalysisScore {
+  /**
+   * 面向用户的快速判断分值，帮助先判断“当前内容离岗位要求还有多远”。
+   * 它不是绝对分，只是把当前输入映射为一个更容易理解的优先级信号。
+   */
+  value: number;
+  /**
+   * 配合分值一起展示的简短标签，用于降低用户阅读门槛。
+   */
+  label: string;
+  /**
+   * 解释当前分值为何成立，是“让用户愿意相信结果”的第一层依据。
+   */
+  reason: string;
+}
+
+export interface AnalysisSuggestion {
+  key: string;
+  /**
+   * 建议标题用于在前端卡片中快速扫读，不和底层字段名直接耦合。
+   */
+  title: string;
+  /**
+   * 建议改动要尽可能指向简历模块，后续 diff / apply 才能按模块收口。
+   * 非简历改写场景可为空，但 JD / 简历分析应尽量落到具体模块。
+   */
+  module?: AnalysisSuggestionModule;
+  /**
+   * reason 不是给模型看的，而是给用户看的：为什么推荐改这个模块。
+   */
+  reason: string;
+  /**
+   * actions 是前端可直接展示的可执行动作，避免只给抽象结论。
+   */
+  actions: string[];
 }
 
 export interface AnalysisReport {
@@ -21,7 +64,35 @@ export interface AnalysisReport {
   locale: AnalysisLocale;
   sourceHash: string;
   inputPreview: string;
+  /**
+   * 结论层：给用户一个可以先读完的总判断。
+   */
   summary: string;
+  /**
+   * 结论层：快速评分与简短标签。
+   */
+  score: AnalysisScore;
+  /**
+   * 依据层：当前输入已经命中的亮点。
+   */
+  strengths: string[];
+  /**
+   * 依据层：当前输入还未体现出来的缺口。
+   */
+  gaps: string[];
+  /**
+   * 依据层：如果不改，后续在投递和面试里容易产生的问题。
+   */
+  risks: string[];
+  /**
+   * 建议层：把分析结果收束成后续可用于 diff / apply 的动作入口。
+   */
+  suggestions: AnalysisSuggestion[];
+  /**
+   * 兼容当前缓存报告面板的过渡字段。
+   * 本期前端主展示会转向 score / strengths / gaps / risks / suggestions，
+   * 但缓存面板仍可通过 sections 平稳过渡，避免本 issue 一次性打碎所有界面。
+   */
   sections: AnalysisReportSection[];
   generator: 'mock-cache' | 'ai-provider';
   createdAt: string;
@@ -47,10 +118,26 @@ interface StoreGeneratedReportInput extends GetOrCreateReportInput {
   };
 }
 
+interface StructuredAnalysisPayload {
+  summary: string;
+  score: AnalysisScore;
+  strengths: string[];
+  gaps: string[];
+  risks: string[];
+  suggestions: AnalysisSuggestion[];
+}
+
 const SUPPORTED_SCENARIOS = new Set<AnalysisScenario>([
   'jd-match',
   'resume-review',
   'offer-compare',
+]);
+
+const SUPPORTED_SUGGESTION_MODULES = new Set<AnalysisSuggestionModule>([
+  'profile',
+  'experiences',
+  'projects',
+  'highlights',
 ]);
 
 function normalizeContent(content: string): string {
@@ -66,222 +153,537 @@ function buildInputPreview(content: string): string {
 }
 
 function extractKeywords(content: string, locale: AnalysisLocale): string[] {
-  const matches = content.match(/[A-Za-z0-9.+#-]{2,}/g) ?? [];
-  const unique = Array.from(new Set(matches.map((item) => item.toLowerCase())));
+  const englishMatches = content.match(/[A-Za-z0-9.+#-]{2,}/g) ?? [];
+  const chineseMatches = content.match(/[\u4e00-\u9fa5]{2,}/g) ?? [];
+  const unique = Array.from(
+    new Set([...englishMatches, ...chineseMatches].map((item) => item.trim())),
+  );
 
   if (unique.length > 0) {
-    return unique.slice(0, 3);
+    return unique.slice(0, 4);
   }
 
   return locale === 'en'
-    ? ['resume', 'experience', 'skills']
-    : ['简历', '经历', '技能'];
+    ? ['resume', 'impact', 'delivery']
+    : ['简历', '结果', '交付'];
 }
 
-function buildSummary(
+function clampScore(value: number): number {
+  return Math.max(0, Math.min(100, Math.round(value)));
+}
+
+function buildScoreLabel(value: number, locale: AnalysisLocale): string {
+  if (locale === 'en') {
+    if (value >= 85) {
+      return 'Highly aligned';
+    }
+
+    if (value >= 70) {
+      return 'Strong baseline';
+    }
+
+    if (value >= 55) {
+      return 'Needs reinforcement';
+    }
+
+    return 'Needs major revision';
+  }
+
+  if (value >= 85) {
+    return '高度匹配';
+  }
+
+  if (value >= 70) {
+    return '基础匹配良好';
+  }
+
+  if (value >= 55) {
+    return '需要继续补强';
+  }
+
+  return '需要重点调整';
+}
+
+function extractJsonObject(rawText: string): string {
+  const fencedMatch = rawText.match(/```(?:json)?\s*([\s\S]*?)```/i);
+
+  if (fencedMatch?.[1]) {
+    return fencedMatch[1].trim();
+  }
+
+  const firstBrace = rawText.indexOf('{');
+  const lastBrace = rawText.lastIndexOf('}');
+
+  if (firstBrace === -1 || lastBrace === -1 || lastBrace <= firstBrace) {
+    throw new BadGatewayException('AI 未返回可解析的 JSON 结果');
+  }
+
+  return rawText.slice(firstBrace, lastBrace + 1).trim();
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === 'string');
+}
+
+function normalizeSuggestionModule(
+  value: unknown,
+): AnalysisSuggestionModule | undefined {
+  if (value == null) {
+    return undefined;
+  }
+
+  if (
+    typeof value === 'string' &&
+    SUPPORTED_SUGGESTION_MODULES.has(value as AnalysisSuggestionModule)
+  ) {
+    return value as AnalysisSuggestionModule;
+  }
+
+  throw new BadGatewayException('AI 返回的建议模块无效');
+}
+
+function sanitizeActionList(actions: string[], locale: AnalysisLocale): string[] {
+  const normalized = actions.map((action) => action.trim()).filter(Boolean);
+
+  if (normalized.length > 0) {
+    return normalized.slice(0, 3);
+  }
+
+  return locale === 'en'
+    ? ['Add one quantified result', 'Clarify one ownership boundary']
+    : ['补一条量化结果', '补一条职责边界说明'];
+}
+
+function validateStructuredAnalysisPayload(
+  value: unknown,
+  locale: AnalysisLocale,
+): StructuredAnalysisPayload {
+  if (!value || typeof value !== 'object') {
+    throw new BadGatewayException('AI 返回的分析结构无效');
+  }
+
+  const candidate = value as Record<string, unknown>;
+
+  if (typeof candidate.summary !== 'string' || !candidate.summary.trim()) {
+    throw new BadGatewayException('AI 返回的分析摘要无效');
+  }
+
+  const scoreCandidate = candidate.score;
+
+  if (!scoreCandidate || typeof scoreCandidate !== 'object') {
+    throw new BadGatewayException('AI 返回的评分结构无效');
+  }
+
+  const scoreRecord = scoreCandidate as Record<string, unknown>;
+
+  if (
+    typeof scoreRecord.value !== 'number' ||
+    typeof scoreRecord.label !== 'string' ||
+    typeof scoreRecord.reason !== 'string'
+  ) {
+    throw new BadGatewayException('AI 返回的评分字段无效');
+  }
+
+  if (!isStringArray(candidate.strengths)) {
+    throw new BadGatewayException('AI 返回的 strengths 字段无效');
+  }
+
+  if (!isStringArray(candidate.gaps)) {
+    throw new BadGatewayException('AI 返回的 gaps 字段无效');
+  }
+
+  if (!isStringArray(candidate.risks)) {
+    throw new BadGatewayException('AI 返回的 risks 字段无效');
+  }
+
+  if (!Array.isArray(candidate.suggestions)) {
+    throw new BadGatewayException('AI 返回的 suggestions 字段无效');
+  }
+
+  const suggestions = candidate.suggestions.map((item, index) => {
+    if (!item || typeof item !== 'object') {
+      throw new BadGatewayException('AI 返回的建议项结构无效');
+    }
+
+    const suggestion = item as Record<string, unknown>;
+
+    if (
+      typeof suggestion.title !== 'string' ||
+      typeof suggestion.reason !== 'string' ||
+      !isStringArray(suggestion.actions)
+    ) {
+      throw new BadGatewayException('AI 返回的建议项字段无效');
+    }
+
+    return {
+      key:
+        typeof suggestion.key === 'string' && suggestion.key.trim()
+          ? suggestion.key.trim()
+          : `suggestion-${index + 1}`,
+      title: suggestion.title.trim(),
+      module: normalizeSuggestionModule(suggestion.module),
+      reason: suggestion.reason.trim(),
+      actions: sanitizeActionList(suggestion.actions, locale),
+    };
+  });
+
+  return {
+    summary: candidate.summary.trim(),
+    score: {
+      value: clampScore(scoreRecord.value),
+      label: scoreRecord.label.trim(),
+      reason: scoreRecord.reason.trim(),
+    },
+    strengths: candidate.strengths.map((item) => item.trim()).filter(Boolean),
+    gaps: candidate.gaps.map((item) => item.trim()).filter(Boolean),
+    risks: candidate.risks.map((item) => item.trim()).filter(Boolean),
+    suggestions,
+  };
+}
+
+function buildMockStructuredPayload(
   scenario: AnalysisScenario,
   keywords: string[],
   locale: AnalysisLocale,
-): string {
+): StructuredAnalysisPayload {
   if (locale === 'en') {
     if (scenario === 'jd-match') {
-      return `Cached JD match preview highlights ${keywords.join(', ')} and keeps the result reusable for the same input.`;
+      return {
+        summary: `The current input already aligns with ${keywords.join(', ')}, but the resume still needs clearer business outcomes to become more convincing.`,
+        score: {
+          value: 78,
+          label: buildScoreLabel(78, locale),
+          reason:
+            'Core skill keywords are visible, but quantified impact and ownership are still under-expressed.',
+        },
+        strengths: [
+          `The input already mentions ${keywords[0]} and ${keywords[1] ?? keywords[0]}.`,
+          'The overall direction is already close to the target role.',
+        ],
+        gaps: [
+          'There is not enough quantified delivery impact yet.',
+          'Business context and collaboration scope still need sharper wording.',
+        ],
+        risks: [
+          'Listing technologies alone may look like tool exposure rather than deep ownership.',
+        ],
+        suggestions: [
+          {
+            key: 'profile-positioning',
+            module: 'profile',
+            title: 'Tighten the top-level positioning',
+            reason:
+              'The profile summary is the fastest place to tell recruiters what role this resume is optimized for.',
+            actions: [
+              'Add one role-focused headline',
+              'Add one sentence with business impact',
+            ],
+          },
+          {
+            key: 'project-impact',
+            module: 'projects',
+            title: 'Strengthen project outcomes',
+            reason:
+              'Projects are where matching keywords should be connected to business value and delivery results.',
+            actions: [
+              'Add one quantified outcome',
+              'Clarify one ownership boundary',
+            ],
+          },
+        ],
+      };
     }
 
     if (scenario === 'resume-review') {
-      return `Cached resume review focuses on ${keywords.join(', ')} and keeps a stable mock report for tutorials.`;
+      return {
+        summary:
+          'The resume already has a solid technical baseline, but it still needs stronger impact framing before it feels interview-ready.',
+        score: {
+          value: 76,
+          label: buildScoreLabel(76, locale),
+          reason:
+            'Technical coverage exists, but the resume still under-explains outcomes, ownership, and differentiation.',
+        },
+        strengths: [
+          `The resume already exposes keywords like ${keywords.join(', ')}.`,
+          'The bilingual structure is already suitable for later polishing.',
+        ],
+        gaps: [
+          'Each major project still needs a clearer strongest-result sentence.',
+          'The top summary does not yet fully reflect role positioning.',
+        ],
+        risks: [
+          'Without explicit impact statements, the resume may look execution-only.',
+        ],
+        suggestions: [
+          {
+            key: 'profile-summary',
+            module: 'profile',
+            title: 'Refine the profile summary first',
+            reason:
+              'The summary is the fastest place to establish positioning and value before readers enter detailed sections.',
+            actions: [
+              'Add one role-oriented summary sentence',
+              'Mention one representative achievement',
+            ],
+          },
+          {
+            key: 'experience-impact',
+            module: 'experiences',
+            title: 'Add measurable experience impact',
+            reason:
+              'Experience entries carry the most trust in interview screening and should show scope plus results.',
+            actions: [
+              'Add one quantified result',
+              'Clarify one owned module or initiative',
+            ],
+          },
+        ],
+      };
     }
 
-    return `Cached offer comparison starts from ${keywords.join(', ')} and provides a deterministic demo result.`;
+    return {
+      summary:
+        'The current offer comparison is enough for a demo walkthrough, but a real decision still needs clearer trade-offs and personal priorities.',
+      score: {
+        value: 68,
+        label: buildScoreLabel(68, locale),
+        reason:
+          'Comparison dimensions are present, but the decision criteria still need stronger prioritization.',
+      },
+      strengths: [
+        `The current comparison already covers ${keywords.join(', ')} as useful dimensions.`,
+      ],
+      gaps: [
+        'The input does not yet rank growth, ownership, and compensation priorities clearly.',
+      ],
+      risks: [
+        'If salary becomes the only lens, the final recommendation may be misleading.',
+      ],
+      suggestions: [
+        {
+          key: 'decision-priority',
+          title: 'Clarify the decision priority first',
+          reason:
+            'Offer comparison becomes more reliable when growth path, ownership, and compensation are explicitly ordered.',
+          actions: [
+            'Rank your top three decision factors',
+            'Write one risk you are unwilling to accept',
+          ],
+        },
+      ],
+    };
   }
 
   if (scenario === 'jd-match') {
-    return `当前为缓存版 JD 匹配预览，重点围绕 ${keywords.join('、')} 生成稳定报告，便于教程阶段复用。`;
+    return {
+      summary: `当前输入已经覆盖 ${keywords.join('、')} 等关键信号，但要真正提升命中率，还需要把技术关键词落到结果与职责上。`,
+      score: {
+        value: 78,
+        label: buildScoreLabel(78, locale),
+        reason: '当前已具备核心关键词基础，但量化结果、业务影响和主导范围表达还不够充分。',
+      },
+      strengths: [
+        `已覆盖 ${keywords[0]}、${keywords[1] ?? keywords[0]} 等目标岗位关键词。`,
+        '整体方向已经接近目标岗位，不需要从零重写。',
+      ],
+      gaps: [
+        '缺少量化结果来证明交付价值。',
+        '缺少对业务背景与协作边界的说明。',
+      ],
+      risks: [
+        '如果只写技术栈，容易被理解为使用过工具而不是形成过主导能力。',
+      ],
+      suggestions: [
+        {
+          key: 'profile-positioning',
+          module: 'profile',
+          title: '先对齐顶部定位',
+          reason: '个人摘要是招聘方最快形成第一印象的入口，应先说明你与岗位的贴合点。',
+          actions: ['补一条岗位定位句', '补一条代表性结果描述'],
+        },
+        {
+          key: 'project-impact',
+          module: 'projects',
+          title: '补强项目结果表达',
+          reason: 'JD 更关心“做过什么并产生了什么结果”，项目模块最适合承载这类信息。',
+          actions: ['补一条量化结果', '补一条主导职责描述'],
+        },
+      ],
+    };
   }
 
   if (scenario === 'resume-review') {
-    return `当前为缓存版简历建议预览，聚焦 ${keywords.join('、')}，用于演示稳定的 mock 分析结果。`;
+    return {
+      summary: '当前简历已经具备基础竞争力，但在面试前还需要进一步把成果、定位和差异化讲清楚。',
+      score: {
+        value: 76,
+        label: buildScoreLabel(76, locale),
+        reason: '技术覆盖已经具备，但简历对结果、主导范围和岗位定位的解释仍有提升空间。',
+      },
+      strengths: [
+        `已覆盖 ${keywords.join('、')} 等核心关键词。`,
+        '双语结构已经具备，适合继续做更细的针对性优化。',
+      ],
+      gaps: [
+        '缺少最能代表竞争力的量化成果。',
+        '顶部摘要还没有完全体现岗位定位与个人优势。',
+      ],
+      risks: [
+        '如果没有明确主导范围，容易在筛选时被理解为参与执行而不是负责推进。',
+      ],
+      suggestions: [
+        {
+          key: 'profile-summary',
+          module: 'profile',
+          title: '先优化个人摘要',
+          reason: '摘要是 HR 与面试官最快读取的入口，应先突出定位与结果。',
+          actions: ['补一条面向岗位的定位句', '加入一条代表性结果描述'],
+        },
+        {
+          key: 'experience-impact',
+          module: 'experiences',
+          title: '补强经历成果描述',
+          reason: '工作经历是最能证明能力与影响范围的模块，需要更具体的结果与职责信息。',
+          actions: ['补一条量化结果', '补一条主导职责描述'],
+        },
+      ],
+    };
   }
 
-  return `当前为缓存版 offer 对比预览，从 ${keywords.join('、')} 等维度给出可复用的演示结论。`;
+  return {
+    summary: '当前 offer 对比已经能形成初步判断，但要做更稳的决策，还需要先明确个人优先级与不能接受的风险。',
+    score: {
+      value: 68,
+      label: buildScoreLabel(68, locale),
+      reason: '当前对比维度已经有基础，但个人优先级与取舍依据还不够明确。',
+    },
+    strengths: [`当前已围绕 ${keywords.join('、')} 等维度形成基础对比框架。`],
+    gaps: ['还没有清晰排序成长空间、职责边界、薪资福利等个人优先级。'],
+    risks: ['如果只比较薪资，很容易忽略成长机会与岗位边界带来的长期影响。'],
+    suggestions: [
+      {
+        key: 'decision-priority',
+        title: '先确认决策优先级',
+        reason: '只有先明确你最重视什么，后续的 offer 建议才会更可信。',
+        actions: ['写下最重要的三个取舍维度', '补充一个绝对不能接受的风险点'],
+      },
+    ],
+  };
 }
 
-function buildSections(
-  scenario: AnalysisScenario,
-  keywords: string[],
+function sanitizeGeneratedSummary(
+  generatedText: string,
+  locale: AnalysisLocale,
+  fallbackSummary: string,
+): string {
+  const normalized = generatedText.replace(/\s+/g, ' ').trim();
+
+  if (!normalized || normalized.startsWith('Mock AI response')) {
+    return fallbackSummary;
+  }
+
+  const maxLength = locale === 'en' ? 220 : 120;
+  return normalized.slice(0, maxLength);
+}
+
+function buildFallbackGeneratedPayload(input: {
+  scenario: AnalysisScenario;
+  locale: AnalysisLocale;
+  keywords: string[];
+  generatedText: string;
+}): StructuredAnalysisPayload {
+  const mockPayload = buildMockStructuredPayload(
+    input.scenario,
+    input.keywords,
+    input.locale,
+  );
+
+  return {
+    ...mockPayload,
+    summary: sanitizeGeneratedSummary(
+      input.generatedText,
+      input.locale,
+      mockPayload.summary,
+    ),
+  };
+}
+
+function buildSectionsFromStructuredPayload(
+  payload: StructuredAnalysisPayload,
   locale: AnalysisLocale,
 ): AnalysisReportSection[] {
-  if (locale === 'en') {
-    if (scenario === 'jd-match') {
-      return [
-        {
-          key: 'match-overview',
-          title: 'Match Overview',
-          bullets: [
-            `The current input already mentions ${keywords[0]} and ${keywords[1] ?? keywords[0]}.`,
-            'This report is cached by normalized input and can be reused directly.',
-          ],
-        },
-        {
-          key: 'missing-signals',
-          title: 'Missing Signals',
-          bullets: [
-            'Add more quantified outcomes to improve credibility.',
-            'Clarify collaboration scope, ownership, and delivery impact.',
-          ],
-        },
-        {
-          key: 'next-actions',
-          title: 'Next Actions',
-          bullets: [
-            'Keep this cached preview for viewer demo mode.',
-            'Upgrade to real provider analysis in the next milestone step.',
-          ],
-        },
-      ];
-    }
-
-    if (scenario === 'resume-review') {
-      return [
-        {
-          key: 'strengths',
-          title: 'Strengths',
-          bullets: [
-            `The resume already exposes keywords like ${keywords.join(', ')}.`,
-            'Content blocks are ready for a later bilingual polishing flow.',
-          ],
-        },
-        {
-          key: 'risks',
-          title: 'Risks',
-          bullets: [
-            'Project outcomes may still feel too generic.',
-            'Technical depth can be supported by clearer architecture context.',
-          ],
-        },
-        {
-          key: 'recommendations',
-          title: 'Recommendations',
-          bullets: [
-            'Prepare one stronger summary sentence for each project.',
-            'Reserve this structure for later real AI review output.',
-          ],
-        },
-      ];
-    }
-
-    return [
-      {
-        key: 'comparison',
-        title: 'Comparison Axes',
-        bullets: [
-          `Use ${keywords.join(', ')} as demo dimensions for the mock report.`,
-          'Keep the current output deterministic for repeatable tutorials.',
-        ],
-      },
-      {
-        key: 'suggestion',
-        title: 'Suggestion',
-        bullets: [
-          'Prefer the option with clearer growth path and ownership scope.',
-          'Treat the current result as a cached walkthrough, not final advice.',
-        ],
-      },
-      {
-        key: 'follow-up',
-        title: 'Follow-up',
-        bullets: [
-          'Add real provider orchestration in the next AI milestone step.',
-          'Add viewer read-only access after role boundary refinement.',
-        ],
-      },
-    ];
-  }
-
-  if (scenario === 'jd-match') {
-    return [
-      {
-        key: 'match-overview',
-        title: '匹配概览',
-        bullets: [
-          `当前输入已经覆盖 ${keywords[0]}、${keywords[1] ?? keywords[0]} 等关键信号。`,
-          '结果按归一化输入缓存，可直接复用同一份预设报告。',
-        ],
-      },
-      {
-        key: 'missing-signals',
-        title: '待补信号',
-        bullets: [
-          '可继续补充量化结果与业务影响，增强可信度。',
-          '可补充协作范围、负责模块和落地结果。',
-        ],
-      },
-      {
-        key: 'next-actions',
-        title: '下一步建议',
-        bullets: [
-          '当前结果适合用于 viewer 体验态演示。',
-          '后续再接入真实 Provider 与任务编排。',
-        ],
-      },
-    ];
-  }
-
-  if (scenario === 'resume-review') {
-    return [
-      {
-        key: 'strengths',
-        title: '已有亮点',
-        bullets: [
-          `简历中已经体现 ${keywords.join('、')} 等关键词。`,
-          '内容结构适合后续继续补充双语润色与发布流。',
-        ],
-      },
-      {
-        key: 'risks',
-        title: '风险提示',
-        bullets: [
-          '项目成果描述还可以更具体，避免过于概括。',
-          '技术栈描述可增加架构背景与取舍说明。',
-        ],
-      },
-      {
-        key: 'recommendations',
-        title: '优化建议',
-        bullets: [
-          '为每个项目补一条最强结果描述。',
-          '当前结构先稳定下来，后续再替换成真实 AI 输出。',
-        ],
-      },
-    ];
-  }
-
   return [
     {
-      key: 'comparison',
-      title: '对比维度',
+      key: 'conclusion',
+      title: locale === 'en' ? 'Conclusion' : '结论摘要',
       bullets: [
-        `当前用 ${keywords.join('、')} 作为演示维度生成稳定 mock 结果。`,
-        '适合教程阶段重复演示缓存命中效果。',
+        payload.summary,
+        locale === 'en'
+          ? `Score: ${payload.score.value} / 100 · ${payload.score.label}`
+          : `评分：${payload.score.value} / 100 · ${payload.score.label}`,
+        payload.score.reason,
       ],
     },
     {
-      key: 'suggestion',
-      title: '建议结论',
+      key: 'evidence',
+      title: locale === 'en' ? 'Evidence' : '判断依据',
       bullets: [
-        '优先选择成长空间更清晰、职责边界更明确的一方。',
-        '当前输出仅作为缓存示例，不作为真实决策建议。',
-      ],
+        ...payload.strengths.map((item) =>
+          locale === 'en' ? `Strength: ${item}` : `优势：${item}`,
+        ),
+        ...payload.gaps.map((item) =>
+          locale === 'en' ? `Gap: ${item}` : `缺口：${item}`,
+        ),
+      ].slice(0, 6),
     },
     {
-      key: 'follow-up',
-      title: '后续补充',
-      bullets: [
-        '下一步接入真实 Provider 与管理员触发能力。',
-        '随后再补 viewer 只读缓存体验闭环。',
-      ],
+      key: 'risks',
+      title: locale === 'en' ? 'Risks' : '风险提示',
+      bullets: payload.risks,
+    },
+    {
+      key: 'suggestions',
+      title: locale === 'en' ? 'Suggestions' : '建议动作',
+      bullets: payload.suggestions.flatMap((item) => [
+        item.module
+          ? locale === 'en'
+            ? `${item.title} (${item.module})`
+            : `${item.title}（${item.module}）`
+          : item.title,
+        item.reason,
+        ...item.actions,
+      ]),
     },
   ];
+}
+
+function buildReportFromPayload(input: {
+  scenario: AnalysisScenario;
+  locale: AnalysisLocale;
+  normalizedContent: string;
+  sourceHash: string;
+  cacheKey: string;
+  generator: AnalysisReport['generator'];
+  payload: StructuredAnalysisPayload;
+}): AnalysisReport {
+  return {
+    reportId: `${input.scenario}-${input.sourceHash.slice(0, 12)}`,
+    cacheKey: input.cacheKey,
+    scenario: input.scenario,
+    locale: input.locale,
+    sourceHash: input.sourceHash,
+    inputPreview: buildInputPreview(input.normalizedContent),
+    summary: input.payload.summary,
+    score: input.payload.score,
+    strengths: input.payload.strengths,
+    gaps: input.payload.gaps,
+    risks: input.payload.risks,
+    suggestions: input.payload.suggestions,
+    sections: buildSectionsFromStructuredPayload(input.payload, input.locale),
+    generator: input.generator,
+    createdAt: new Date().toISOString(),
+  };
 }
 
 @Injectable()
@@ -310,18 +712,16 @@ export class AnalysisReportCacheService {
     }
 
     const keywords = extractKeywords(normalizedContent, locale);
-    const report: AnalysisReport = {
-      reportId: `${scenario}-${sourceHash.slice(0, 12)}`,
-      cacheKey,
+    const payload = buildMockStructuredPayload(scenario, keywords, locale);
+    const report = buildReportFromPayload({
       scenario,
       locale,
+      normalizedContent,
       sourceHash,
-      inputPreview: buildInputPreview(normalizedContent),
-      summary: buildSummary(scenario, keywords, locale),
-      sections: buildSections(scenario, keywords, locale),
+      cacheKey,
       generator: 'mock-cache',
-      createdAt: new Date().toISOString(),
-    };
+      payload,
+    });
 
     this.cache.set(cacheKey, report);
     this.reportIndex.set(report.reportId, report);
@@ -343,46 +743,23 @@ export class AnalysisReportCacheService {
 
     const sourceHash = computeHash(normalizedContent);
     const cacheKey = `${scenario}:${locale}:${sourceHash}`;
-    const report: AnalysisReport = {
-      reportId: `${scenario}-${sourceHash.slice(0, 12)}`,
-      cacheKey,
+    const keywords = extractKeywords(normalizedContent, locale);
+    const payload = this.resolveGeneratedPayload({
       scenario,
       locale,
+      keywords,
+      generatedText: input.generatedText,
+    });
+
+    const report = buildReportFromPayload({
+      scenario,
+      locale,
+      normalizedContent,
       sourceHash,
-      inputPreview: buildInputPreview(normalizedContent),
-      summary: input.generatedText.trim(),
-      sections: [
-        {
-          key: 'analysis-result',
-          title: locale === 'en' ? 'Analysis Result' : '分析结果',
-          bullets: [input.generatedText.trim()],
-        },
-        {
-          key: 'provider',
-          title: locale === 'en' ? 'Provider Info' : 'Provider 信息',
-          bullets: [
-            `${input.providerSummary.provider} / ${input.providerSummary.model}`,
-            locale === 'en'
-              ? `Runtime mode: ${input.providerSummary.mode}`
-              : `运行模式：${input.providerSummary.mode}`,
-          ],
-        },
-        {
-          key: 'next-step',
-          title: locale === 'en' ? 'Next Step' : '下一步',
-          bullets: [
-            locale === 'en'
-              ? 'Viewer can now read this cached result without triggering a new request.'
-              : '当前结果已进入缓存，viewer 可直接只读查看。',
-            locale === 'en'
-              ? 'This endpoint stays as the admin trigger boundary for later real AI integration.'
-              : '该入口作为后续真实 AI 接入前的管理员触发边界。',
-          ],
-        },
-      ],
+      cacheKey,
       generator: 'ai-provider',
-      createdAt: new Date().toISOString(),
-    };
+      payload,
+    });
 
     this.cache.set(cacheKey, report);
     this.reportIndex.set(report.reportId, report);
@@ -415,6 +792,22 @@ export class AnalysisReportCacheService {
     }
 
     return report;
+  }
+
+  private resolveGeneratedPayload(input: {
+    scenario: AnalysisScenario;
+    locale: AnalysisLocale;
+    keywords: string[];
+    generatedText: string;
+  }): StructuredAnalysisPayload {
+    try {
+      return validateStructuredAnalysisPayload(
+        JSON.parse(extractJsonObject(input.generatedText)),
+        input.locale,
+      );
+    } catch {
+      return buildFallbackGeneratedPayload(input);
+    }
   }
 
   private validateScenario(scenario: string): AnalysisScenario {

--- a/apps/server/test/ai-report-cache.e2e-spec.ts
+++ b/apps/server/test/ai-report-cache.e2e-spec.ts
@@ -59,7 +59,12 @@ describe('AI report cache (e2e)', () => {
       .expect(200);
 
     expect(detail.body.reportId).toBe(first.body.report.reportId);
-    expect(detail.body.sections).toHaveLength(3);
+    expect(detail.body.score.value).toBeGreaterThan(0);
+    expect(detail.body.strengths.length).toBeGreaterThan(0);
+    expect(detail.body.gaps.length).toBeGreaterThan(0);
+    expect(detail.body.risks.length).toBeGreaterThan(0);
+    expect(detail.body.suggestions.length).toBeGreaterThan(0);
+    expect(detail.body.sections).toHaveLength(4);
   });
 
   it('should reject unsupported analysis scenarios', async () => {

--- a/apps/server/test/ai-report-role-access.e2e-spec.ts
+++ b/apps/server/test/ai-report-role-access.e2e-spec.ts
@@ -171,6 +171,11 @@ describe('AI report role access (e2e)', () => {
 
     expect(response.body.report.generator).toBe('ai-provider');
     expect(response.body.report.summary.length).toBeGreaterThan(0);
+    expect(response.body.report.score.value).toBeGreaterThan(0);
+    expect(response.body.report.strengths.length).toBeGreaterThan(0);
+    expect(response.body.report.gaps.length).toBeGreaterThan(0);
+    expect(response.body.report.risks.length).toBeGreaterThan(0);
+    expect(response.body.report.suggestions.length).toBeGreaterThan(0);
 
     const optimizeResponse = await request(app.getHttpServer())
       .post('/ai/reports/resume-optimize')

--- a/docs/30-开发日志/M12-issue-121-AI-分析结果契约稳定化.md
+++ b/docs/30-开发日志/M12-issue-121-AI-分析结果契约稳定化.md
@@ -1,0 +1,239 @@
+# M12 / issue-121 开发日志：AI 分析结果契约稳定化
+
+- Issue：`#121`
+- 里程碑：`M12 开源版收尾与智能简历改写`
+- 分支：`fys-dev/feat-m12-ai-analysis-contract-stabilization`
+- 日期：`2026-03-31`
+
+## 背景
+
+当前仓库已经具备 AI 工作台最小闭环：
+
+- 管理员可上传文件
+- 管理员可触发真实分析
+- 管理员可生成结构化简历建议并一键应用到草稿
+- viewer 只能读取缓存结果
+
+但 `POST /ai/reports/analyze` 仍偏“工程验证态”：
+
+- 返回主内容还是自由文本
+- 前端主要依赖 `summary + sections`
+- 结果虽然能显示，但还不够稳定、可解释、可继续长成产品能力
+
+如果继续沿着自由文本往下做，会出现两个问题：
+
+- 前端越来越需要“猜”字段含义
+- 后续 diff / apply / 模块级确认会缺少稳定上游输入
+
+所以这轮先不继续扩 UI，而是先把“分析结果契约”收住。
+
+## 本次目标
+
+- 稳定 `POST /ai/reports/analyze` 的响应结构
+- 让结果明确分成“结论层 / 依据层 / 建议层”
+- 给关键字段补上代码注释，说明字段存在理由与呈现意图
+- 为后续建议稿 diff 预览和模块级 apply 打地基
+
+## 非目标
+
+- 不做 diff 预览
+- 不做模块级勾选 apply
+- 不重做整个 AI 工作台页面结构
+- 不引入 AI 历史持久化或任务队列
+- 不扩展 viewer 新能力
+
+## TDD / 测试设计
+
+### 1. 先锁服务端结构化契约
+
+更新：
+
+- `apps/server/src/modules/ai/analysis-report-cache.service.spec.ts`
+- `apps/server/test/ai-report-role-access.e2e-spec.ts`
+- `apps/server/test/ai-report-cache.e2e-spec.ts`
+
+验证：
+
+- mock 缓存报告必须稳定返回 `score / strengths / gaps / risks / suggestions`
+- 管理员真实分析返回的结果也必须具备同样的结构
+- 兼容层 `sections` 仍然存在，但不再是唯一主结构
+
+### 2. 再锁前端结构化展示
+
+更新：
+
+- `apps/admin/components/ai-analysis-panel.spec.tsx`
+
+验证：
+
+- 后台分析面板不再只渲染旧的 `sections`
+- 页面能够直接展示：
+  - 评分
+  - 判断理由
+  - 已有优势
+  - 待补缺口
+  - 风险提示
+  - 建议动作
+
+## 实际改动
+
+### 1. 服务端新增稳定的结构化分析字段
+
+更新：
+
+- `apps/server/src/modules/ai/analysis-report-cache.service.ts`
+
+新增结构：
+
+- `score`
+- `strengths`
+- `gaps`
+- `risks`
+- `suggestions`
+
+并补了字段级注释，说明：
+
+- `score` 用来帮助用户快速判断优先级，不是绝对分
+- `strengths / gaps / risks` 是让用户“理解并信服”的依据层
+- `suggestions` 要尽量指向 `profile / experiences / projects / highlights`
+- `sections` 当前作为兼容层保留，避免本轮一次性打碎缓存阅读面板
+
+### 2. 真实 Provider 改成优先返回 JSON
+
+更新：
+
+- `apps/server/src/modules/ai/ai-report.controller.ts`
+
+这轮把 `analyze` 的 prompt 收成了：
+
+- 明确要求只输出 JSON
+- 明确输出字段结构
+- 明确 `strengths / gaps / risks / suggestions` 各自承担什么业务语义
+
+同时保留了 fallback：
+
+- 如果 Provider 没有返回合法 JSON
+- 或当前处于 mock 模式
+
+服务端仍会生成一份稳定的结构化结果，保证开源环境和教程环境都能继续工作。
+
+### 3. 后台分析面板改成三层展示
+
+更新：
+
+- `apps/admin/lib/ai-workbench-types.ts`
+- `apps/admin/components/ai-analysis-panel.tsx`
+
+页面上现在明确分成三层：
+
+- 结论层：摘要 + 评分 + 判断理由
+- 依据层：已有优势 / 待补缺口 / 风险提示
+- 建议层：建议模块 + 原因 + 可执行动作
+
+这比之前只显示一段文本更稳，因为用户可以先理解：
+
+- 结果是什么
+- 为什么这样判断
+- 建议改哪里
+
+再决定后续是否继续生成建议稿、是否应用到草稿。
+
+## Review 记录
+
+### 是否符合当前 Issue 与里程碑目标
+
+符合。
+
+本轮只收：
+
+- `analyze` 契约稳定化
+- 后台分析结果结构化展示
+- 相关测试与注释
+
+没有越界去做：
+
+- diff 预览
+- 模块级 apply
+- AI 历史
+- 队列与任务中心
+
+### 是否存在可抽离的组件、公共函数、skills 或其他复用能力
+
+有一个潜在抽离点：
+
+- “分析结果展示卡片”后续可以抽成共享组件
+
+但当前只有 AI 工作台一处消费，而且下一期还会继续长出 diff 预览与模块选择，所以这轮刻意不提前抽，以免过早抽象。
+
+### 本次最重要的边界判断
+
+这轮的关键不是“让 AI 返回更多字段”，而是：
+
+- 不再让前端从自由文本里猜结构
+- 先把结果解释清楚，再谈建议稿与 apply
+
+也就是说，这轮是把 AI 能力从“黑盒按钮”往“可解释辅助决策”推进了一层。
+
+## 自测结果
+
+已执行：
+
+- `pnpm --filter @my-resume/server test -- src/modules/ai/analysis-report-cache.service.spec.ts`
+- `pnpm --filter @my-resume/admin test -- components/ai-analysis-panel.spec.tsx`
+- `pnpm --filter @my-resume/server typecheck`
+- `pnpm --filter @my-resume/admin typecheck`
+- `pnpm --filter @my-resume/server test:e2e`
+
+结果：
+
+- 服务端分析契约测试通过
+- 后台结构化展示测试通过
+- `server / admin` 类型检查通过
+- `server` e2e 通过
+
+补充说明：
+
+- `server` e2e 在当前沙箱内直接运行会因为端口权限报 `listen EPERM`
+- 提权后重跑通过，说明本轮改动本身没有引入接口回归
+
+## 遇到的问题
+
+### 1. 真实 Provider 不一定稳定返回 JSON
+
+问题：
+
+即使 prompt 已经要求 JSON，真实 Provider 仍有可能返回自由文本或夹带代码块。
+
+处理：
+
+- 服务端先尝试解析 JSON
+- 失败后回退到稳定的 fallback 结构
+
+这样可以同时保证：
+
+- 真实 Provider 优先输出结构化结果
+- mock 与异常响应也不会打断当前开源版主线
+
+### 2. viewer 缓存阅读面板不能被本轮顺手打碎
+
+问题：
+
+如果直接删掉旧的 `sections`，当前缓存阅读面板会被连带打碎，超出本轮范围。
+
+处理：
+
+- 保留 `sections` 作为兼容层
+- 主展示面板先转向新结构字段
+- 缓存阅读面板后续再在独立 issue 中继续收
+
+## 后续切入点
+
+这轮完成后，后续最自然的下一步是：
+
+1. 基于 `suggestions` 做建议稿 diff 预览
+2. 将建议稿应用改成模块级确认，而不是直接一键写回
+3. 继续整理 AI 输入体验，让 `JD / 优化要求 / offer 对比` 的入口更清楚
+
+## 一句话总结
+
+这轮不是把 AI 做得“更花”，而是把 AI 的分析结果先做得“更像一个可信的产品输入”。


### PR DESCRIPTION
## Summary
- stabilize `POST /ai/reports/analyze` around a structured result contract instead of free-form text only
- add conclusion / evidence / suggestion fields with code comments that explain product intent and later diff/apply usage
- update the admin AI analysis panel to render score, strengths, gaps, risks, and actionable suggestions
- add dev log and update server/admin tests to lock the new contract

## Related Issue
- Closes #121

## Scope
- [x] Only current issue scope
- [x] No unrelated refactor included

## Testing
- [x] `pnpm --filter @my-resume/server test -- src/modules/ai/analysis-report-cache.service.spec.ts`
- [x] `pnpm --filter @my-resume/admin test -- components/ai-analysis-panel.spec.tsx`
- [x] `pnpm --filter @my-resume/server typecheck`
- [x] `pnpm --filter @my-resume/admin typecheck`
- [x] `pnpm --filter @my-resume/server test:e2e`

## Notes
- `sections` is intentionally kept as a compatibility layer for cached report reading, while the main admin analysis experience has moved to the new structured fields.
- server e2e needed to run outside the sandbox in this environment because the local test server needs temporary port binding.
