### PR TITLE
feat(m12): add ai diff preview and module apply

### DIFF
--- a/apps/admin/app/globals.css
+++ b/apps/admin/app/globals.css
@@ -294,9 +294,43 @@ textarea {
   );
 }
 
+.module-diff-header {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.module-check {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.65rem;
+  color: var(--display-color-text-muted);
+}
+
+.module-check input {
+  width: auto;
+  margin: 0;
+}
+
+.module-diff-stack {
+  display: grid;
+  gap: 0.85rem;
+}
+
+.module-diff-entry {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.module-diff-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.75rem;
+}
+
 @media (max-width: 960px) {
   .analysis-section-grid,
   .dashboard-main-grid,
+  .module-diff-grid,
   .scenario-grid {
     grid-template-columns: minmax(0, 1fr);
   }

--- a/apps/admin/components/ai-analysis-panel.spec.tsx
+++ b/apps/admin/components/ai-analysis-panel.spec.tsx
@@ -59,10 +59,10 @@ const runtimeSummary = {
 };
 
 function ControlledAnalysisPanel(props: {
+  applyResumeOptimization?: typeof import('../lib/ai-workbench-api').applyAiResumeOptimization;
   canAnalyze: boolean;
   generateResumeOptimization?: typeof import('../lib/ai-workbench-api').generateAiResumeOptimization;
   helperMessage?: string | null;
-  saveDraft?: typeof import('../lib/resume-draft-api').updateDraftResume;
   triggerAnalysis?: typeof import('../lib/ai-workbench-api').triggerAiWorkbenchAnalysis;
   initialContent?: string;
 }) {
@@ -77,8 +77,8 @@ function ControlledAnalysisPanel(props: {
       helperMessage={props.helperMessage}
       onContentChange={setContent}
       runtimeSummary={runtimeSummary}
+      applyResumeOptimization={props.applyResumeOptimization}
       generateResumeOptimization={props.generateResumeOptimization}
-      saveDraft={props.saveDraft}
       triggerAnalysis={props.triggerAnalysis}
     />
   );
@@ -227,12 +227,60 @@ describe('AiAnalysisPanel', () => {
     expect(triggerAnalysis).not.toHaveBeenCalled();
   });
 
-  it('should generate a structured suggestion and apply it to the draft', async () => {
+  it('should preview module diffs and apply only the selected modules', async () => {
     const user = userEvent.setup();
     const generateResumeOptimization = vi.fn().mockResolvedValue({
       summary: '已生成结构化建议稿',
       focusAreas: ['强化摘要', '补强项目亮点'],
       changedModules: ['profile', 'projects'],
+      moduleDiffs: [
+        {
+          module: 'profile',
+          title: '个人定位与摘要',
+          reason: '个人摘要决定面试官最先看到的岗位定位。',
+          entries: [
+            {
+              key: 'profile-summary',
+              label: '个人摘要',
+              before: '中文：原始中文摘要 | English: Original English summary',
+              after: '中文：新的中文摘要 | English: New English summary',
+            },
+          ],
+        },
+        {
+          module: 'projects',
+          title: '项目摘要与亮点',
+          reason: '项目经历能证明技术方案、业务场景和个人贡献。',
+          entries: [
+            {
+              key: 'project-0-summary',
+              label: '项目 1 摘要',
+              before: '中文：旧项目摘要 | English: Old project summary',
+              after: '中文：新项目摘要 | English: New project summary',
+            },
+          ],
+        },
+      ],
+      applyPayload: {
+        draftUpdatedAt: '2026-03-30T00:00:00.000Z',
+        patch: {
+          profile: {
+            summary: {
+              zh: '新的中文摘要',
+              en: 'New English summary',
+            },
+          },
+          projects: [
+            {
+              index: 0,
+              summary: {
+                zh: '新项目摘要',
+                en: 'New project summary',
+              },
+            },
+          ],
+        },
+      },
       suggestedResume: {
         ...createTestResume(),
         profile: {
@@ -249,7 +297,7 @@ describe('AiAnalysisPanel', () => {
         mode: 'openai-compatible',
       },
     });
-    const saveDraft = vi.fn().mockResolvedValue({
+    const applyResumeOptimization = vi.fn().mockResolvedValue({
       status: 'draft',
       resume: createTestResume(),
       updatedAt: '2026-03-30T00:00:00.000Z',
@@ -257,10 +305,10 @@ describe('AiAnalysisPanel', () => {
 
     render(
       <ControlledAnalysisPanel
+        applyResumeOptimization={applyResumeOptimization}
         canAnalyze
         generateResumeOptimization={generateResumeOptimization}
         initialContent="请根据 React 和 Next.js 岗位优化当前简历"
-        saveDraft={saveDraft}
       />,
     );
 
@@ -277,15 +325,24 @@ describe('AiAnalysisPanel', () => {
     });
 
     expect(await screen.findByText('已生成结构化建议稿')).toBeInTheDocument();
-    expect(screen.getByText('模块：profile')).toBeInTheDocument();
+    expect(screen.getAllByText('模块：profile').length).toBeGreaterThan(0);
+    expect(screen.getByText('个人定位与摘要')).toBeInTheDocument();
+    expect(screen.getByText('个人摘要')).toBeInTheDocument();
+    expect(screen.getAllByText('当前草稿').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('建议稿').length).toBeGreaterThan(0);
 
-    await user.click(screen.getByRole('button', { name: '一键应用到当前草稿' }));
+    await user.click(
+      screen.getByRole('checkbox', { name: '应用模块：projects' }),
+    );
+    await user.click(screen.getByRole('button', { name: '应用已选模块到当前草稿' }));
 
     await waitFor(() => {
-      expect(saveDraft).toHaveBeenCalledWith({
+      expect(applyResumeOptimization).toHaveBeenCalledWith({
         apiBaseUrl: 'http://localhost:5577',
         accessToken: 'demo-token',
-        resume: expect.objectContaining({
+        draftUpdatedAt: '2026-03-30T00:00:00.000Z',
+        modules: ['profile'],
+        patch: expect.objectContaining({
           profile: expect.objectContaining({
             summary: {
               zh: '新的中文摘要',
@@ -298,7 +355,7 @@ describe('AiAnalysisPanel', () => {
 
     expect(
       await screen.findByText(
-        'AI 建议稿已应用到当前草稿。公开站内容不会自动变化，仍需手动发布。',
+        '已将 1 个模块应用到当前草稿。公开站内容不会自动变化，仍需手动发布。',
       ),
     ).toBeInTheDocument();
   });

--- a/apps/admin/components/ai-analysis-panel.tsx
+++ b/apps/admin/components/ai-analysis-panel.tsx
@@ -8,28 +8,29 @@ import {
 import { useState } from 'react';
 
 import {
+  applyAiResumeOptimization,
   generateAiResumeOptimization,
   triggerAiWorkbenchAnalysis,
 } from '../lib/ai-workbench-api';
 import {
+  AiResumeOptimizationChangedModule,
   AiResumeOptimizationResult,
   AiWorkbenchLocale,
   AiWorkbenchReport,
   AiWorkbenchRuntimeSummary,
   AiWorkbenchScenario,
 } from '../lib/ai-workbench-types';
-import { updateDraftResume } from '../lib/resume-draft-api';
 
 interface AiAnalysisPanelProps {
   accessToken: string;
   apiBaseUrl: string;
+  applyResumeOptimization?: typeof applyAiResumeOptimization;
   canAnalyze: boolean;
   content: string;
   helperMessage?: string | null;
   onContentChange: (value: string) => void;
   runtimeSummary: AiWorkbenchRuntimeSummary;
   generateResumeOptimization?: typeof generateAiResumeOptimization;
-  saveDraft?: typeof updateDraftResume;
   triggerAnalysis?: typeof triggerAiWorkbenchAnalysis;
 }
 
@@ -86,13 +87,13 @@ function formatScore(report: AiWorkbenchReport): string {
 export function AiAnalysisPanel({
   accessToken,
   apiBaseUrl,
+  applyResumeOptimization = applyAiResumeOptimization,
   canAnalyze,
   content,
   helperMessage,
   onContentChange,
   runtimeSummary,
   generateResumeOptimization = generateAiResumeOptimization,
-  saveDraft = updateDraftResume,
   triggerAnalysis = triggerAiWorkbenchAnalysis,
 }: AiAnalysisPanelProps) {
   const [scenario, setScenario] = useState<AiWorkbenchScenario>('resume-review');
@@ -106,6 +107,9 @@ export function AiAnalysisPanel({
   );
   const [suggestion, setSuggestion] =
     useState<AiResumeOptimizationResult | null>(null);
+  const [selectedModules, setSelectedModules] = useState<
+    AiResumeOptimizationChangedModule[]
+  >([]);
   const [applyPending, setApplyPending] = useState(false);
   const [applyFeedbackMessage, setApplyFeedbackMessage] = useState<string | null>(
     null,
@@ -189,8 +193,10 @@ export function AiAnalysisPanel({
       });
 
       setSuggestion(result);
+      setSelectedModules(result.changedModules);
     } catch (error) {
       setSuggestion(null);
+      setSelectedModules([]);
       setSuggestionErrorMessage(
         error instanceof Error ? error.message : '结构化简历建议生成失败，请稍后重试',
       );
@@ -199,8 +205,21 @@ export function AiAnalysisPanel({
     }
   }
 
+  function toggleSelectedModule(module: AiResumeOptimizationChangedModule) {
+    setSelectedModules((currentModules) =>
+      currentModules.includes(module)
+        ? currentModules.filter((item) => item !== module)
+        : [...currentModules, module],
+    );
+  }
+
   async function handleApplySuggestion() {
     if (!suggestion) {
+      return;
+    }
+
+    if (selectedModules.length === 0) {
+      setSuggestionErrorMessage('请至少勾选一个要应用到草稿的模块。');
       return;
     }
 
@@ -209,14 +228,16 @@ export function AiAnalysisPanel({
     setApplyFeedbackMessage(null);
 
     try {
-      await saveDraft({
+      await applyResumeOptimization({
         apiBaseUrl,
         accessToken,
-        resume: suggestion.suggestedResume,
+        draftUpdatedAt: suggestion.applyPayload.draftUpdatedAt,
+        modules: selectedModules,
+        patch: suggestion.applyPayload.patch,
       });
 
       setApplyFeedbackMessage(
-        'AI 建议稿已应用到当前草稿。公开站内容不会自动变化，仍需手动发布。',
+        `已将 ${selectedModules.length} 个模块应用到当前草稿。公开站内容不会自动变化，仍需手动发布。`,
       );
     } catch (error) {
       setSuggestionErrorMessage(
@@ -470,7 +491,7 @@ export function AiAnalysisPanel({
           <DisplaySurfaceCard className="analysis-summary-card">
             <DisplaySectionIntro
               compact
-              description="当前开源版先只做结构化改写建议和一键应用草稿，不继续扩张到历史与多版本管理。"
+              description="当前开源版先只做结构化改写建议、模块级确认和服务端 apply，不继续扩张到历史与多版本管理。"
               eyebrow="建议摘要"
               title="AI 建议稿说明"
               titleAs="h3"
@@ -485,21 +506,75 @@ export function AiAnalysisPanel({
             ) : null}
           </DisplaySurfaceCard>
 
+          <div className="analysis-section-grid">
+            {suggestion.moduleDiffs.map((moduleDiff) => {
+              const checked = selectedModules.includes(moduleDiff.module);
+
+              return (
+                <DisplaySurfaceCard
+                  as="article"
+                  className="analysis-section-card"
+                  key={moduleDiff.module}
+                >
+                  <div className="module-diff-header">
+                    <DisplaySectionIntro
+                      compact
+                      description={moduleDiff.reason}
+                      eyebrow={`模块：${moduleDiff.module}`}
+                      title={moduleDiff.title}
+                      titleAs="h3"
+                    />
+                    <label className="module-check">
+                      <input
+                        checked={checked}
+                        onChange={() => toggleSelectedModule(moduleDiff.module)}
+                        type="checkbox"
+                      />
+                      <span>{`应用模块：${moduleDiff.module}`}</span>
+                    </label>
+                  </div>
+
+                  <div className="module-diff-stack">
+                    {moduleDiff.entries.map((entry) => (
+                      <div className="module-diff-entry" key={entry.key}>
+                        <strong>{entry.label}</strong>
+                        <div className="module-diff-grid">
+                          <div className="status-box">
+                            <strong>当前草稿</strong>
+                            <span>{entry.before}</span>
+                          </div>
+                          <div className="status-box">
+                            <strong>建议稿</strong>
+                            <span>{entry.after}</span>
+                          </div>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </DisplaySurfaceCard>
+              );
+            })}
+          </div>
+
           <DisplaySurfaceCard className="card stack">
             <DisplaySectionIntro
               compact
-              description="一键应用会覆盖当前草稿，但不会自动发布到公开站。"
+              description="只有勾选的模块会被服务端写回当前草稿，避免前端整份覆盖。"
               eyebrow="草稿应用"
-              title="将建议稿写回当前草稿"
+              title="将已选模块写回当前草稿"
               titleAs="h3"
             />
+            <div className="dashboard-inline-note">
+              当前已选择 {selectedModules.length} / {suggestion.changedModules.length}{' '}
+              个模块。
+            </div>
             <div className="dashboard-entry-actions">
               <button
-                disabled={applyPending}
+                disabled={applyPending || selectedModules.length === 0}
                 onClick={() => void handleApplySuggestion()}
                 type="button"
               >
-                {applyPending ? '正在应用到草稿...' : '一键应用到当前草稿'}
+                {applyPending ? '正在应用到草稿...' : '应用已选模块到当前草稿'}
               </button>
             </div>
           </DisplaySurfaceCard>

--- a/apps/admin/lib/ai-workbench-api.spec.ts
+++ b/apps/admin/lib/ai-workbench-api.spec.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
+  applyAiResumeOptimization,
   fetchCachedAiWorkbenchReport,
   fetchCachedAiWorkbenchReports,
   fetchAiWorkbenchRuntime,
@@ -211,6 +212,32 @@ describe('ai workbench api client', () => {
           summary: '已生成结构化建议',
           focusAreas: ['强化摘要', '补强项目亮点'],
           changedModules: ['profile', 'projects'],
+          moduleDiffs: [
+            {
+              module: 'profile',
+              title: '个人定位与摘要',
+              reason: '个人摘要决定面试官最先看到的岗位定位。',
+              entries: [
+                {
+                  key: 'profile-summary',
+                  label: '个人摘要',
+                  before: '中文：原摘要 | English: Original summary',
+                  after: '中文：新的中文摘要 | English: New English summary',
+                },
+              ],
+            },
+          ],
+          applyPayload: {
+            draftUpdatedAt: '2026-03-30T00:00:00.000Z',
+            patch: {
+              profile: {
+                summary: {
+                  zh: '新的中文摘要',
+                  en: 'New English summary',
+                },
+              },
+            },
+          },
           suggestedResume: {
             meta: {
               slug: 'standard-resume',
@@ -278,6 +305,96 @@ describe('ai workbench api client', () => {
       }),
     );
     expect(response.changedModules).toEqual(['profile', 'projects']);
+    expect(response.moduleDiffs[0]?.entries[0]?.label).toBe('个人摘要');
+    expect(response.applyPayload.patch.profile?.summary?.zh).toBe('新的中文摘要');
     expect(response.suggestedResume.profile.summary.zh).toBe('新的中文摘要');
+  });
+
+  it('should apply selected resume optimization modules with bearer token', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          status: 'draft',
+          updatedAt: '2026-03-31T00:00:00.000Z',
+          resume: {
+            meta: {
+              slug: 'standard-resume',
+              version: 1,
+              defaultLocale: 'zh',
+              locales: ['zh', 'en'],
+            },
+            profile: {
+              fullName: {
+                zh: '付寅生',
+                en: 'Yinsheng Fu',
+              },
+              headline: {
+                zh: '前端工程师',
+                en: 'Frontend Engineer',
+              },
+              summary: {
+                zh: '新的中文摘要',
+                en: 'New English summary',
+              },
+              location: {
+                zh: '成都',
+                en: 'Chengdu',
+              },
+              email: 'demo@example.com',
+              phone: '123456789',
+              website: 'https://example.com',
+              links: [],
+              interests: [],
+            },
+            education: [],
+            experiences: [],
+            projects: [],
+            skills: [],
+            highlights: [],
+          },
+        }),
+      }),
+    );
+
+    const response = await applyAiResumeOptimization({
+      apiBaseUrl: 'http://localhost:5577',
+      accessToken: 'demo-token',
+      draftUpdatedAt: '2026-03-30T00:00:00.000Z',
+      modules: ['profile'],
+      patch: {
+        profile: {
+          summary: {
+            zh: '新的中文摘要',
+            en: 'New English summary',
+          },
+        },
+      },
+    });
+
+    expect(fetch).toHaveBeenCalledWith(
+      'http://localhost:5577/ai/reports/resume-optimize/apply',
+      expect.objectContaining({
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer demo-token',
+        },
+        body: JSON.stringify({
+          draftUpdatedAt: '2026-03-30T00:00:00.000Z',
+          modules: ['profile'],
+          patch: {
+            profile: {
+              summary: {
+                zh: '新的中文摘要',
+                en: 'New English summary',
+              },
+            },
+          },
+        }),
+      }),
+    );
+    expect(response.resume.profile.summary.zh).toBe('新的中文摘要');
   });
 });

--- a/apps/admin/lib/ai-workbench-api.ts
+++ b/apps/admin/lib/ai-workbench-api.ts
@@ -1,4 +1,6 @@
 import {
+  ApplyAiResumeOptimizationInput,
+  ApplyAiResumeOptimizationResult,
   AiResumeOptimizationResult,
   AiWorkbenchCachedReportSummary,
   AiWorkbenchLocale,
@@ -106,6 +108,40 @@ export async function generateAiResumeOptimization(
   }
 
   return (await response.json()) as AiResumeOptimizationResult;
+}
+
+export async function applyAiResumeOptimization(
+  input: ApplyAiResumeOptimizationInput,
+): Promise<ApplyAiResumeOptimizationResult> {
+  const response = await fetch(
+    joinApiUrl(input.apiBaseUrl, '/ai/reports/resume-optimize/apply'),
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${input.accessToken}`,
+      },
+      body: JSON.stringify({
+        draftUpdatedAt: input.draftUpdatedAt,
+        modules: input.modules,
+        patch: input.patch,
+      }),
+    },
+  );
+
+  if (!response.ok) {
+    const payload = (await response.json().catch(() => null)) as
+      | { message?: string | string[] }
+      | null;
+
+    const message = Array.isArray(payload?.message)
+      ? payload.message[0]
+      : payload?.message;
+
+    throw new Error(message || 'AI 建议稿应用失败，请稍后重试');
+  }
+
+  return (await response.json()) as ApplyAiResumeOptimizationResult;
 }
 
 export async function fetchCachedAiWorkbenchReports(

--- a/apps/admin/lib/ai-workbench-types.ts
+++ b/apps/admin/lib/ai-workbench-types.ts
@@ -1,4 +1,5 @@
 import type { StandardResume } from './resume-types';
+import type { LocalizedText, ResumeDraftSnapshot, ResumeHighlightItem } from './resume-types';
 
 export type AiWorkbenchScenario =
   | 'jd-match'
@@ -84,10 +85,61 @@ export type AiResumeOptimizationChangedModule =
   | 'projects'
   | 'highlights';
 
+export interface AiResumeOptimizationProfilePatch {
+  headline?: LocalizedText;
+  summary?: LocalizedText;
+}
+
+export interface AiResumeOptimizationExperiencePatch {
+  index: number;
+  summary?: LocalizedText;
+  highlights?: LocalizedText[];
+}
+
+export interface AiResumeOptimizationProjectPatch {
+  index: number;
+  summary?: LocalizedText;
+  highlights?: LocalizedText[];
+}
+
+export interface AiResumeOptimizationPatch {
+  profile?: AiResumeOptimizationProfilePatch;
+  experiences?: AiResumeOptimizationExperiencePatch[];
+  projects?: AiResumeOptimizationProjectPatch[];
+  highlights?: ResumeHighlightItem[];
+}
+
+export interface AiResumeOptimizationDiffEntry {
+  key: string;
+  label: string;
+  before: string;
+  after: string;
+}
+
+export interface AiResumeOptimizationModuleDiff {
+  module: AiResumeOptimizationChangedModule;
+  title: string;
+  reason: string;
+  entries: AiResumeOptimizationDiffEntry[];
+}
+
+export interface ApplyAiResumeOptimizationInput {
+  apiBaseUrl: string;
+  accessToken: string;
+  draftUpdatedAt: string;
+  modules: AiResumeOptimizationChangedModule[];
+  patch: AiResumeOptimizationPatch;
+}
+
 export interface AiResumeOptimizationResult {
   summary: string;
   focusAreas: string[];
   changedModules: AiResumeOptimizationChangedModule[];
+  moduleDiffs: AiResumeOptimizationModuleDiff[];
+  applyPayload: {
+    draftUpdatedAt: string;
+    patch: AiResumeOptimizationPatch;
+  };
   suggestedResume: StandardResume;
   providerSummary: {
     provider: string;
@@ -95,3 +147,5 @@ export interface AiResumeOptimizationResult {
     mode: string;
   };
 }
+
+export type ApplyAiResumeOptimizationResult = ResumeDraftSnapshot;

--- a/apps/server/src/modules/ai/ai-report.controller.ts
+++ b/apps/server/src/modules/ai/ai-report.controller.ts
@@ -2,6 +2,8 @@ import {
   Body,
   Controller,
   Get,
+  HttpCode,
+  HttpStatus,
   Inject,
   Param,
   Post,
@@ -13,6 +15,7 @@ import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { RoleCapabilitiesGuard } from '../auth/guards/role-capabilities.guard';
 import { AiService } from './ai.service';
 import {
+  ApplyResumeOptimizationInput,
   AiResumeOptimizationService,
   GenerateResumeOptimizationInput,
 } from './ai-resume-optimization.service';
@@ -29,6 +32,7 @@ interface CacheReportBody {
 }
 
 interface ResumeOptimizationBody extends GenerateResumeOptimizationInput {}
+interface ApplyResumeOptimizationBody extends ApplyResumeOptimizationInput {}
 
 const SUPPORTED_SCENARIOS: AnalysisScenario[] = [
   'jd-match',
@@ -99,6 +103,14 @@ export class AiReportController {
   @RequireCapability('canTriggerAiAnalysis')
   async optimizeResume(@Body() body: ResumeOptimizationBody) {
     return this.aiResumeOptimizationService.generateSuggestion(body);
+  }
+
+  @Post('resume-optimize/apply')
+  @HttpCode(HttpStatus.OK)
+  @UseGuards(RoleCapabilitiesGuard)
+  @RequireCapability('canEditResume')
+  async applyResumeOptimization(@Body() body: ApplyResumeOptimizationBody) {
+    return this.aiResumeOptimizationService.applySuggestion(body);
   }
 
   private buildAnalysisPrompt(body: CacheReportBody): string {

--- a/apps/server/src/modules/ai/ai-resume-optimization.service.spec.ts
+++ b/apps/server/src/modules/ai/ai-resume-optimization.service.spec.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import { ResumePublicationService } from '../resume/resume-publication.service';
-import { createExampleStandardResume } from '../resume/domain/standard-resume';
+import {
+  createExampleStandardResume,
+  type StandardResume,
+} from '../resume/domain/standard-resume';
 import { AiService } from './ai.service';
 import { AiResumeOptimizationService } from './ai-resume-optimization.service';
 
@@ -39,6 +42,10 @@ describe('AiResumeOptimizationService', () => {
     expect(result.focusAreas.length).toBeGreaterThan(0);
     expect(result.changedModules).toContain('profile');
     expect(result.suggestedResume.profile.summary.zh).toContain('Next.js');
+    expect(result.moduleDiffs.length).toBeGreaterThan(0);
+    expect(result.moduleDiffs[0]?.entries.length).toBeGreaterThan(0);
+    expect(result.applyPayload.draftUpdatedAt).toBe('2026-03-30T00:00:00.000Z');
+    expect(result.applyPayload.patch.profile?.summary?.zh).toContain('Next.js');
   });
 
   it('should parse provider JSON and merge it into the current resume draft', async () => {
@@ -98,6 +105,20 @@ describe('AiResumeOptimizationService', () => {
     expect(result.suggestedResume.profile.summary.zh).toBe('新的中文摘要');
     expect(result.suggestedResume.projects[0]?.summary.zh).toBe('新的项目摘要');
     expect(result.suggestedResume.profile.email).toBe(resume.profile.email);
+    expect(result.moduleDiffs).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          module: 'profile',
+          entries: expect.arrayContaining([
+            expect.objectContaining({
+              label: '个人摘要',
+              before: expect.any(String),
+              after: expect.any(String),
+            }),
+          ]),
+        }),
+      ]),
+    );
   });
 
   it('should reject invalid provider payloads', async () => {
@@ -133,5 +154,95 @@ describe('AiResumeOptimizationService', () => {
         locale: 'zh',
       }),
     ).rejects.toThrow('AI 返回的 summary 无效');
+  });
+
+  it('should apply only the selected modules back to the current draft', async () => {
+    const resume = createExampleStandardResume();
+    const updateDraft = vi.fn().mockImplementation(async (nextResume: StandardResume) => ({
+      status: 'draft',
+      resume: nextResume,
+      updatedAt: '2026-03-31T00:00:00.000Z',
+    }));
+    const aiService = {
+      getProviderSummary: () => ({
+        provider: 'mock',
+        model: 'mock-resume',
+        mode: 'mock',
+      }),
+      generateText: vi.fn(),
+    } as unknown as AiService;
+    const resumePublicationService = {
+      getDraft: vi.fn().mockResolvedValue({
+        status: 'draft',
+        resume,
+        updatedAt: '2026-03-30T00:00:00.000Z',
+      }),
+      updateDraft,
+    } as unknown as ResumePublicationService;
+
+    const service = new AiResumeOptimizationService(
+      aiService,
+      resumePublicationService,
+    );
+
+    const suggestion = await service.generateSuggestion({
+      instruction: '请针对 Next.js React TypeScript 岗位优化这份简历',
+      locale: 'zh',
+    });
+
+    await service.applySuggestion({
+      draftUpdatedAt: suggestion.applyPayload.draftUpdatedAt,
+      patch: suggestion.applyPayload.patch,
+      modules: ['profile'],
+    });
+
+    expect(updateDraft).toHaveBeenCalledTimes(1);
+    const nextResume = updateDraft.mock.calls[0]?.[0] as StandardResume;
+
+    expect(nextResume.profile.summary.zh).toContain('Next.js');
+    expect(nextResume.projects[0]?.summary.zh).toBe(resume.projects[0]?.summary.zh);
+    expect(nextResume.highlights[0]?.description.zh).toBe(
+      resume.highlights[0]?.description.zh,
+    );
+  });
+
+  it('should reject apply when the draft timestamp is stale', async () => {
+    const resume = createExampleStandardResume();
+    const aiService = {
+      getProviderSummary: () => ({
+        provider: 'mock',
+        model: 'mock-resume',
+        mode: 'mock',
+      }),
+      generateText: vi.fn(),
+    } as unknown as AiService;
+    const resumePublicationService = {
+      getDraft: vi.fn().mockResolvedValue({
+        status: 'draft',
+        resume,
+        updatedAt: '2026-03-31T00:00:00.000Z',
+      }),
+      updateDraft: vi.fn(),
+    } as unknown as ResumePublicationService;
+
+    const service = new AiResumeOptimizationService(
+      aiService,
+      resumePublicationService,
+    );
+
+    await expect(
+      service.applySuggestion({
+        draftUpdatedAt: '2026-03-30T00:00:00.000Z',
+        patch: {
+          profile: {
+            summary: {
+              zh: '新的中文摘要',
+              en: 'New English summary',
+            },
+          },
+        },
+        modules: ['profile'],
+      }),
+    ).rejects.toThrow('当前草稿已发生变化，请重新生成建议稿后再应用');
   });
 });

--- a/apps/server/src/modules/ai/ai-resume-optimization.service.ts
+++ b/apps/server/src/modules/ai/ai-resume-optimization.service.ts
@@ -1,6 +1,7 @@
 import {
   BadGatewayException,
   BadRequestException,
+  ConflictException,
   Inject,
   Injectable,
 } from '@nestjs/common';
@@ -17,30 +18,30 @@ import {
 import { AiService } from './ai.service';
 import { type AnalysisLocale } from './analysis-report-cache.service';
 
-type ResumeOptimizationModule =
+export type ResumeOptimizationModule =
   | 'profile'
   | 'experiences'
   | 'projects'
   | 'highlights';
 
-interface ResumeOptimizationProfilePatch {
+export interface ResumeOptimizationProfilePatch {
   headline?: LocalizedText;
   summary?: LocalizedText;
 }
 
-interface ResumeOptimizationExperiencePatch {
+export interface ResumeOptimizationExperiencePatch {
   index: number;
   summary?: LocalizedText;
   highlights?: LocalizedText[];
 }
 
-interface ResumeOptimizationProjectPatch {
+export interface ResumeOptimizationProjectPatch {
   index: number;
   summary?: LocalizedText;
   highlights?: LocalizedText[];
 }
 
-interface ResumeOptimizationPatch {
+export interface ResumeOptimizationPatch {
   profile?: ResumeOptimizationProfilePatch;
   experiences?: ResumeOptimizationExperiencePatch[];
   projects?: ResumeOptimizationProjectPatch[];
@@ -62,6 +63,8 @@ export interface GenerateResumeOptimizationResult {
   summary: string;
   focusAreas: string[];
   changedModules: ResumeOptimizationModule[];
+  moduleDiffs: ResumeOptimizationModuleDiff[];
+  applyPayload: ResumeOptimizationApplyPayload;
   suggestedResume: StandardResume;
   providerSummary: {
     provider: string;
@@ -70,12 +73,73 @@ export interface GenerateResumeOptimizationResult {
   };
 }
 
+export interface ResumeOptimizationDiffEntry {
+  key: string;
+  label: string;
+  before: string;
+  after: string;
+}
+
+export interface ResumeOptimizationModuleDiff {
+  module: ResumeOptimizationModule;
+  title: string;
+  /**
+   * reason 会直接展示给管理员，解释“为什么这个模块值得先确认再应用”。
+   * 开源版先把业务意图写清楚，避免 AI 建议被理解成黑盒覆盖。
+   */
+  reason: string;
+  entries: ResumeOptimizationDiffEntry[];
+}
+
+export interface ResumeOptimizationApplyPayload {
+  /**
+   * 用于校验建议稿是不是基于当前草稿生成的，避免旧建议误覆盖新草稿。
+   */
+  draftUpdatedAt: string;
+  /**
+   * applyPayload 只承载结构化 patch，而不是整份 suggestedResume。
+   * 这样服务端才能继续掌控模块级 apply 和最终结构校验。
+   */
+  patch: ResumeOptimizationPatch;
+}
+
+export interface ApplyResumeOptimizationInput {
+  draftUpdatedAt: string;
+  patch: unknown;
+  modules: ResumeOptimizationModule[];
+}
+
 function cloneResume(resume: StandardResume): StandardResume {
   return JSON.parse(JSON.stringify(resume)) as StandardResume;
 }
 
 function normalizeInstruction(instruction: string): string {
   return instruction.replace(/\s+/g, ' ').trim();
+}
+
+function normalizeModules(modules: unknown): ResumeOptimizationModule[] {
+  if (!Array.isArray(modules)) {
+    throw new BadRequestException('请选择要应用的简历模块');
+  }
+
+  const validModules: ResumeOptimizationModule[] = [
+    'profile',
+    'experiences',
+    'projects',
+    'highlights',
+  ];
+
+  const normalized = Array.from(new Set(modules)).flatMap((item) =>
+    validModules.includes(item as ResumeOptimizationModule)
+      ? [item as ResumeOptimizationModule]
+      : [],
+  );
+
+  if (normalized.length === 0) {
+    throw new BadRequestException('请至少选择一个要应用的简历模块');
+  }
+
+  return normalized;
 }
 
 function extractKeywords(
@@ -350,6 +414,20 @@ function applyPatch(
   return nextResume;
 }
 
+function pickPatchByModules(
+  patch: ResumeOptimizationPatch,
+  modules: ResumeOptimizationModule[],
+): ResumeOptimizationPatch {
+  const selected = new Set(modules);
+
+  return {
+    profile: selected.has('profile') ? patch.profile : undefined,
+    experiences: selected.has('experiences') ? patch.experiences : undefined,
+    projects: selected.has('projects') ? patch.projects : undefined,
+    highlights: selected.has('highlights') ? patch.highlights : undefined,
+  };
+}
+
 function detectChangedModules(
   previousResume: StandardResume,
   nextResume: StandardResume,
@@ -369,6 +447,252 @@ function detectChangedModules(
       JSON.stringify(nextResume[moduleKey])
     );
   }) as ResumeOptimizationModule[];
+}
+
+function formatLocalizedValue(value: LocalizedText | undefined): string {
+  const zh = value?.zh.trim() || '（空）';
+  const en = value?.en.trim() || '(empty)';
+
+  return `中文：${zh} | English: ${en}`;
+}
+
+function getModulePresentation(module: ResumeOptimizationModule): {
+  title: string;
+  reason: string;
+} {
+  switch (module) {
+    case 'profile':
+      return {
+        title: '个人定位与摘要',
+        reason:
+          '个人摘要和标题决定面试官最先如何理解你的岗位定位，是“是否继续看下去”的第一印象模块。',
+      };
+    case 'experiences':
+      return {
+        title: '工作经历与职责边界',
+        reason:
+          '工作经历是证明职责范围、协作方式和交付结果的主证据，直接影响面试官是否相信你的经历深度。',
+      };
+    case 'projects':
+      return {
+        title: '项目摘要与亮点',
+        reason:
+          '项目经历通常承载技术方案、业务场景和个人贡献，是和目标 JD 对齐时最容易被追问的部分。',
+      };
+    case 'highlights':
+      return {
+        title: '差异化亮点总结',
+        reason:
+          '亮点总结负责帮助招聘方快速记住你最值得被记住的信号，适合在 apply 前再次确认表达是否可信。',
+      };
+  }
+}
+
+function buildProfileDiff(
+  previousResume: StandardResume,
+  nextResume: StandardResume,
+  patch: ResumeOptimizationPatch,
+): ResumeOptimizationModuleDiff | null {
+  if (!patch.profile) {
+    return null;
+  }
+
+  const entries: ResumeOptimizationDiffEntry[] = [];
+
+  if (patch.profile.headline) {
+    entries.push({
+      key: 'profile-headline',
+      label: '个人标题',
+      before: formatLocalizedValue(previousResume.profile.headline),
+      after: formatLocalizedValue(nextResume.profile.headline),
+    });
+  }
+
+  if (patch.profile.summary) {
+    entries.push({
+      key: 'profile-summary',
+      label: '个人摘要',
+      before: formatLocalizedValue(previousResume.profile.summary),
+      after: formatLocalizedValue(nextResume.profile.summary),
+    });
+  }
+
+  if (entries.length === 0) {
+    return null;
+  }
+
+  return {
+    module: 'profile',
+    ...getModulePresentation('profile'),
+    entries,
+  };
+}
+
+function buildExperiencesDiff(
+  previousResume: StandardResume,
+  nextResume: StandardResume,
+  patch: ResumeOptimizationPatch,
+): ResumeOptimizationModuleDiff | null {
+  if (!patch.experiences || patch.experiences.length === 0) {
+    return null;
+  }
+
+  const entries: ResumeOptimizationDiffEntry[] = [];
+
+  patch.experiences.forEach((item) => {
+    const previousItem = previousResume.experiences[item.index];
+    const nextItem = nextResume.experiences[item.index];
+
+    if (!previousItem || !nextItem) {
+      return;
+    }
+
+    const scopeLabel = `${previousItem.companyName.zh} · ${previousItem.role.zh}`;
+
+    if (item.summary) {
+      entries.push({
+        key: `experience-${item.index}-summary`,
+        label: `${scopeLabel} / 经历摘要`,
+        before: formatLocalizedValue(previousItem.summary),
+        after: formatLocalizedValue(nextItem.summary),
+      });
+    }
+
+    if (item.highlights) {
+      item.highlights.forEach((_, highlightIndex) => {
+        entries.push({
+          key: `experience-${item.index}-highlight-${highlightIndex}`,
+          label: `${scopeLabel} / 亮点 ${highlightIndex + 1}`,
+          before: formatLocalizedValue(
+            previousItem.highlights[highlightIndex] as LocalizedText | undefined,
+          ),
+          after: formatLocalizedValue(
+            nextItem.highlights[highlightIndex] as LocalizedText | undefined,
+          ),
+        });
+      });
+    }
+  });
+
+  if (entries.length === 0) {
+    return null;
+  }
+
+  return {
+    module: 'experiences',
+    ...getModulePresentation('experiences'),
+    entries,
+  };
+}
+
+function buildProjectsDiff(
+  previousResume: StandardResume,
+  nextResume: StandardResume,
+  patch: ResumeOptimizationPatch,
+): ResumeOptimizationModuleDiff | null {
+  if (!patch.projects || patch.projects.length === 0) {
+    return null;
+  }
+
+  const entries: ResumeOptimizationDiffEntry[] = [];
+
+  patch.projects.forEach((item) => {
+    const previousItem = previousResume.projects[item.index];
+    const nextItem = nextResume.projects[item.index];
+
+    if (!previousItem || !nextItem) {
+      return;
+    }
+
+    const scopeLabel = `${previousItem.name.zh} · ${previousItem.role.zh}`;
+
+    if (item.summary) {
+      entries.push({
+        key: `project-${item.index}-summary`,
+        label: `${scopeLabel} / 项目摘要`,
+        before: formatLocalizedValue(previousItem.summary),
+        after: formatLocalizedValue(nextItem.summary),
+      });
+    }
+
+    if (item.highlights) {
+      item.highlights.forEach((_, highlightIndex) => {
+        entries.push({
+          key: `project-${item.index}-highlight-${highlightIndex}`,
+          label: `${scopeLabel} / 亮点 ${highlightIndex + 1}`,
+          before: formatLocalizedValue(
+            previousItem.highlights[highlightIndex] as LocalizedText | undefined,
+          ),
+          after: formatLocalizedValue(
+            nextItem.highlights[highlightIndex] as LocalizedText | undefined,
+          ),
+        });
+      });
+    }
+  });
+
+  if (entries.length === 0) {
+    return null;
+  }
+
+  return {
+    module: 'projects',
+    ...getModulePresentation('projects'),
+    entries,
+  };
+}
+
+function buildHighlightsDiff(
+  previousResume: StandardResume,
+  nextResume: StandardResume,
+  patch: ResumeOptimizationPatch,
+): ResumeOptimizationModuleDiff | null {
+  if (!patch.highlights || patch.highlights.length === 0) {
+    return null;
+  }
+
+  const entries: ResumeOptimizationDiffEntry[] = [];
+
+  patch.highlights.forEach((_, index) => {
+    entries.push({
+      key: `highlight-${index}-title`,
+      label: `亮点 ${index + 1} / 标题`,
+      before: formatLocalizedValue(previousResume.highlights[index]?.title),
+      after: formatLocalizedValue(nextResume.highlights[index]?.title),
+    });
+    entries.push({
+      key: `highlight-${index}-description`,
+      label: `亮点 ${index + 1} / 描述`,
+      before: formatLocalizedValue(previousResume.highlights[index]?.description),
+      after: formatLocalizedValue(nextResume.highlights[index]?.description),
+    });
+  });
+
+  return {
+    module: 'highlights',
+    ...getModulePresentation('highlights'),
+    entries,
+  };
+}
+
+function buildModuleDiffs(
+  previousResume: StandardResume,
+  nextResume: StandardResume,
+  patch: ResumeOptimizationPatch,
+  changedModules: ResumeOptimizationModule[],
+): ResumeOptimizationModuleDiff[] {
+  return changedModules.flatMap((module) => {
+    const diff =
+      module === 'profile'
+        ? buildProfileDiff(previousResume, nextResume, patch)
+        : module === 'experiences'
+          ? buildExperiencesDiff(previousResume, nextResume, patch)
+          : module === 'projects'
+            ? buildProjectsDiff(previousResume, nextResume, patch)
+            : buildHighlightsDiff(previousResume, nextResume, patch);
+
+    return diff ? [diff] : [];
+  });
 }
 
 function buildMockSuggestion(
@@ -499,6 +823,7 @@ export class AiResumeOptimizationService {
 
     const suggestedResume = applyPatch(draft.resume, payload.patch);
     const validationResult = validateStandardResume(suggestedResume);
+    const changedModules = detectChangedModules(draft.resume, suggestedResume);
 
     if (!validationResult.valid) {
       throw new BadGatewayException(
@@ -509,10 +834,50 @@ export class AiResumeOptimizationService {
     return {
       summary: payload.summary,
       focusAreas: payload.focusAreas,
-      changedModules: detectChangedModules(draft.resume, suggestedResume),
+      changedModules,
+      moduleDiffs: buildModuleDiffs(
+        draft.resume,
+        suggestedResume,
+        payload.patch,
+        changedModules,
+      ),
+      applyPayload: {
+        draftUpdatedAt: draft.updatedAt,
+        patch: payload.patch,
+      },
       suggestedResume,
       providerSummary,
     };
+  }
+
+  async applySuggestion(input: ApplyResumeOptimizationInput) {
+    const selectedModules = normalizeModules(input.modules);
+    const draft = await this.resumePublicationService.getDraft();
+
+    if (draft.updatedAt !== input.draftUpdatedAt) {
+      throw new ConflictException(
+        '当前草稿已发生变化，请重新生成建议稿后再应用',
+      );
+    }
+
+    const validatedPatch = validatePatch(input.patch, draft.resume);
+    const selectedPatch = pickPatchByModules(validatedPatch, selectedModules);
+    const nextResume = applyPatch(draft.resume, selectedPatch);
+    const appliedModules = detectChangedModules(draft.resume, nextResume);
+
+    if (appliedModules.length === 0) {
+      throw new BadRequestException('当前选择的模块没有实际改动可应用');
+    }
+
+    const validationResult = validateStandardResume(nextResume);
+
+    if (!validationResult.valid) {
+      throw new BadGatewayException(
+        validationResult.errors[0] ?? 'AI 建议稿未通过当前简历结构校验',
+      );
+    }
+
+    return this.resumePublicationService.updateDraft(nextResume);
   }
 
   private async generateProviderSuggestion(

--- a/apps/server/test/ai-report-role-access.e2e-spec.ts
+++ b/apps/server/test/ai-report-role-access.e2e-spec.ts
@@ -135,6 +135,23 @@ describe('AI report role access (e2e)', () => {
         locale: 'zh',
       })
       .expect(403);
+
+    await request(app.getHttpServer())
+      .post('/ai/reports/resume-optimize/apply')
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send({
+        draftUpdatedAt: '2026-03-31T00:00:00.000Z',
+        modules: ['profile'],
+        patch: {
+          profile: {
+            summary: {
+              zh: '新的中文摘要',
+              en: 'New English summary',
+            },
+          },
+        },
+      })
+      .expect(403);
   });
 
   it('should allow admin to trigger analysis and write cached ai results', async () => {
@@ -188,6 +205,24 @@ describe('AI report role access (e2e)', () => {
 
     expect(optimizeResponse.body.summary.length).toBeGreaterThan(0);
     expect(optimizeResponse.body.changedModules).toContain('profile');
+    expect(optimizeResponse.body.moduleDiffs.length).toBeGreaterThan(0);
+    expect(optimizeResponse.body.applyPayload.draftUpdatedAt).toBeTruthy();
     expect(optimizeResponse.body.suggestedResume.meta.slug).toBe('standard-resume');
+
+    const applyResponse = await request(app.getHttpServer())
+      .post('/ai/reports/resume-optimize/apply')
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send({
+        draftUpdatedAt: optimizeResponse.body.applyPayload.draftUpdatedAt,
+        modules: ['profile'],
+        patch: optimizeResponse.body.applyPayload.patch,
+      })
+      .expect(200);
+
+    expect(applyResponse.body.status).toBe('draft');
+    expect(applyResponse.body.resume.profile.summary.zh).not.toBe('');
+    expect(applyResponse.body.resume.projects[0].summary.zh).toBe(
+      '为药械企业提供推广与结算管理的 SaaS 方案，支持多组织、多任务与合规流程。',
+    );
   });
 });


### PR DESCRIPTION
## Summary
- add structured module diff data for AI resume optimization results
- add server-side apply endpoint that only writes selected modules back to the draft
- update the admin AI panel to preview reasons, before/after changes, and module-level apply
- cover the new contract with server tests, admin tests, and e2e role checks

## Validation
- `pnpm --filter @my-resume/server test -- src/modules/ai/ai-resume-optimization.service.spec.ts`
- `pnpm --filter @my-resume/admin exec vitest run lib/ai-workbench-api.spec.ts components/ai-analysis-panel.spec.tsx`
- `pnpm --filter @my-resume/server typecheck`
- `pnpm --filter @my-resume/admin typecheck`
- `pnpm --filter @my-resume/server test:e2e -- test/ai-report-role-access.e2e-spec.ts`
- `pnpm --filter @my-resume/server build`
- `pnpm --filter @my-resume/admin build`

## Issue
- refs #123
