### PR TITLE
fix(m20): auto-clean stale ecs port conflicts before release

### DIFF
--- a/deploy/ecs/README.md
+++ b/deploy/ecs/README.md
@@ -14,6 +14,7 @@
 - `bootstrap.sh`：安装 Docker / Nginx / Certbot 并初始化部署目录
 - `render-config.sh`：渲染 `.env`、`compose.prod.yml` 与 Nginx 配置
 - `release.sh <tag>`：发布指定版本（自动识别 build/image）
+- `pre-release-port-cleanup.sh`：发布前清理旧项目残留容器占用端口
 - `deploy-latest-tag.sh`：同步 `main`+标签后，自动发布最新 tag 并执行验收
 - `rollback.sh [tag]`：回滚到上一版或指定 tag
 - `build-and-push-images.sh`：本地构建并推送三端镜像（image 模式专用）
@@ -135,6 +136,7 @@ DEPLOY_ROOT=/opt/my-resume ./deploy/ecs/deploy-latest-tag.sh
 
 1. `docker compose pull`
 2. `docker compose up -d --no-build --remove-orphans`
+3. 发布前自动清理旧 compose 项目占用端口（5577/5555/5566）
 
 无需再 `--build`。
 
@@ -187,6 +189,7 @@ docker compose up -d --build --remove-orphans
 
 - **拉不到镜像**：先在 ECS 上 `docker login ghcr.io`
 - **还是在构建**：检查 `DEPLOY_MODE=image` 是否生效
+- **端口冲突（5577/5555/5566）**：`release.sh` 会自动执行 `pre-release-port-cleanup.sh` 清理旧项目残留容器
 - **证书申请失败**：先检查 DNS 是否全部解析到 ECS
 - **2核2G 机器卡死**：避免 build 模式，统一改 image 模式
 

--- a/deploy/ecs/lib.sh
+++ b/deploy/ecs/lib.sh
@@ -237,6 +237,35 @@ resolve_image_references() {
   export IMAGE_TAG SERVER_IMAGE_REF WEB_IMAGE_REF ADMIN_IMAGE_REF
 }
 
