### PR TITLE
fix(server): normalize relative sqlite DATABASE_URL

### DIFF
--- a/apps/server/src/database/__tests__/database.config.spec.ts
+++ b/apps/server/src/database/__tests__/database.config.spec.ts
@@ -38,4 +38,16 @@ describe('database.config', () => {
     expect(config.authToken).toBe('turso-token')
     expect(config.isRemote).toBe(false)
   })
+
+  it('should normalize relative sqlite file url to repo root path', () => {
+    const config = resolveDatabaseConfig(
+      {
+        DATABASE_URL: 'file:./.data/my-resume.db',
+      },
+      '/workspace/my-resume',
+    )
+
+    expect(config.url).toBe('file:/workspace/my-resume/.data/my-resume.db')
+    expect(config.isRemote).toBe(false)
+  })
 })

--- a/apps/server/src/database/database.config.ts
+++ b/apps/server/src/database/database.config.ts
@@ -1,5 +1,5 @@
 import { mkdirSync } from 'fs'
-import { dirname, join } from 'path'
+import { dirname, isAbsolute, join, resolve } from 'path'
 import { resolveRepoRoot } from '../config/repo-root'
 
 export interface DatabaseRuntimeConfig {
@@ -25,18 +25,48 @@ export function buildDefaultDatabaseUrl(repoRoot = resolveRepoRoot()): string {
   return `file:${join(repoRoot, '.data', 'my-resume.db')}`
 }
 
+function splitFilePathAndSuffix(filePath: string): [pathname: string, suffix: string] {
+  const queryIndex = filePath.indexOf('?')
+
+  if (queryIndex === -1) {
+    return [filePath, '']
+  }
+
+  return [filePath.slice(0, queryIndex), filePath.slice(queryIndex)]
+}
+
+function normalizeFileDatabaseUrl(url: string, repoRoot: string): string {
+  if (!url.startsWith('file:')) {
+    return url
+  }
+
+  const filePath = url.slice('file:'.length)
+  const [pathname, suffix] = splitFilePathAndSuffix(filePath)
+
+  if (!pathname || pathname.startsWith(':memory:') || suffix.includes('mode=memory')) {
+    return url
+  }
+
+  if (isAbsolute(pathname)) {
+    return url
+  }
+
+  return `file:${resolve(repoRoot, pathname)}${suffix}`
+}
+
 export function ensureLocalDatabaseDirectory(url: string): void {
   if (!url.startsWith('file:')) {
     return
   }
 
   const filePath = url.slice('file:'.length)
+  const [pathname, suffix] = splitFilePathAndSuffix(filePath)
 
-  if (!filePath || filePath.startsWith(':memory:') || filePath.includes('mode=memory')) {
+  if (!pathname || pathname.startsWith(':memory:') || suffix.includes('mode=memory')) {
     return
   }
 
-  mkdirSync(dirname(filePath), {
+  mkdirSync(dirname(pathname), {
     recursive: true,
   })
 }
@@ -45,9 +75,10 @@ export function resolveDatabaseConfig(
   env: NodeJS.ProcessEnv,
   repoRoot = resolveRepoRoot(__dirname),
 ): DatabaseRuntimeConfig {
-  const url =
+  const rawUrl =
     firstDefinedValue(env.DATABASE_URL, env.TURSO_DATABASE_URL, env.LIBSQL_URL) ||
     buildDefaultDatabaseUrl(repoRoot)
+  const url = normalizeFileDatabaseUrl(rawUrl, repoRoot)
 
   const authToken = firstDefinedValue(
     env.DATABASE_AUTH_TOKEN,

--- a/docs/30-开发日志/M20-issue-203-server-相对数据库路径规范化修复.md
+++ b/docs/30-开发日志/M20-issue-203-server-相对数据库路径规范化修复.md
@@ -1,0 +1,27 @@
+# M20 Issue 203 - server 相对数据库路径规范化修复
+
+## 背景
+本地 `.env.development.local` 使用 `DATABASE_URL=file:./.data/my-resume.db`。当 server 进程 cwd 在 `apps/server` 时，相对路径会指向 `apps/server/.data/my-resume.db`，导致读到错误库并触发查询失败。
+
+## 本次目标
+- 统一规范 `file:` 类型数据库 URL：相对路径解析到仓库根目录
+- 避免 cwd 差异导致连接错误数据库
+
+## 实际改动
+- `apps/server/src/database/database.config.ts`
+  - 新增 `file:` URL 规范化逻辑
+  - 相对路径（如 `file:./.data/my-resume.db`）转换为仓库根绝对路径
+  - `ensureLocalDatabaseDirectory` 同步支持 query 后缀切分
+- `apps/server/src/database/__tests__/database.config.spec.ts`
+  - 新增相对 sqlite URL 规范化测试
+
+## 测试与验证
+- `pnpm --filter @my-resume/server test src/database/__tests__/database.config.spec.ts`
+- `pnpm --filter @my-resume/server typecheck`
+- 手工验证：
+  - `cd apps/server && DATABASE_URL='file:./.data/my-resume.db' pnpm db:check`
+  - 输出已固定到仓库根：`file:/Users/fri/Desktop/personal/my-resume/.data/my-resume.db`
+
+## 后续建议
+- 保留 `.env.development.local` 相对写法不变（对开发者更友好）
+- server 侧负责收敛并规范化，避免环境差异引发隐式故障


### PR DESCRIPTION
## Summary
- fix server DB config to normalize relative sqlite `file:` URLs against repo root
- prevent cwd-dependent DB misrouting (e.g. `apps/server/.data/...`)
- add regression test + devlog

## Root cause
`DATABASE_URL=file:./.data/my-resume.db` is relative. When Nest server starts with cwd at `apps/server`, it can point to `apps/server/.data/my-resume.db`, causing query failures against wrong/empty DB.

## Changes
- `apps/server/src/database/database.config.ts`
  - add relative `file:` URL normalization to repo-root absolute path
  - improve local DB directory handling for `file:?query` suffix
- `apps/server/src/database/__tests__/database.config.spec.ts`
  - add test for `file:./.data/my-resume.db` normalization
- `docs/30-开发日志/M20-issue-203-server-相对数据库路径规范化修复.md`

## Validation
- ✅ `pnpm --filter @my-resume/server test src/database/__tests__/database.config.spec.ts`
- ✅ `pnpm --filter @my-resume/server typecheck`
- ✅ `cd apps/server && DATABASE_URL='file:./.data/my-resume.db' pnpm db:check`
  - output resolves to repo-root DB path

Closes #203
