### PR TITLE
chore(web,admin): tag-based boot version and banner log

### DIFF
--- a/apps/admin/app/providers.tsx
+++ b/apps/admin/app/providers.tsx
@@ -14,6 +14,16 @@ declare global {
   }
 }
 
+const startupBanner = String.raw`
+   __      _     _       _       _     
+  / _|    (_)   | |     | |     | |    
+ | |_ _ __ _  __| | ___ | |_ __ | |__  
+ |  _| '__| |/ _\` |/ _ \\| | '_ \\| '_ \\ 
+ | | | |  | | (_| | (_) | | |_) | | | |
+ |_| |_|  |_|\__,_|\___/|_| .__/|_| |_|
+                          | |          
+                          |_|          `
+
 function ThemeDatasetBridge() {
   const { resolvedTheme } = useTheme()
 
@@ -58,6 +68,7 @@ export function ProvidersWithLocale({
 
     loggedScopes[scope] = true
 
+    console.log(startupBanner)
     console.log('[my-resume:admin] boot', {
       apiBaseUrl: DEFAULT_API_BASE_URL,
       href: window.location.href,

--- a/apps/admin/next.config.ts
+++ b/apps/admin/next.config.ts
@@ -1,5 +1,6 @@
 import type { NextConfig } from 'next'
 import createNextIntlPlugin from 'next-intl/plugin'
+import { execSync } from 'node:child_process'
 import { readFileSync } from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -9,7 +10,27 @@ const packageJsonPath = path.join(dirname, 'package.json')
 const packageVersion = JSON.parse(readFileSync(packageJsonPath, 'utf8')) as {
   version?: string
 }
-const appVersion = process.env.NEXT_PUBLIC_APP_VERSION ?? packageVersion.version ?? '0.0.0'
+
+function resolveLatestGitTag(): string | undefined {
+  try {
+    const tag = execSync('git tag --sort=-v:refname | head -n 1', {
+      cwd: path.join(dirname, '../..'),
+      stdio: ['ignore', 'pipe', 'ignore'],
+    })
+      .toString()
+      .trim()
+
+    return tag || undefined
+  } catch {
+    return undefined
+  }
+}
+
+const appVersion =
+  process.env.NEXT_PUBLIC_APP_VERSION ??
+  resolveLatestGitTag() ??
+  packageVersion.version ??
+  '0.0.0'
 
 const nextConfig: NextConfig = {
   eslint: {

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@my-resume/admin",
-  "version": "0.0.1",
+  "version": "2.2.8",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@my-resume/server",
-  "version": "0.0.1",
+  "version": "2.2.8",
   "description": "Personal resume monorepo server scaffold",
   "author": "Fridolph",
   "private": true,

--- a/apps/web/app/web-locale-providers.tsx
+++ b/apps/web/app/web-locale-providers.tsx
@@ -13,6 +13,16 @@ declare global {
   }
 }
 
+const startupBanner = String.raw`
+   __      _     _       _       _     
+  / _|    (_)   | |     | |     | |    
+ | |_ _ __ _  __| | ___ | |_ __ | |__  
+ |  _| '__| |/ _\` |/ _ \\| | '_ \\| '_ \\ 
+ | | | |  | | (_| | (_) | | |_) | | | |
+ |_| |_|  |_|\__,_|\___/|_| .__/|_| |_|
+                          | |          
+                          |_|          `
+
 export function WebLocaleProviders({
   children,
   heroLocale,
@@ -36,6 +46,7 @@ export function WebLocaleProviders({
 
     loggedScopes[scope] = true
 
+    console.log(startupBanner)
     console.log('[my-resume:web] boot', {
       apiBaseUrl: DEFAULT_PUBLIC_API_BASE_URL,
       href: window.location.href,

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,5 +1,6 @@
 import type { NextConfig } from 'next'
 import createNextIntlPlugin from 'next-intl/plugin'
+import { execSync } from 'node:child_process'
 import { readFileSync } from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -9,7 +10,27 @@ const packageJsonPath = path.join(dirname, 'package.json')
 const packageVersion = JSON.parse(readFileSync(packageJsonPath, 'utf8')) as {
   version?: string
 }
-const appVersion = process.env.NEXT_PUBLIC_APP_VERSION ?? packageVersion.version ?? '0.0.0'
+
+function resolveLatestGitTag(): string | undefined {
+  try {
+    const tag = execSync('git tag --sort=-v:refname | head -n 1', {
+      cwd: path.join(dirname, '../..'),
+      stdio: ['ignore', 'pipe', 'ignore'],
+    })
+      .toString()
+      .trim()
+
+    return tag || undefined
+  } catch {
+    return undefined
+  }
+}
+
+const appVersion =
+  process.env.NEXT_PUBLIC_APP_VERSION ??
+  resolveLatestGitTag() ??
+  packageVersion.version ??
+  '0.0.0'
 
 const nextConfig: NextConfig = {
   eslint: {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@my-resume/web",
-  "version": "0.0.1",
+  "version": "2.2.8",
   "private": true,
   "type": "module",
   "scripts": {

--- a/docs/30-开发日志/M20-issue-205-web-admin-tag版本与启动banner日志.md
+++ b/docs/30-开发日志/M20-issue-205-web-admin-tag版本与启动banner日志.md
@@ -1,0 +1,34 @@
+# M20 Issue 205 - web/admin tag 版本与启动 banner 日志
+
+## 背景
+当前 `web/admin` 启动日志中的版本值来自 `package.json`（0.0.1），不利于线上快速判断是否命中目标发布版本。
+
+## 本次目标
+- 启动日志版本优先显示发布 tag
+- 在启动日志前增加 ASCII banner
+- 将 workspace 各 `package.json` 版本同步到当前发布版本（2.2.8）
+
+## 实际改动
+- `apps/web/next.config.ts`
+- `apps/admin/next.config.ts`
+  - 版本策略改为：
+    1. `NEXT_PUBLIC_APP_VERSION`
+    2. `git tag --sort=-v:refname | head -n 1`
+    3. `package.json version`
+- `apps/web/app/web-locale-providers.tsx`
+- `apps/admin/app/providers.tsx`
+  - 在 boot log 前新增 ASCII banner `console.log`
+- 版本号同步：
+  - 根 `package.json`
+  - `apps/*/package.json`
+  - `packages/*/package.json`
+  - 统一更新为 `2.2.8`
+
+## 测试与验证
+- `cd apps/web && ../../node_modules/.bin/tsc --noEmit --incremental false`
+- `cd apps/admin && ../../node_modules/.bin/tsc --noEmit --incremental false`
+- `git tag --sort=-v:refname | head -n 1` 输出 `v2.2.8`
+
+## 后续建议
+- 后续每次发版后，同步 bump workspace package 版本
+- 保持部署脚本传入 `NEXT_PUBLIC_APP_VERSION=$TAG`，确保线上严格与发布版本一致

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "my-resume-app",
   "private": true,
-  "version": "0.0.0",
+  "version": "2.2.8",
   "type": "module",
   "packageManager": "pnpm@10.8.0",
   "scripts": {

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@my-resume/api-client",
   "private": true,
-  "version": "0.0.1",
+  "version": "2.2.8",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@my-resume/config",
   "private": true,
-  "version": "0.0.1",
+  "version": "2.2.8",
   "type": "module",
   "scripts": {
     "lint": "oxlint --config ../../.oxlintrc.json --ignore-path ../../.eslintignore .",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@my-resume/ui",
   "private": true,
-  "version": "0.0.1",
+  "version": "2.2.8",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@my-resume/utils",
   "private": true,
-  "version": "0.0.1",
+  "version": "2.2.8",
   "type": "module",
   "exports": {
     ".": {


### PR DESCRIPTION
## Summary
- make web/admin startup `version` prefer release tag instead of fixed package fallback
- add ASCII banner log before boot diagnostics
- sync workspace `package.json` versions to `2.2.8`

## Changes
- tag-first version resolution
  - `apps/web/next.config.ts`
  - `apps/admin/next.config.ts`
  - version source order:
    1) `NEXT_PUBLIC_APP_VERSION`
    2) latest git tag (`git tag --sort=-v:refname | head -n 1`)
    3) package version fallback
- startup banner + boot log
  - `apps/web/app/web-locale-providers.tsx`
  - `apps/admin/app/providers.tsx`
- version sync to 2.2.8
  - root/package + apps/package + packages/package versions
- devlog
  - `docs/30-开发日志/M20-issue-205-web-admin-tag版本与启动banner日志.md`

## Validation
- ✅ `cd apps/web && ../../node_modules/.bin/tsc --noEmit --incremental false`
- ✅ `cd apps/admin && ../../node_modules/.bin/tsc --noEmit --incremental false`
- ✅ latest tag check returns `v2.2.8`

Closes #205
