### PR TITLE
feat(m12): refresh ai workbench draft snapshot

### DIFF
--- a/apps/admin/components/admin-ai-workbench-shell.spec.tsx
+++ b/apps/admin/components/admin-ai-workbench-shell.spec.tsx
@@ -7,11 +7,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 const {
   fetchCurrentUserMock,
   fetchAiWorkbenchRuntimeMock,
+  fetchDraftResumeMock,
   readAccessTokenMock,
   clearAccessTokenMock,
 } = vi.hoisted(() => ({
   fetchCurrentUserMock: vi.fn(),
   fetchAiWorkbenchRuntimeMock: vi.fn(),
+  fetchDraftResumeMock: vi.fn(),
   readAccessTokenMock: vi.fn(),
   clearAccessTokenMock: vi.fn(),
 }));
@@ -22,6 +24,10 @@ vi.mock('../lib/auth-api', () => ({
 
 vi.mock('../lib/ai-workbench-api', () => ({
   fetchAiWorkbenchRuntime: fetchAiWorkbenchRuntimeMock,
+}));
+
+vi.mock('../lib/resume-draft-api', () => ({
+  fetchDraftResume: fetchDraftResumeMock,
 }));
 
 vi.mock('../lib/session-storage', () => ({
@@ -74,13 +80,55 @@ vi.mock('./ai-analysis-panel', () => ({
   AiAnalysisPanel: ({
     canAnalyze,
     content,
+    onDraftApplied,
   }: {
     canAnalyze: boolean;
     content: string;
+    onDraftApplied?: (snapshot: {
+      status: 'draft';
+      updatedAt: string;
+      resume: {
+        profile: {
+          headline: {
+            zh: string;
+            en: string;
+          };
+          summary: {
+            zh: string;
+            en: string;
+          };
+        };
+      };
+    }) => void;
   }) => (
     <div>
       <span>{canAnalyze ? '真实分析面板占位' : '真实分析只读占位'}</span>
       <span>{`当前分析内容：${content || '空'}`}</span>
+      {canAnalyze ? (
+        <button
+          onClick={() =>
+            onDraftApplied?.({
+              status: 'draft',
+              updatedAt: '2026-03-31T10:00:00.000Z',
+              resume: {
+                profile: {
+                  headline: {
+                    zh: 'AI 优化后标题',
+                    en: 'AI Optimized Headline',
+                  },
+                  summary: {
+                    zh: 'AI 优化后的中文摘要',
+                    en: 'AI optimized English summary',
+                  },
+                },
+              },
+            })
+          }
+          type="button"
+        >
+          模拟应用草稿
+        </button>
+      ) : null}
     </div>
   ),
 }));
@@ -104,6 +152,23 @@ const runtimeSummary = {
   model: 'deepseek-v3',
   mode: 'live',
   supportedScenarios: ['jd-match', 'resume-review', 'offer-compare'] as const,
+};
+
+const draftSnapshot = {
+  status: 'draft' as const,
+  updatedAt: '2026-03-31T09:00:00.000Z',
+  resume: {
+    profile: {
+      headline: {
+        zh: '当前草稿标题',
+        en: 'Current Draft Headline',
+      },
+      summary: {
+        zh: '当前草稿摘要',
+        en: 'Current draft summary',
+      },
+    },
+  },
 };
 
 const adminUser = {
@@ -134,6 +199,7 @@ describe('AdminAiWorkbenchShell', () => {
   beforeEach(() => {
     fetchCurrentUserMock.mockReset();
     fetchAiWorkbenchRuntimeMock.mockReset();
+    fetchDraftResumeMock.mockReset();
     readAccessTokenMock.mockReset();
     clearAccessTokenMock.mockReset();
   });
@@ -158,6 +224,7 @@ describe('AdminAiWorkbenchShell', () => {
     readAccessTokenMock.mockReturnValue('admin-token');
     fetchCurrentUserMock.mockResolvedValue(adminUser);
     fetchAiWorkbenchRuntimeMock.mockResolvedValue(runtimeSummary);
+    fetchDraftResumeMock.mockResolvedValue(draftSnapshot);
 
     render(<AdminAiWorkbenchShell />);
 
@@ -176,16 +243,25 @@ describe('AdminAiWorkbenchShell', () => {
     expect(screen.getByText('真实分析面板占位')).toBeInTheDocument();
     expect(screen.getByText('admin 缓存结果面板占位')).toBeInTheDocument();
     expect(screen.getByText('当前分析内容：空')).toBeInTheDocument();
+    expect(await screen.findByText('当前草稿快照')).toBeInTheDocument();
+    expect(screen.getByText('当前草稿标题')).toBeInTheDocument();
+    expect(screen.getByText('当前草稿摘要')).toBeInTheDocument();
 
     await user.click(screen.getByRole('button', { name: '模拟提取完成' }));
 
     expect(screen.getByText('当前分析内容：resume text content')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: '模拟应用草稿' }));
+
+    expect(await screen.findByText('AI 优化后标题')).toBeInTheDocument();
+    expect(screen.getByText('AI 优化后的中文摘要')).toBeInTheDocument();
   });
 
   it('should render viewer-specific guidance for read-only AI experience', async () => {
     readAccessTokenMock.mockReturnValue('viewer-token');
     fetchCurrentUserMock.mockResolvedValue(viewerUser);
     fetchAiWorkbenchRuntimeMock.mockResolvedValue(runtimeSummary);
+    fetchDraftResumeMock.mockResolvedValue(draftSnapshot);
 
     render(<AdminAiWorkbenchShell />);
 
@@ -196,5 +272,6 @@ describe('AdminAiWorkbenchShell', () => {
     expect(screen.getByText('viewer 缓存结果面板占位')).toBeInTheDocument();
     expect(screen.getByText('文件提取只读占位')).toBeInTheDocument();
     expect(screen.getByText('真实分析只读占位')).toBeInTheDocument();
+    expect(fetchDraftResumeMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/admin/components/admin-ai-workbench-shell.tsx
+++ b/apps/admin/components/admin-ai-workbench-shell.tsx
@@ -16,6 +16,8 @@ import { fetchAiWorkbenchRuntime } from '../lib/ai-workbench-api';
 import { AiWorkbenchRuntimeSummary } from '../lib/ai-workbench-types';
 import { AuthUserView } from '../lib/auth-types';
 import { DEFAULT_API_BASE_URL } from '../lib/env';
+import { fetchDraftResume } from '../lib/resume-draft-api';
+import { ResumeDraftSnapshot } from '../lib/resume-types';
 import {
   clearAccessToken,
   readAccessToken,
@@ -52,6 +54,15 @@ export function AdminAiWorkbenchShell() {
   const [analysisHelperMessage, setAnalysisHelperMessage] = useState<
     string | null
   >(null);
+  const [draftSnapshot, setDraftSnapshot] = useState<ResumeDraftSnapshot | null>(
+    null,
+  );
+  const [draftSnapshotStatus, setDraftSnapshotStatus] = useState<
+    'idle' | 'loading' | 'ready' | 'error'
+  >('idle');
+  const [draftSnapshotMessage, setDraftSnapshotMessage] = useState<string | null>(
+    null,
+  );
 
   useEffect(() => {
     const accessToken = readAccessToken();
@@ -84,6 +95,36 @@ export function AdminAiWorkbenchShell() {
       });
   }, []);
 
+  useEffect(() => {
+    if (status !== 'ready' || !currentUser?.capabilities.canEditResume) {
+      return;
+    }
+
+    const accessToken = readAccessToken();
+
+    if (!accessToken) {
+      return;
+    }
+
+    setDraftSnapshotStatus('loading');
+    setDraftSnapshotMessage(null);
+
+    fetchDraftResume({
+      apiBaseUrl: DEFAULT_API_BASE_URL,
+      accessToken,
+    })
+      .then((snapshot) => {
+        setDraftSnapshot(snapshot);
+        setDraftSnapshotStatus('ready');
+      })
+      .catch((error) => {
+        setDraftSnapshotStatus('error');
+        setDraftSnapshotMessage(
+          error instanceof Error ? error.message : '草稿快照读取失败，请稍后重试',
+        );
+      });
+  }, [currentUser?.capabilities.canEditResume, status]);
+
   function handleExtractedText(result: FileExtractionResult) {
     setAnalysisContent(result.text);
     setAnalysisHelperMessage(
@@ -97,6 +138,12 @@ export function AdminAiWorkbenchShell() {
     if (analysisHelperMessage) {
       setAnalysisHelperMessage(null);
     }
+  }
+
+  function handleDraftApplied(snapshot: ResumeDraftSnapshot) {
+    setDraftSnapshot(snapshot);
+    setDraftSnapshotStatus('ready');
+    setDraftSnapshotMessage('当前草稿快照已刷新，可直接确认 AI 改写结果。');
   }
 
   if (status === 'loading') {
@@ -194,6 +241,7 @@ export function AdminAiWorkbenchShell() {
             canAnalyze={isAdmin}
             content={analysisContent}
             helperMessage={analysisHelperMessage}
+            onDraftApplied={handleDraftApplied}
             onContentChange={handleAnalysisContentChange}
             runtimeSummary={runtimeSummary}
           />
@@ -227,6 +275,42 @@ export function AdminAiWorkbenchShell() {
         </div>
 
         <aside className="dashboard-column stack">
+          {currentUser.capabilities.canEditResume ? (
+            <DisplaySurfaceCard className="card stack">
+              <DisplaySectionIntro
+                description="这里展示 AI 工作台当前看到的草稿快照，apply 成功后会即时刷新，避免必须切回后台首页再确认。"
+                eyebrow="草稿反馈"
+                title="当前草稿快照"
+              />
+
+              {draftSnapshotStatus === 'loading' ? (
+                <p className="muted">正在加载当前草稿快照...</p>
+              ) : null}
+
+              {draftSnapshotStatus === 'error' && draftSnapshotMessage ? (
+                <p className="error-text">{draftSnapshotMessage}</p>
+              ) : null}
+
+              {draftSnapshotMessage && draftSnapshotStatus === 'ready' ? (
+                <div className="dashboard-inline-note">{draftSnapshotMessage}</div>
+              ) : null}
+
+              {draftSnapshot ? (
+                <div className="stack">
+                  <div className="status-box">
+                    <strong>{draftSnapshot.resume.profile.headline.zh}</strong>
+                    <span>{draftSnapshot.resume.profile.summary.zh}</span>
+                    <span>{`最近更新时间：${new Date(draftSnapshot.updatedAt).toLocaleString('zh-CN', { hour12: false })}`}</span>
+                  </div>
+                  <div className="status-box">
+                    <strong>{draftSnapshot.resume.profile.headline.en}</strong>
+                    <span>{draftSnapshot.resume.profile.summary.en}</span>
+                  </div>
+                </div>
+              ) : null}
+            </DisplaySurfaceCard>
+          ) : null}
+
           <DisplaySurfaceCard className="card stack">
             <DisplaySectionIntro
               description="先把当前运行时状态和角色限制写清楚，避免 AI 工作台后续越做越散。"

--- a/apps/admin/components/ai-analysis-panel.spec.tsx
+++ b/apps/admin/components/ai-analysis-panel.spec.tsx
@@ -63,6 +63,11 @@ function ControlledAnalysisPanel(props: {
   canAnalyze: boolean;
   generateResumeOptimization?: typeof import('../lib/ai-workbench-api').generateAiResumeOptimization;
   helperMessage?: string | null;
+  onDraftApplied?: (snapshot: {
+    status: 'draft';
+    updatedAt: string;
+    resume: StandardResume;
+  }) => void;
   triggerAnalysis?: typeof import('../lib/ai-workbench-api').triggerAiWorkbenchAnalysis;
   initialContent?: string;
 }) {
@@ -76,6 +81,7 @@ function ControlledAnalysisPanel(props: {
       content={content}
       helperMessage={props.helperMessage}
       onContentChange={setContent}
+      onDraftApplied={props.onDraftApplied}
       runtimeSummary={runtimeSummary}
       applyResumeOptimization={props.applyResumeOptimization}
       generateResumeOptimization={props.generateResumeOptimization}
@@ -396,6 +402,7 @@ describe('AiAnalysisPanel', () => {
       resume: createTestResume(),
       updatedAt: '2026-03-30T00:00:00.000Z',
     });
+    const onDraftApplied = vi.fn();
 
     render(
       <ControlledAnalysisPanel
@@ -403,6 +410,7 @@ describe('AiAnalysisPanel', () => {
         canAnalyze
         generateResumeOptimization={generateResumeOptimization}
         initialContent="请根据 React 和 Next.js 岗位优化当前简历"
+        onDraftApplied={onDraftApplied}
         triggerAnalysis={triggerAnalysis}
       />,
     );
@@ -458,6 +466,12 @@ describe('AiAnalysisPanel', () => {
           }),
         }),
       });
+    });
+
+    expect(onDraftApplied).toHaveBeenCalledWith({
+      status: 'draft',
+      resume: createTestResume(),
+      updatedAt: '2026-03-30T00:00:00.000Z',
     });
 
     expect(

--- a/apps/admin/components/ai-analysis-panel.tsx
+++ b/apps/admin/components/ai-analysis-panel.tsx
@@ -15,6 +15,7 @@ import {
 import {
   AiResumeOptimizationChangedModule,
   AiResumeOptimizationResult,
+  ApplyAiResumeOptimizationResult,
   AiWorkbenchLocale,
   AiWorkbenchReport,
   AiWorkbenchRuntimeSummary,
@@ -28,6 +29,7 @@ interface AiAnalysisPanelProps {
   canAnalyze: boolean;
   content: string;
   helperMessage?: string | null;
+  onDraftApplied?: (snapshot: ApplyAiResumeOptimizationResult) => void;
   onContentChange: (value: string) => void;
   runtimeSummary: AiWorkbenchRuntimeSummary;
   generateResumeOptimization?: typeof generateAiResumeOptimization;
@@ -91,6 +93,7 @@ export function AiAnalysisPanel({
   canAnalyze,
   content,
   helperMessage,
+  onDraftApplied,
   onContentChange,
   runtimeSummary,
   generateResumeOptimization = generateAiResumeOptimization,
@@ -262,15 +265,18 @@ export function AiAnalysisPanel({
     setApplyPending(true);
     setSuggestionErrorMessage(null);
     setApplyFeedbackMessage(null);
+    setModuleLinkMessage(null);
 
     try {
-      await applyResumeOptimization({
+      const nextSnapshot = await applyResumeOptimization({
         apiBaseUrl,
         accessToken,
         draftUpdatedAt: suggestion.applyPayload.draftUpdatedAt,
         modules: selectedModules,
         patch: suggestion.applyPayload.patch,
       });
+
+      onDraftApplied?.(nextSnapshot);
 
       setApplyFeedbackMessage(
         `已将 ${selectedModules.length} 个模块应用到当前草稿。公开站内容不会自动变化，仍需手动发布。`,


### PR DESCRIPTION
## Summary
- load the current draft snapshot inside the admin AI workbench for admin users
- refresh the draft snapshot immediately after AI apply succeeds
- keep viewer read-only by avoiding draft fetches for non-edit roles
- cover the snapshot refresh flow with workbench and analysis panel tests

## Validation
- `pnpm --filter @my-resume/admin exec vitest run components/admin-ai-workbench-shell.spec.tsx components/ai-analysis-panel.spec.tsx`
- `pnpm --filter @my-resume/admin build`
- `pnpm --filter @my-resume/admin typecheck`

## Issue
- refs #127