+normalize_compose_project_name() {
+  local value="$1"
+
+  value=$(printf '%s' "$value" | tr '[:upper:]' '[:lower:]')
+  value=${value//[^a-z0-9_-]/-}
+  value=${value#-}
+  value=${value#_}
+  value=${value%-}
+  value=${value%_}
+
+  if [[ -z "$value" ]]; then
+    value='my-resume'
+  fi
+
+  printf '%s\n' "$value"
+}
+
+resolve_compose_project_name() {
+  local candidate
+
+  candidate="${COMPOSE_PROJECT_NAME:-${DEPLOY_COMPOSE_PROJECT_NAME:-${ROOT_DOMAIN:-my-resume}}}"
+  candidate=$(normalize_compose_project_name "$candidate")
+
+  COMPOSE_PROJECT_NAME="$candidate"
+  export COMPOSE_PROJECT_NAME
+
+  printf '%s\n' "$COMPOSE_PROJECT_NAME"
+}
+
 docker_registry_login_if_configured() {
   local registry_host
 
@@ -318,9 +347,11 @@ EOF
 compose_cmd() {
   local compose_file="$1"
   local env_file="$2"
+  local compose_project
   shift 2
 
-  sudo_cmd docker compose -f "$compose_file" --env-file "$env_file" "$@"
+  compose_project=$(resolve_compose_project_name)
+  sudo_cmd docker compose --project-name "$compose_project" -f "$compose_file" --env-file "$env_file" "$@"
 }
 
 resolve_nginx_site_layout() {

--- a/deploy/ecs/pre-release-port-cleanup.sh
+++ b/deploy/ecs/pre-release-port-cleanup.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=./lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+KEEP_PROJECT=''
+PORTS=()
+
+usage() {
+  cat <<'EOF'
+Usage:
+  ./deploy/ecs/pre-release-port-cleanup.sh [--stack-env <path>] [--keep-project <name>] [--port <port>]... [--dry-run]
+
+Options:
+  --stack-env      指定 stack env 文件
+  --keep-project   当前保留的 compose project（默认自动解析）
+  --port           需要清理冲突的 host 端口，可重复传入；默认 5577 5555 5566
+  --dry-run        只打印将执行的清理动作
+EOF
+}
+
+docker_cmd() {
+  if [[ "$(id -u)" -eq 0 ]]; then
+    docker "$@"
+    return 0
+  fi
+
+  sudo docker "$@"
+}
+
+is_my_resume_service() {
+  local service_name="$1"
+  case "$service_name" in
+    server | web | admin)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --stack-env)
+      STACK_ENV_FILE="$2"
+      shift 2
+      ;;
+    --keep-project)
+      KEEP_PROJECT="$2"
+      shift 2
+      ;;
+    --port)
+      PORTS+=("$2")
+      shift 2
+      ;;
+    --dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      die "Unknown argument: $1"
+      ;;
+  esac
+done
+
+load_stack_env
+
+if [[ "$DRY_RUN" == '1' ]] && ! command -v docker >/dev/null 2>&1; then
+  log "[dry-run] docker command not found, skip container inspection"
+  exit 0
+fi
+
+require_commands docker
+
+if (( ${#PORTS[@]} == 0 )); then
+  PORTS=(5577 5555 5566)
+fi
+
+if [[ -z "$KEEP_PROJECT" ]]; then
+  KEEP_PROJECT=$(resolve_compose_project_name)
+else
+  KEEP_PROJECT=$(normalize_compose_project_name "$KEEP_PROJECT")
+fi
+
+log "Port conflict pre-clean target project: $KEEP_PROJECT"
+
+for port in "${PORTS[@]}"; do
+  mapfile -t container_ids < <(docker_cmd ps -q --filter "publish=${port}")
+  if (( ${#container_ids[@]} == 0 )); then
+    log "Port $port is free"
+    continue
+  fi
+
+  for container_id in "${container_ids[@]}"; do
+    container_name=$(docker_cmd inspect --format '{{.Name}}' "$container_id" | sed 's#^/##')
+    compose_project=$(docker_cmd inspect --format '{{ index .Config.Labels "com.docker.compose.project" }}' "$container_id")
+    compose_service=$(docker_cmd inspect --format '{{ index .Config.Labels "com.docker.compose.service" }}' "$container_id")
+
+    if [[ "$compose_project" == "$KEEP_PROJECT" ]]; then
+      log "Port $port in-use by current project container, keep: $container_name"
+      continue
+    fi
+
+    if ! is_my_resume_service "$compose_service"; then
+      log "Port $port occupied by non-target container, skip cleanup: $container_name (project=${compose_project:-n/a}, service=${compose_service:-n/a})"
+      continue
+    fi
+
+    log "Removing stale container on port $port: $container_name (project=${compose_project:-n/a}, service=${compose_service})"
+    run_cmd docker_cmd rm -f "$container_id"
+  done
+
+  mapfile -t remaining_ids < <(docker_cmd ps -q --filter "publish=${port}")
+  if (( ${#remaining_ids[@]} == 0 )); then
+    log "Port $port cleanup complete"
+    continue
+  fi
+
+  unresolved=0
+  for container_id in "${remaining_ids[@]}"; do
+    compose_project=$(docker_cmd inspect --format '{{ index .Config.Labels "com.docker.compose.project" }}' "$container_id")
+    if [[ "$compose_project" != "$KEEP_PROJECT" ]]; then
+      unresolved=1
+      container_name=$(docker_cmd inspect --format '{{.Name}}' "$container_id" | sed 's#^/##')
+      compose_service=$(docker_cmd inspect --format '{{ index .Config.Labels "com.docker.compose.service" }}' "$container_id")
+      log "Unresolved port $port holder: $container_name (project=${compose_project:-n/a}, service=${compose_service:-n/a})"
+    fi
+  done
+
+  if (( unresolved == 1 )); then
+    die "Port $port still occupied by non-current project containers"
+  fi
+done
+
+log "Port conflict pre-clean completed"

--- a/deploy/ecs/release.sh
+++ b/deploy/ecs/release.sh
@@ -104,6 +104,12 @@ sudo_cmd systemctl reload nginx
 ln -sfn "$RELEASE_DIR" "$CURRENT_LINK"
 printf '%s\n' "$RELEASE_DIR" >"$CURRENT_RELEASE_FILE"
 
+cleanup_args=(--stack-env "$STACK_ENV_FILE")
+if [[ "$DRY_RUN" == '1' ]]; then
+  cleanup_args+=(--dry-run)
+fi
+run_cmd "$SCRIPT_DIR/pre-release-port-cleanup.sh" "${cleanup_args[@]}"
+
 if [[ "$DEPLOY_MODE" == 'image' ]]; then
   docker_registry_login_if_configured
   compose_cmd "$RELEASE_DIR/compose.prod.yml" "$RELEASE_DIR/.env" pull

--- a/deploy/ecs/rollback.sh
+++ b/deploy/ecs/rollback.sh
@@ -51,6 +51,12 @@ fi
 ln -sfn "$TARGET_RELEASE" "$CURRENT_LINK"
 printf '%s\n' "$TARGET_RELEASE" >"$CURRENT_RELEASE_FILE"
 
+cleanup_args=(--stack-env "$STACK_ENV_FILE")
+if [[ "$DRY_RUN" == '1' ]]; then
+  cleanup_args+=(--dry-run)
+fi
+run_cmd "$SCRIPT_DIR/pre-release-port-cleanup.sh" "${cleanup_args[@]}"
+
 compose_cmd "$TARGET_RELEASE/compose.prod.yml" "$TARGET_RELEASE/.env" up -d --build --remove-orphans
 
 curl_check "$(healthcheck_url server)" "server"

--- a/deploy/ecs/stack-env-checklist.md
+++ b/deploy/ecs/stack-env-checklist.md
@@ -66,6 +66,12 @@ cp /opt/my-resume/deploy/templates/stack.env.example \
 DEPLOY_MODE=image
 ```
 
+建议同时固定 compose project 名，避免历史发布目录变更导致旧容器残留占用端口：
+
+```env
+DEPLOY_COMPOSE_PROJECT_NAME=my-resume
+```
+
 ### 镜像仓库配置（推荐用前缀）
 
 ```env

--- a/deploy/templates/stack.env.example
+++ b/deploy/templates/stack.env.example
@@ -8,6 +8,8 @@ REPO_URL=https://github.com/your-name/my-resume.git
 # - build: ECS 上执行 docker compose --build（默认）
 # - image: ECS 只拉镜像并启动（推荐 2核2G 机器）
 DEPLOY_MODE=image
+# 可选：固定 compose project 名，避免每次发布目录变化导致旧容器残留占用端口
+# DEPLOY_COMPOSE_PROJECT_NAME=my-resume
 
 # image 模式镜像配置（二选一）
 # 方案 A：填前缀，自动推导 server/web/admin 三个仓库

--- a/docs/30-开发日志/M20-follow-up-ECS端口冲突自动清理脚本.md
+++ b/docs/30-开发日志/M20-follow-up-ECS端口冲突自动清理脚本.md
@@ -1,0 +1,46 @@
+# M20 Follow-up：ECS 端口冲突自动清理脚本
+
+## 背景
+
+- 线上发布偶发失败，报错：
+  - `Bind for 127.0.0.1:5577 failed: port is already allocated`
+- 根因是历史发布使用不同 compose project，旧容器未被当前发布自动回收，导致 `5577/5555/5566` 端口被占用。
+
+## 本次目标
+
+- 新增发布前端口冲突清理脚本，避免重复手工排查和手工 `docker rm -f`。
+- 保证发布/回滚流程都能自动执行端口冲突预清理。
+
+## 实际改动
+
+- 新增：`deploy/ecs/pre-release-port-cleanup.sh`
+  - 默认扫描端口：`5577/5555/5566`
+  - 只清理 `server/web/admin` 旧 compose 项目容器
+  - 保留当前 compose project 容器，避免误删当前发布目标
+  - 支持 `--port`、`--keep-project`、`--stack-env`、`--dry-run`
+- 更新：`deploy/ecs/release.sh`
+  - 在 `docker compose up` 前自动执行 `pre-release-port-cleanup.sh`
+- 更新：`deploy/ecs/rollback.sh`
+  - 回滚时同样自动执行端口冲突预清理
+- 更新：`deploy/ecs/lib.sh`
+  - 为 `docker compose` 统一追加稳定 `--project-name`
+  - 新增 `DEPLOY_COMPOSE_PROJECT_NAME` 支持，默认按域名规范化生成
+- 文档：
+  - `deploy/ecs/README.md`
+  - `deploy/ecs/stack-env-checklist.md`
+  - `deploy/templates/stack.env.example`
+
+## 测试与验证
+
+- 语法检查：
+  - `bash -n deploy/ecs/lib.sh`
+  - `bash -n deploy/ecs/pre-release-port-cleanup.sh`
+  - `bash -n deploy/ecs/release.sh`
+  - `bash -n deploy/ecs/rollback.sh`
+- 干跑建议：
+  - `./deploy/ecs/pre-release-port-cleanup.sh --stack-env ./.env.stack.local --dry-run`
+
+## 后续建议
+
+- 在 ECS 的 `stack.env.local` 固定 `DEPLOY_COMPOSE_PROJECT_NAME=my-resume`，减少历史容器碎片化。
+- 可增加一个定时清理任务，回收长期不用的旧 release snapshots 与无引用镜像层。


### PR DESCRIPTION
## 背景
线上发布偶发失败：

- Bind for 127.0.0.1:5577 failed: port is already allocated

主要由历史 compose project 残留容器占用端口导致。

## 本次改动
- 新增 `deploy/ecs/pre-release-port-cleanup.sh`
  - 默认清理冲突端口：5577 / 5555 / 5566
  - 仅清理 `server/web/admin` 的旧 compose 项目容器
  - 支持 `--dry-run` / `--port` / `--keep-project`
- `release.sh` 在 `compose up` 前自动执行清理
- `rollback.sh` 在回滚前自动执行清理
- `lib.sh` 为 compose 命令统一稳定 `--project-name`，支持 `DEPLOY_COMPOSE_PROJECT_NAME`
- 更新部署文档与开发日志

## 验证
- `bash -n deploy/ecs/lib.sh`
- `bash -n deploy/ecs/pre-release-port-cleanup.sh`
- `bash -n deploy/ecs/release.sh`
- `bash -n deploy/ecs/rollback.sh`
- `./deploy/ecs/pre-release-port-cleanup.sh --stack-env ./.env.stack.local --dry-run`
