### PR TITLE
fix(deploy): prevent nounset crash for optional build args

### DIFF
--- a/deploy/ecs/build-and-push-images.sh
+++ b/deploy/ecs/build-and-push-images.sh
@@ -255,12 +255,12 @@ if [[ "$ENGINE_BUILD" == '1' ]]; then
 
   if [[ -n "$BASE_IMAGE" ]]; then
     run_cmd docker build --pull=false --platform "$PLATFORM" -f apps/server/Dockerfile -t "$SERVER_REF" --build-arg "BASE_IMAGE=$BASE_IMAGE" .
-    run_cmd docker build --pull=false --platform "$PLATFORM" -f apps/web/Dockerfile -t "$WEB_REF" --build-arg "BASE_IMAGE=$BASE_IMAGE" "${WEB_BUILD_ARGS[@]}" .
-    run_cmd docker build --pull=false --platform "$PLATFORM" -f apps/admin/Dockerfile -t "$ADMIN_REF" --build-arg "BASE_IMAGE=$BASE_IMAGE" "${ADMIN_BUILD_ARGS[@]}" .
+    run_cmd docker build --pull=false --platform "$PLATFORM" -f apps/web/Dockerfile -t "$WEB_REF" --build-arg "BASE_IMAGE=$BASE_IMAGE" "${WEB_BUILD_ARGS[@]-}" .
+    run_cmd docker build --pull=false --platform "$PLATFORM" -f apps/admin/Dockerfile -t "$ADMIN_REF" --build-arg "BASE_IMAGE=$BASE_IMAGE" "${ADMIN_BUILD_ARGS[@]-}" .
   else
     run_cmd docker build --pull=false --platform "$PLATFORM" -f apps/server/Dockerfile -t "$SERVER_REF" .
-    run_cmd docker build --pull=false --platform "$PLATFORM" -f apps/web/Dockerfile -t "$WEB_REF" "${WEB_BUILD_ARGS[@]}" .
-    run_cmd docker build --pull=false --platform "$PLATFORM" -f apps/admin/Dockerfile -t "$ADMIN_REF" "${ADMIN_BUILD_ARGS[@]}" .
+    run_cmd docker build --pull=false --platform "$PLATFORM" -f apps/web/Dockerfile -t "$WEB_REF" "${WEB_BUILD_ARGS[@]-}" .
+    run_cmd docker build --pull=false --platform "$PLATFORM" -f apps/admin/Dockerfile -t "$ADMIN_REF" "${ADMIN_BUILD_ARGS[@]-}" .
   fi
 
   if [[ "$PUSH" == '1' ]]; then
@@ -281,12 +281,12 @@ else
 
   if [[ -n "$BASE_IMAGE" ]]; then
     run_cmd docker buildx build --builder "$BUILDER_NAME" --pull=false --platform "$PLATFORM" -f apps/server/Dockerfile -t "$SERVER_REF" --build-arg "BASE_IMAGE=$BASE_IMAGE" "${PUBLISH_ARGS[@]}" .
-    run_cmd docker buildx build --builder "$BUILDER_NAME" --pull=false --platform "$PLATFORM" -f apps/web/Dockerfile -t "$WEB_REF" --build-arg "BASE_IMAGE=$BASE_IMAGE" "${WEB_BUILDX_ARGS[@]}" "${PUBLISH_ARGS[@]}" .
-    run_cmd docker buildx build --builder "$BUILDER_NAME" --pull=false --platform "$PLATFORM" -f apps/admin/Dockerfile -t "$ADMIN_REF" --build-arg "BASE_IMAGE=$BASE_IMAGE" "${ADMIN_BUILDX_ARGS[@]}" "${PUBLISH_ARGS[@]}" .
+    run_cmd docker buildx build --builder "$BUILDER_NAME" --pull=false --platform "$PLATFORM" -f apps/web/Dockerfile -t "$WEB_REF" --build-arg "BASE_IMAGE=$BASE_IMAGE" "${WEB_BUILDX_ARGS[@]-}" "${PUBLISH_ARGS[@]}" .
+    run_cmd docker buildx build --builder "$BUILDER_NAME" --pull=false --platform "$PLATFORM" -f apps/admin/Dockerfile -t "$ADMIN_REF" --build-arg "BASE_IMAGE=$BASE_IMAGE" "${ADMIN_BUILDX_ARGS[@]-}" "${PUBLISH_ARGS[@]}" .
   else
     run_cmd docker buildx build --builder "$BUILDER_NAME" --pull=false --platform "$PLATFORM" -f apps/server/Dockerfile -t "$SERVER_REF" "${PUBLISH_ARGS[@]}" .
