### PR TITLE
fix(web): complete EN resume keyword/date rendering

### DIFF
--- a/apps/web/app/[locale]/_resume/__tests__/published-resume-skills-utils.spec.ts
+++ b/apps/web/app/[locale]/_resume/__tests__/published-resume-skills-utils.spec.ts
@@ -40,6 +40,27 @@ describe('published resume skills utils', () => {
     expect(tokens.some((token) => token.label === 'Node.js')).toBe(true)
   })
 
+  it('should translate known chinese skill lines for english rendering', () => {
+    const groups = normalizeSkillGroups(
+      [
+        {
+          ...publishedResumeFixture.resume.skills[0],
+          keywords: ['构建产物分析、懒加载与首屏性能优化'],
+        },
+      ],
+      'en',
+    )
+
+    expect(groups[0]?.parsedKeywords[0]?.content).toBe(
+      'Build artifact analysis, lazy loading, and first-screen performance optimization',
+    )
+
+    const tokens = buildSkillCloudTokens(groups, 'en')
+    expect(tokens[0]?.label).toBe(
+      'Build artifact analysis, lazy loading, and first-screen performance optimization',
+    )
+  })
+
   it('should build radar from proficiency scores and pie from real skill item counts', () => {
     const groups = rankSkillGroups(
       normalizeSkillGroups([

--- a/apps/web/app/[locale]/_resume/published-resume-education-section.tsx
+++ b/apps/web/app/[locale]/_resume/published-resume-education-section.tsx
@@ -56,7 +56,7 @@ export function PublishedResumeEducationSection({
                     </p>
                   </div>
                   <span className="text-base font-medium text-slate-500 dark:text-slate-400">
-                    {formatDateRange(item)}
+                    {formatDateRange(item, locale)}
                   </span>
                 </div>
 

--- a/apps/web/app/[locale]/_resume/published-resume-experience-section.tsx
+++ b/apps/web/app/[locale]/_resume/published-resume-experience-section.tsx
@@ -77,7 +77,9 @@ export function PublishedResumeExperienceSection({
                     {roleLine ? <p className={itemMetaTextClass}>{roleLine}</p> : null}
                   </div>
                 </div>
-                <span className={itemMetaTextClass}>{formatDateRange(experience)}</span>
+                <span className={itemMetaTextClass}>
+                  {formatDateRange(experience, locale)}
+                </span>
               </div>
 
               <div className="grid gap-4">

--- a/apps/web/app/[locale]/_resume/published-resume-projects-section.tsx
+++ b/apps/web/app/[locale]/_resume/published-resume-projects-section.tsx
@@ -78,7 +78,7 @@ export function PublishedResumeProjectsSection({
                     {role ? <p className={itemMetaTextClass}>{role}</p> : null}
                   </div>
                 </div>
-                <span className={itemMetaTextClass}>{formatDateRange(project)}</span>
+                <span className={itemMetaTextClass}>{formatDateRange(project, locale)}</span>
               </div>
 
               {summary ? (

--- a/apps/web/app/[locale]/_resume/published-resume-skills-section.tsx
+++ b/apps/web/app/[locale]/_resume/published-resume-skills-section.tsx
@@ -173,7 +173,7 @@ export function PublishedResumeSkillsSection({
     }
   }, [chartMode, chartRenderers, isJsdom, shouldLoadChart])
 
-  const normalizedGroups = useMemo(() => normalizeSkillGroups(skills), [skills])
+  const normalizedGroups = useMemo(() => normalizeSkillGroups(skills, locale), [locale, skills])
   const chartGroups = useMemo(
     () => rankSkillGroups(normalizedGroups, locale),
     [locale, normalizedGroups],

--- a/apps/web/app/[locale]/_resume/published-resume-skills-utils.ts
+++ b/apps/web/app/[locale]/_resume/published-resume-skills-utils.ts
@@ -64,8 +64,138 @@ const chartPalette = [
   '#0f766e',
 ] as const
 
+const enSkillKeywordLineMap = new Map<string, string>([
+  [
+    'Vue / React / Next.js / Nuxt 组件化与页面架构',
+    'Vue / React / Next.js / Nuxt component architecture and page systems',
+  ],
+  [
+    'TypeScript 类型建模与 Composition API / Hooks 实践',
+    'TypeScript type modeling with Composition API / Hooks practices',
+  ],
+  [
+    '复杂交互、响应式布局与可访问性体验打磨',
+    'Complex interactions, responsive layouts, and accessibility refinement',
+  ],
+  [
+    '前端状态管理、数据请求与设计系统协作',
+    'Frontend state management, data fetching, and design-system collaboration',
+  ],
+  [
+    'Vite / Webpack / Turborepo / pnpm workspace 工程治理',
+    'Vite / Webpack / Turborepo / pnpm workspace engineering governance',
+  ],
+  [
+    '构建产物分析、懒加载与首屏性能优化',
+    'Build artifact analysis, lazy loading, and first-screen performance optimization',
+  ],
+  [
+    'CI/CD、Lint、Typecheck 与可回滚交付流程',
+    'CI/CD, lint, typecheck, and rollback-safe delivery workflow',
+  ],
+  [
+    'Monorepo 渐进式重构与模块边界拆分',
+    'Progressive monorepo refactoring and module boundary decomposition',
+  ],
+  [
+    'Prompt Engineering、RAG 与知识库问答基础链路',
+    'Prompt engineering, RAG, and knowledge-base Q&A baseline workflow',
+  ],
+  [
+    'Claude Code / Cursor / Codex 辅助开发工作流',
+    'Claude Code / Cursor / Codex assisted development workflow',
+  ],
+  [
+    'AI Provider Adapter 与流式响应接入实践',
+    'AI Provider Adapter and streaming-response integration practices',
+  ],
+  [
+    'OpenClaw / Coze / Agent 工作流学习与验证',
+    'OpenClaw / Coze / Agent workflow learning and validation',
+  ],
+  [
+    '模块边界、路由结构与领域模型拆分',
+    'Module boundaries, route structures, and domain model decomposition',
+  ],
+  [
+    '前后端接口契约、权限边界与发布链路设计',
+    'Frontend-backend API contracts, permission boundaries, and release-flow design',
+  ],
+  [
+    '教学型渐进重构方案、Issue 拆解与 Review 节奏',
+    'Tutorial-driven incremental refactor plans, issue decomposition, and review cadence',
+  ],
+  [
+    '复杂页面信息架构与可维护组件组织',
+    'Complex page information architecture and maintainable component organization',
+  ],
+  [
+    'Node.js / NestJS / RESTful API 服务端开发',
+    'Node.js / NestJS / RESTful API backend development',
+  ],
+  [
+    'JWT 认证、角色能力模型与接口权限控制',
+    'JWT authentication, role capability models, and API access control',
+  ],
+  [
+    'SQLite / Drizzle ORM / MongoDB 数据层实践',
+    'SQLite / Drizzle ORM / MongoDB data-layer practices',
+  ],
+  [
+    'WebSocket / SSE / 文件处理等应用能力接入',
+    'WebSocket / SSE / file-processing capability integration',
+  ],
+  [
+    '安全、SaaS、能源与内容社区等业务场景交付经验',
+    'Delivery experience across security, SaaS, energy, and content-community scenarios',
+  ],
+  [
+    '需求拆解、优先级判断与跨角色沟通推进',
+    'Requirement decomposition, priority judgment, and cross-role collaboration',
+  ],
+  [
+    '从后台治理到公开展示的完整产品链路理解',
+    'End-to-end product flow understanding from admin governance to public presentation',
+  ],
+  [
+    '技术方案文档、教程沉淀与可复用知识资产建设',
+    'Technical proposal docs, tutorial codification, and reusable knowledge assets',
+  ],
+])
+
+const enSkillKeywordPhraseMap = new Map<string, string>([
+  ['构建体系', 'build systems'],
+  ['需求理解', 'requirement understanding'],
+  ['业务洞察', 'business insight'],
+  ['模块边界', 'module boundaries'],
+  ['性能优化', 'performance optimization'],
+  ['可访问性', 'accessibility'],
+])
+
 function stripMarkdownBold(value: string): string {
   return value.replace(/^\*\*(.+)\*\*$/u, '$1').trim()
+}
+
+function hasChineseCharacters(value: string): boolean {
+  return /[\u4e00-\u9fff]/u.test(value)
+}
+
+function localizeSkillLine(raw: string, locale: ResumeLocale): string {
+  if (locale !== 'en' || !hasChineseCharacters(raw)) {
+    return raw
+  }
+
+  const directMatch = enSkillKeywordLineMap.get(raw.trim())
+  if (directMatch) {
+    return directMatch
+  }
+
+  let translated = raw
+  enSkillKeywordPhraseMap.forEach((replacement, phrase) => {
+    translated = translated.replaceAll(phrase, replacement)
+  })
+
+  return translated
 }
 
 export function parseSkillLine(raw: string): ParsedSkillLine {
@@ -90,10 +220,15 @@ export function parseSkillLine(raw: string): ParsedSkillLine {
   }
 }
 
-export function normalizeSkillGroups(skills: ResumeSkillGroup[]): NormalizedSkillGroup[] {
+export function normalizeSkillGroups(
+  skills: ResumeSkillGroup[],
+  locale: ResumeLocale = 'zh',
+): NormalizedSkillGroup[] {
   return skills.map((group) => ({
     ...group,
-    parsedKeywords: group.keywords.map(parseSkillLine),
+    parsedKeywords: group.keywords.map((rawKeyword) =>
+      parseSkillLine(localizeSkillLine(rawKeyword, locale)),
+    ),
   }))
 }
 

--- a/docs/30-开发日志/M20-issue-197-en-简历内容补全.md
+++ b/docs/30-开发日志/M20-issue-197-en-简历内容补全.md
@@ -1,0 +1,46 @@
+# M20 Issue 197 - EN 简历内容补全（关键词与时间展示）
+
+## 背景
+- 英文公开页仍存在中文内容残留：技能词云/结构化关键词和时间字段中的 `至今`
+- 影响英文版一致性与教程学习体验
+
+## 本次目标
+- 在不改后端协议和简历 schema 的前提下，补齐 EN 展示缺口
+- 保持现有数据结构兼容并可小步回滚
+
+## 实际改动
+- `packages/utils/src/date.ts`
+  - `formatDateRange` 新增可选 `locale` 参数
+  - EN 下将相对时间值 `至今/目前/现在` 映射为 `Present`
+  - ZH 下将 `present/current/ongoing` 映射为 `至今`
+- `apps/web/app/[locale]/_resume/*-section.tsx`
+  - 教育/经历/项目区统一改为 `formatDateRange(item, locale)`
+- `apps/web/app/[locale]/_resume/published-resume-skills-utils.ts`
+  - 新增 EN 技能关键词直译表与短语兜底替换
+  - `normalizeSkillGroups` 新增 `locale` 入参，EN 下优先输出英文关键词文本
+- `apps/web/app/[locale]/_resume/published-resume-skills-section.tsx`
+  - 调整为 `normalizeSkillGroups(skills, locale)`
+- 测试补充
+  - `packages/utils/src/index.spec.ts`
+  - `apps/web/app/[locale]/_resume/__tests__/published-resume-skills-utils.spec.ts`
+
+## Review 记录
+- 方案采用“展示层 locale 兜底”而非 schema 大改，符合当前教程节奏
+- 改动范围聚焦在 web + utils，不扩张到 server 接口层
+
+## 遇到的问题
+- 当前环境 `gh` 未在 PATH 中，但 `/opt/homebrew/bin/gh` 可用
+- 沙箱默认无外网，创建 Issue 需升级网络权限
+
+## 测试与验证
+- 已执行：
+  - ✅ `pnpm --filter @my-resume/utils typecheck`
+  - ✅ `cd apps/web && ../../node_modules/.bin/tsc --noEmit --incremental false`
+- 受环境影响暂未通过：
+  - ⚠️ `pnpm --filter @my-resume/utils test`（`@rollup/rollup-darwin-arm64` 本地签名问题）
+  - ⚠️ `pnpm --filter @my-resume/web typecheck`（`@next/swc-darwin-arm64` 本地签名问题）
+- 手工验证建议：`/en` 下技能区和时间区是否已英文化
+
+## 后续教程切入点
+- 服务端渲染项目里“数据 schema 不变”的前提下，如何在展示层做 locale 兜底
+- 技能词云这类非结构化文案的渐进式国际化策略

--- a/packages/utils/src/date.ts
+++ b/packages/utils/src/date.ts
@@ -11,6 +11,23 @@ interface DateRangeLike {
   startDate: string
 }
 
-export function formatDateRange(dateRange: DateRangeLike): string {
-  return `${dateRange.startDate} - ${dateRange.endDate}`
+const zhPresentTokens = new Set(['至今', '目前', '现在'])
+const enPresentTokens = new Set(['present', 'current', 'ongoing'])
+
+function resolveLocalizedEndDate(endDate: string, locale: AppLocale): string {
+  const normalized = endDate.trim()
+
+  if (locale === 'en') {
+    return zhPresentTokens.has(normalized) ? 'Present' : endDate
+  }
+
+  return enPresentTokens.has(normalized.toLowerCase()) ? '至今' : endDate
+}
+
+export function formatDateRange(dateRange: DateRangeLike, locale?: AppLocale): string {
+  const localizedEndDate = locale
+    ? resolveLocalizedEndDate(dateRange.endDate, locale)
+    : dateRange.endDate
+
+  return `${dateRange.startDate} - ${localizedEndDate}`
 }

--- a/packages/utils/src/index.spec.ts
+++ b/packages/utils/src/index.spec.ts
@@ -71,5 +71,25 @@ describe('@my-resume/utils', () => {
         startDate: '2024-01',
       }),
     ).toBe('2024-01 - 2026-04')
+
+    expect(
+      formatDateRange(
+        {
+          endDate: '至今',
+          startDate: '2024-01',
+        },
+        'en',
+      ),
+    ).toBe('2024-01 - Present')
+
+    expect(
+      formatDateRange(
+        {
+          endDate: 'Present',
+          startDate: '2024-01',
+        },
+        'zh',
+      ),
+    ).toBe('2024-01 - 至今')
   })
 })


### PR DESCRIPTION
## Summary
- fix EN resume rendering gaps for skills cloud/structure keywords
- localize relative date labels in EN (`至今` -> `Present`)
- add issue dev log for traceability

## Changes
- `apps/web/app/[locale]/_resume/published-resume-skills-utils.ts`
  - add EN keyword glossary (direct mapping + phrase fallback)
  - `normalizeSkillGroups` now accepts `locale`
- `apps/web/app/[locale]/_resume/published-resume-skills-section.tsx`
  - pass locale into skill normalization flow
- `apps/web/app/[locale]/_resume/published-resume-{education,experience,projects}-section.tsx`
  - use `formatDateRange(item, locale)`
- `packages/utils/src/date.ts`
  - add locale-aware relative end-date conversion
- tests
  - `packages/utils/src/index.spec.ts`
  - `apps/web/app/[locale]/_resume/__tests__/published-resume-skills-utils.spec.ts`
- docs
  - `docs/30-开发日志/M20-issue-197-en-简历内容补全.md`

## Validation
- ✅ `pnpm --filter @my-resume/utils typecheck`
- ✅ `cd apps/web && ../../node_modules/.bin/tsc --noEmit --incremental false`
- ⚠️ `pnpm --filter @my-resume/utils test` blocked by local native module signature issue (`@rollup/rollup-darwin-arm64`)
- ⚠️ `pnpm --filter @my-resume/web typecheck` blocked by local native module signature issue (`@next/swc-darwin-arm64`)

Closes #197