-    run_cmd docker buildx build --builder "$BUILDER_NAME" --pull=false --platform "$PLATFORM" -f apps/web/Dockerfile -t "$WEB_REF" "${WEB_BUILDX_ARGS[@]}" "${PUBLISH_ARGS[@]}" .
-    run_cmd docker buildx build --builder "$BUILDER_NAME" --pull=false --platform "$PLATFORM" -f apps/admin/Dockerfile -t "$ADMIN_REF" "${ADMIN_BUILDX_ARGS[@]}" "${PUBLISH_ARGS[@]}" .
+    run_cmd docker buildx build --builder "$BUILDER_NAME" --pull=false --platform "$PLATFORM" -f apps/web/Dockerfile -t "$WEB_REF" "${WEB_BUILDX_ARGS[@]-}" "${PUBLISH_ARGS[@]}" .
+    run_cmd docker buildx build --builder "$BUILDER_NAME" --pull=false --platform "$PLATFORM" -f apps/admin/Dockerfile -t "$ADMIN_REF" "${ADMIN_BUILDX_ARGS[@]-}" "${PUBLISH_ARGS[@]}" .
   fi
 fi
 

--- a/docs/30-开发日志/M20-issue-199-build-and-push-images-nounset-修复.md
+++ b/docs/30-开发日志/M20-issue-199-build-and-push-images-nounset-修复.md
@@ -1,0 +1,35 @@
+# M20 Issue 199 - build-and-push-images 空参数在 nounset 下报错修复
+
+## 背景
+在本地执行镜像构建脚本 `deploy/ecs/build-and-push-images.sh` 时，如果未传 `--public-api-base-url`，脚本会在 `set -u`（nounset）模式下报错：
+
+- `ADMIN_BUILDX_ARGS[@]: unbound variable`
+
+这会导致 admin 镜像构建中断，影响本地镜像更新流程稳定性。
+
+## 本次目标
+- 修复空数组参数展开在 `nounset` 下的异常
+- 保持构建参数行为与发布流程不变
+
+## 实际改动
+- 文件：`deploy/ecs/build-and-push-images.sh`
+- 将可选数组参数展开统一改为带默认值形式：
+  - `${WEB_BUILD_ARGS[@]-}`
+  - `${ADMIN_BUILD_ARGS[@]-}`
+  - `${WEB_BUILDX_ARGS[@]-}`
+  - `${ADMIN_BUILDX_ARGS[@]-}`
+
+## Review 记录
+- 方案为最小改动，不改构建参数语义，仅修复 `nounset` 兼容性
+- 同时覆盖 engine/buildx 两条路径，避免后续同类问题
+
+## 测试与验证
+- 已执行（不传 `--public-api-base-url`）：
+  - `./deploy/ecs/build-and-push-images.sh --tag v2.2.7 --server-image local/my-resume-server --web-image local/my-resume-web --admin-image local/my-resume-admin --web-server-api-base-url http://server:5577 --dry-run`
+- 已执行（传入 `--public-api-base-url`）：
+  - `./deploy/ecs/build-and-push-images.sh --tag v2.2.7 --server-image local/my-resume-server --web-image local/my-resume-web --admin-image local/my-resume-admin --public-api-base-url http://localhost:5577 --web-server-api-base-url http://server:5577 --dry-run`
+- 两条路径均已通过，脚本不再报 `unbound variable`
+
+## 后续教程切入点
+- `set -u` 在发布脚本中的常见坑（空数组、可选参数）
+- 如何用最小变更做发布脚本鲁棒性补丁


### PR DESCRIPTION
## Summary
- fix `set -u` failure in deploy build script when optional build-arg arrays are empty
- keep existing build/push logic unchanged
- add issue devlog for traceability

## Changes
- `deploy/ecs/build-and-push-images.sh`
  - replace optional array expansion with nounset-safe form:
    - `${WEB_BUILD_ARGS[@]-}`
    - `${ADMIN_BUILD_ARGS[@]-}`
    - `${WEB_BUILDX_ARGS[@]-}`
    - `${ADMIN_BUILDX_ARGS[@]-}`
- `docs/30-开发日志/M20-issue-199-build-and-push-images-nounset-修复.md`

## Validation
- ✅ dry-run without `--public-api-base-url`
- ✅ dry-run with `--public-api-base-url`
- both paths pass without `unbound variable`

Closes #199
