### PR TITLE
feat(m21): issue #177 RAG 数据契约与索引表最小骨架

### DIFF
--- a/apps/admin/app/[locale]/_auth/types/auth.types.ts
+++ b/apps/admin/app/[locale]/_auth/types/auth.types.ts
@@ -1,3 +1,6 @@
+/**
+ * 后台角色能力定义。
+ */
 export interface RoleCapabilities {
   canAccessAdminSurface?: boolean
   canReadPublishedResume?: boolean
@@ -7,6 +10,9 @@ export interface RoleCapabilities {
   canTriggerAiAnalysis?: boolean
 }
 
+/**
+ * 当前登录用户视图。
+ */
 export interface AuthUserView {
   id: string
   username: string
@@ -15,6 +21,9 @@ export interface AuthUserView {
   capabilities: RoleCapabilities
 }
 
+/**
+ * 登录成功返回模型。
+ */
 export interface LoginResult {
   accessToken: string
   tokenType: 'Bearer'

--- a/apps/admin/app/[locale]/dashboard/_shared/types/admin-navigation.types.ts
+++ b/apps/admin/app/[locale]/dashboard/_shared/types/admin-navigation.types.ts
@@ -1,3 +1,6 @@
+/**
+ * 后台导航项模型。
+ */
 export interface AdminNavigationItem {
   key: 'overview' | 'resume' | 'ai' | 'optimizationHistory' | 'publish'
   href:

--- a/apps/admin/app/[locale]/dashboard/ai/_ai/types/ai-file.types.ts
+++ b/apps/admin/app/[locale]/dashboard/ai/_ai/types/ai-file.types.ts
@@ -1,5 +1,11 @@
+/**
+ * 可提取文本的文件类型。
+ */
 export type ExtractedFileType = 'txt' | 'md' | 'pdf' | 'docx'
 
+/**
+ * 文件提取结果模型。
+ */
 export interface FileExtractionResult {
   fileName: string
   fileType: ExtractedFileType

--- a/apps/admin/app/[locale]/dashboard/ai/_ai/types/ai-workbench.types.ts
+++ b/apps/admin/app/[locale]/dashboard/ai/_ai/types/ai-workbench.types.ts
@@ -6,6 +6,9 @@ import type {
 
 export type AiWorkbenchScenario = 'jd-match' | 'resume-review' | 'offer-compare'
 
+/**
+ * AI 工作台运行时摘要。
+ */
 export interface AiWorkbenchRuntimeSummary {
   provider: string
   model: string
@@ -13,8 +16,19 @@ export interface AiWorkbenchRuntimeSummary {
   supportedScenarios: readonly AiWorkbenchScenario[]
 }
 
+/**
+ * AI 工作台语言。
+ */
 export type AiWorkbenchLocale = 'zh' | 'en'
+
+/**
+ * 报告生成来源。
+ */
 export type AiWorkbenchReportGenerator = 'mock-cache' | 'ai-provider'
+
+/**
+ * 建议影响模块。
+ */
 export type AiAnalysisSuggestionModule =
   | 'profile'
   | 'experiences'
@@ -30,6 +44,9 @@ export interface AiWorkbenchScore {
   reason: string
 }
 
+/**
+ * AI 建议条目。
+ */
 export interface AiWorkbenchSuggestion {
   key: string
   title: string
@@ -41,12 +58,18 @@ export interface AiWorkbenchSuggestion {
   actions: string[]
 }
 
+/**
+ * AI 报告分节条目。
+ */
 export interface AiWorkbenchReportSection {
   key: string
   title: string
   bullets: string[]
 }
 
+/**
+ * AI 工作台完整报告。
+ */
 export interface AiWorkbenchReport {
   reportId: string
   cacheKey: string
@@ -65,6 +88,9 @@ export interface AiWorkbenchReport {
   createdAt: string
 }
 
+/**
+ * 缓存报告摘要。
+ */
 export interface AiWorkbenchCachedReportSummary {
   reportId: string
   scenario: AiWorkbenchScenario
@@ -74,16 +100,33 @@ export interface AiWorkbenchCachedReportSummary {
   createdAt: string
 }
 
+/**
+ * 触发分析返回结果。
+ */
 export interface TriggerAiWorkbenchAnalysisResult {
   cached: boolean
   report: AiWorkbenchReport
   usageRecordId: string
 }
 
+/**
+ * 使用记录操作类型。
+ */
 export type AiUsageRecordOperationType = 'analysis-report' | 'resume-optimization'
+
+/**
+ * 使用记录状态。
+ */
 export type AiUsageRecordStatus = 'succeeded' | 'failed'
+
+/**
+ * 使用记录过滤类型。
+ */
 export type AiUsageRecordFilterType = 'all' | AiUsageRecordOperationType
 
+/**
+ * 使用记录摘要。
+ */
 export interface AiUsageRecordSummary {
   id: string
   operationType: AiUsageRecordOperationType
@@ -105,10 +148,16 @@ export interface AiUsageRecordSummary {
   scoreValue?: number
 }
 
+/**
+ * 使用记录详情。
+ */
 export interface AiUsageRecordDetail extends AiUsageRecordSummary {
   detail: unknown | null
 }
 
+/**
+ * 简历优化变更模块。
+ */
 export type AiResumeOptimizationChangedModule =
   | 'profile'
   | 'experiences'
@@ -120,18 +169,27 @@ export interface AiResumeOptimizationProfilePatch {
   summary?: LocalizedText
 }
 
+/**
+ * 工作经历优化补丁。
+ */
 export interface AiResumeOptimizationExperiencePatch {
   index: number
   summary?: LocalizedText
   highlights?: LocalizedText[]
 }
 
+/**
+ * 项目优化补丁。
+ */
 export interface AiResumeOptimizationProjectPatch {
   index: number
   summary?: LocalizedText
   highlights?: LocalizedText[]
 }
 
+/**
+ * 简历优化总补丁。
+ */
 export interface AiResumeOptimizationPatch {
   profile?: AiResumeOptimizationProfilePatch
   experiences?: AiResumeOptimizationExperiencePatch[]
@@ -139,6 +197,9 @@ export interface AiResumeOptimizationPatch {
   highlights?: ResumeHighlightItem[]
 }
 
+/**
+ * 优化差异条目。
+ */
 export interface AiResumeOptimizationDiffEntry {
   key: string
   label: string
@@ -148,6 +209,9 @@ export interface AiResumeOptimizationDiffEntry {
   suggestedValue: string
 }
 
+/**
+ * 优化模块差异。
+ */
 export interface AiResumeOptimizationModuleDiff {
   module: AiResumeOptimizationChangedModule
   title: string
@@ -155,6 +219,9 @@ export interface AiResumeOptimizationModuleDiff {
   entries: AiResumeOptimizationDiffEntry[]
 }
 
+/**
+ * 应用优化结果入参。
+ */
 export interface ApplyAiResumeOptimizationInput {
   apiBaseUrl: string
   accessToken: string
@@ -162,6 +229,9 @@ export interface ApplyAiResumeOptimizationInput {
   modules: AiResumeOptimizationChangedModule[]
 }
 
+/**
+ * AI 简历优化结果。
+ */
 export interface AiResumeOptimizationResult {
   resultId: string
   usageRecordId?: string
@@ -180,4 +250,7 @@ export interface AiResumeOptimizationResult {
   }
 }
 
+/**
+ * 应用优化后的返回快照。
+ */
 export type ApplyAiResumeOptimizationResult = ResumeDraftSnapshot

--- a/apps/admin/app/[locale]/dashboard/resume/_resume/types/draft-editor-panel.types.ts
+++ b/apps/admin/app/[locale]/dashboard/resume/_resume/types/draft-editor-panel.types.ts
@@ -3,6 +3,9 @@ import {
   createUpdateDraftResumeMethod,
 } from '../services/resume-draft-api'
 
+/**
+ * 草稿编辑面板组件入参。
+ */
 export interface ResumeDraftEditorPanelProps {
   accessToken: string
   apiBaseUrl: string

--- a/apps/admin/app/[locale]/dashboard/resume/_resume/types/draft-editor.types.ts
+++ b/apps/admin/app/[locale]/dashboard/resume/_resume/types/draft-editor.types.ts
@@ -3,9 +3,24 @@ import type { ReactNode } from 'react'
 
 import type { StandardResume } from './resume.types'
 
+/**
+ * 编辑器状态。
+ */
 export type DraftEditorStatus = 'idle' | 'loading' | 'ready' | 'error'
+
+/**
+ * 扁平字段缓存（用于受控输入回填）。
+ */
 export type DraftFieldValues = Record<string, string>
+
+/**
+ * 当前编辑语言模式。
+ */
 export type EditorLocaleMode = 'zh' | 'en'
+
+/**
+ * 可排序集合键。
+ */
 export type SortableCollectionKey =
   | 'profileLinks'
   | 'profileInterests'
@@ -14,30 +29,59 @@ export type SortableCollectionKey =
   | 'projects'
   | 'skills'
   | 'highlights'
+
+/**
+ * 可排序集合状态映射。
+ */
 export type SortableCollectionState = Record<SortableCollectionKey, string[]>
 
+/**
+ * 草稿变更可选项。
+ */
 export interface ResumeDraftMutationOptions {
   syncDraftFields?: boolean
 }
 
+/**
+ * 翻译动作处理器。
+ */
 export interface TranslationActionHandlers {
   onClear: () => void
   onCopy: () => void
 }
 
+/**
+ * 草稿变更函数类型。
+ */
 export type ResumeDraftMutator = (draft: StandardResume) => void
+
+/**
+ * 更新草稿函数类型。
+ */
 export type UpdateResumeDraft = (
   mutator: ResumeDraftMutator,
   options?: ResumeDraftMutationOptions,
 ) => void
+
+/**
+ * 更新排序集合函数类型。
+ */
 export type UpdateSortableCollection = (
   collection: SortableCollectionKey,
   updater: (currentIds: string[]) => string[],
 ) => void
+
+/**
+ * 处理拖拽排序结束事件函数类型。
+ */
 export type HandleCollectionDragEnd = (
   collection: SortableCollectionKey,
   event: DragEndEvent,
 ) => void
+
+/**
+ * 渲染翻译动作函数类型。
+ */
 export type RenderTranslationActions = (
   scopeTitle: string,
   handlers: TranslationActionHandlers,

--- a/apps/admin/app/[locale]/dashboard/resume/_resume/types/editor-primitives.types.ts
+++ b/apps/admin/app/[locale]/dashboard/resume/_resume/types/editor-primitives.types.ts
@@ -2,6 +2,9 @@ import type { ReactNode } from 'react'
 
 import type { EditorLocaleMode } from './draft-editor.types'
 
+/**
+ * 图标按钮基础入参。
+ */
 export interface IconActionButtonProps {
   buttonProps?: Record<string, unknown>
   className?: string
@@ -13,6 +16,9 @@ export interface IconActionButtonProps {
   variant?: 'ghost' | 'outline'
 }
 
+/**
+ * 双语编辑字段入参。
+ */
 export interface LocalizedEditorFieldProps {
   label: string
   localeMode: EditorLocaleMode
@@ -23,6 +29,9 @@ export interface LocalizedEditorFieldProps {
   variant?: 'input' | 'textarea'
 }
 
+/**
+ * 编辑分节容器入参。
+ */
 export interface EditorSectionProps {
   action?: ReactNode
   children: ReactNode
@@ -32,6 +41,9 @@ export interface EditorSectionProps {
   title: string
 }
 
+/**
+ * 编辑条目容器入参。
+ */
 export interface EditorEntryProps {
   action?: ReactNode
   children: ReactNode

--- a/apps/admin/app/[locale]/dashboard/resume/_resume/types/education-section.types.ts
+++ b/apps/admin/app/[locale]/dashboard/resume/_resume/types/education-section.types.ts
@@ -8,6 +8,9 @@ import type {
   SortableCollectionState,
 } from './draft-editor.types'
 
+/**
+ * 教育经历分节组件入参。
+ */
 export interface EducationSectionProps {
   addEducation: () => void
   draftFieldValues: DraftFieldValues

--- a/apps/admin/app/[locale]/dashboard/resume/_resume/types/experiences-section.types.ts
+++ b/apps/admin/app/[locale]/dashboard/resume/_resume/types/experiences-section.types.ts
@@ -8,6 +8,9 @@ import type {
   SortableCollectionState,
 } from './draft-editor.types'
 
+/**
+ * 工作经历分节组件入参。
+ */
 export interface ExperiencesSectionProps {
   addExperience: () => void
   draftFieldValues: DraftFieldValues

--- a/apps/admin/app/[locale]/dashboard/resume/_resume/types/profile-section.types.ts
+++ b/apps/admin/app/[locale]/dashboard/resume/_resume/types/profile-section.types.ts
@@ -8,6 +8,9 @@ import type {
   SortableCollectionState,
 } from './draft-editor.types'
 
+/**
+ * 个人资料分节组件入参。
+ */
 export interface ProfileSectionProps {
   addProfileInterest: () => void
   addProfileLink: () => void

--- a/apps/admin/app/[locale]/dashboard/resume/_resume/types/projects-section.types.ts
+++ b/apps/admin/app/[locale]/dashboard/resume/_resume/types/projects-section.types.ts
@@ -8,6 +8,9 @@ import type {
   SortableCollectionState,
 } from './draft-editor.types'
 
+/**
+ * 项目经历分节组件入参。
+ */
 export interface ProjectsSectionProps {
   addProject: () => void
   addProjectLink: (projectIndex: number) => void

--- a/apps/admin/app/[locale]/dashboard/resume/_resume/types/resume.types.ts
+++ b/apps/admin/app/[locale]/dashboard/resume/_resume/types/resume.types.ts
@@ -1,3 +1,10 @@
+/**
+ * admin 侧简历域类型统一出口。
+ *
+ * 说明：
+ * - 统一复用 `@my-resume/api-client` 契约类型，避免本地重复定义。
+ * - 此文件仅做 re-export，不新增字段语义。
+ */
 export type {
   LocalizedText,
   ResumeDraftSnapshot,

--- a/apps/admin/app/[locale]/dashboard/resume/_resume/types/skills-highlights-sections.types.ts
+++ b/apps/admin/app/[locale]/dashboard/resume/_resume/types/skills-highlights-sections.types.ts
@@ -8,6 +8,9 @@ import type {
   SortableCollectionState,
 } from './draft-editor.types'
 
+/**
+ * 技能分组分节组件入参。
+ */
 export interface SkillsSectionProps {
   addSkillGroup: () => void
   draftFieldValues: DraftFieldValues
@@ -24,6 +27,9 @@ export interface SkillsSectionProps {
   updateSkillProficiency: (index: number, value: string) => void
 }
 
+/**
+ * 亮点分节组件入参。
+ */
 export interface HighlightsSectionProps {
   addHighlight: () => void
   editorLocaleMode: EditorLocaleMode

--- a/apps/server/src/database/__tests__/schema.spec.ts
+++ b/apps/server/src/database/__tests__/schema.spec.ts
@@ -1,7 +1,15 @@
 import { getTableColumns } from 'drizzle-orm'
 import { describe, expect, it } from 'vitest'
 
-import { aiUsageRecords, resumeDrafts, resumePublicationSnapshots, systemMeta } from '../schema'
+import {
+  aiUsageRecords,
+  ragChunks,
+  ragDocuments,
+  ragIndexRuns,
+  resumeDrafts,
+  resumePublicationSnapshots,
+  systemMeta,
+} from '../schema'
 
 describe('database schema', () => {
   it('should keep the system meta table for infrastructure bootstrap', () => {
@@ -50,6 +58,53 @@ describe('database schema', () => {
       'errorMessage',
       'durationMs',
       'createdAt',
+    ])
+  })
+
+  it('should define rag documents table for retrieval-side source contracts', () => {
+    expect(Object.keys(getTableColumns(ragDocuments))).toEqual([
+      'id',
+      'sourceType',
+      'sourceScope',
+      'sourceId',
+      'sourceVersion',
+      'locale',
+      'title',
+      'contentHash',
+      'metadataJson',
+      'createdAt',
+      'updatedAt',
+    ])
+  })
+
+  it('should define rag chunks table for semantic retrieval blocks', () => {
+    expect(Object.keys(getTableColumns(ragChunks))).toEqual([
+      'id',
+      'documentId',
+      'chunkIndex',
+      'section',
+      'content',
+      'contentHash',
+      'embeddingJson',
+      'metadataJson',
+      'createdAt',
+      'updatedAt',
+    ])
+  })
+
+  it('should define rag index runs table for index lifecycle tracking', () => {
+    expect(Object.keys(getTableColumns(ragIndexRuns))).toEqual([
+      'id',
+      'sourceType',
+      'sourceScope',
+      'sourceVersion',
+      'status',
+      'chunkCount',
+      'errorMessage',
+      'startedAt',
+      'finishedAt',
+      'createdAt',
+      'updatedAt',
     ])
   })
 })

--- a/apps/server/src/database/schema.ts
+++ b/apps/server/src/database/schema.ts
@@ -1,9 +1,16 @@
-import { index, integer, sqliteTable, text } from 'drizzle-orm/sqlite-core'
+import { index, integer, sqliteTable, text, uniqueIndex } from 'drizzle-orm/sqlite-core'
 
 import type { StandardResume } from '../modules/resume/domain/standard-resume'
 
 import { STANDARD_RESUME_KEY } from './resume-records'
 
+/**
+ * system_meta：系统级键值元信息表。
+ *
+ * 作用：
+ * - 存储轻量级运行时元信息（如初始化标记、版本戳等）。
+ * - 不承载业务核心数据。
+ */
 export const systemMeta = sqliteTable('system_meta', {
   key: text('key').primaryKey(),
   value: text('value').notNull(),
@@ -12,6 +19,13 @@ export const systemMeta = sqliteTable('system_meta', {
   }).notNull(),
 })
 
+/**
+ * resume_drafts：当前草稿位。
+ *
+ * 作用：
+ * - 只保存“当前可编辑草稿”的最新状态。
+ * - 通过固定 resume_key 做单槽位 upsert。
+ */
 export const resumeDrafts = sqliteTable('resume_drafts', {
   resumeKey: text('resume_key')
     .primaryKey()
@@ -27,6 +41,13 @@ export const resumeDrafts = sqliteTable('resume_drafts', {
   }).notNull(),
 })
 
+/**
+ * resume_publication_snapshots：发布快照表（append-only）。
+ *
+ * 作用：
+ * - 每次发布都追加一条不可变快照。
+ * - 与草稿态分离，保证公开展示可追溯。
+ */
 export const resumePublicationSnapshots = sqliteTable(
   'resume_publication_snapshots',
   {
@@ -49,6 +70,13 @@ export const resumePublicationSnapshots = sqliteTable(
   }),
 )
 
+/**
+ * ai_usage_records：AI 调用审计表。
+ *
+ * 作用：
+ * - 记录 AI 分析/优化等调用的输入摘要、状态、耗时与关联记录。
+ * - 支撑后续运营排查、成本分析与结果追踪。
+ */
 export const aiUsageRecords = sqliteTable(
   'ai_usage_records',
   {
@@ -80,5 +108,159 @@ export const aiUsageRecords = sqliteTable(
       table.createdAt,
     ),
     createdAtIndex: index('ai_usage_records_created_at_idx').on(table.createdAt),
+  }),
+)
+
+/**
+ * RAG 知识源大类：
+ * - resume_core: 简历核心事实（优先级最高）
+ * - user_docs: 用户补充资料（博客、文章、兴趣内容等）
+ */
+export type RagSourceType = 'resume_core' | 'user_docs'
+
+/**
+ * RAG 知识源作用域：
+ * - draft: 草稿态（编辑中的最新内容）
+ * - published: 发布态（对外稳定内容）
+ */
+export type RagSourceScope = 'draft' | 'published'
+
+/**
+ * RAG 索引运行状态：
+ * - pending: 任务已创建，等待或正在执行
+ * - succeeded: 索引成功
+ * - failed: 索引失败
+ */
+export type RagIndexRunStatus = 'pending' | 'succeeded' | 'failed'
+
+/**
+ * rag_documents：检索态文档主表
+ *
+ * 这张表与 resume_drafts / resume_publication_snapshots 分离：
+ * - 前者服务“编辑/展示”
+ * - 本表服务“检索/过滤/版本追踪”
+ */
+export const ragDocuments = sqliteTable(
+  'rag_documents',
+  {
+    id: text('id').primaryKey(),
+    sourceType: text('source_type').$type<RagSourceType>().notNull(),
+    sourceScope: text('source_scope').$type<RagSourceScope>().notNull(),
+    sourceId: text('source_id').notNull(),
+    sourceVersion: text('source_version').notNull(),
+    locale: text('locale').notNull(),
+    title: text('title').notNull(),
+    contentHash: text('content_hash').notNull(),
+    metadataJson: text('metadata_json', {
+      mode: 'json',
+    }).$type<Record<string, unknown> | null>(),
+    createdAt: integer('created_at', {
+      mode: 'timestamp_ms',
+    }).notNull(),
+    updatedAt: integer('updated_at', {
+      mode: 'timestamp_ms',
+    }).notNull(),
+  },
+  (table) => ({
+    sourceIdentityUnique: uniqueIndex('rag_documents_source_identity_unique').on(
+      table.sourceType,
+      table.sourceScope,
+      table.sourceId,
+      table.sourceVersion,
+      table.locale,
+    ),
+    sourceTypeScopeLocaleIndex: index('rag_documents_source_type_scope_locale_idx').on(
+      table.sourceType,
+      table.sourceScope,
+      table.locale,
+    ),
+    updatedAtIndex: index('rag_documents_updated_at_idx').on(table.updatedAt),
+  }),
+)
+
+/**
+ * rag_chunks：检索态 chunk 表
+ *
+ * embedding 先落 JSON，保证 SQLite 最小可运行；
+ * 后续可平滑迁移到专用向量数据库。
+ */
+export const ragChunks = sqliteTable(
+  'rag_chunks',
+  {
+    id: text('id').primaryKey(),
+    documentId: text('document_id')
+      .notNull()
+      .references(() => ragDocuments.id, {
+        onDelete: 'cascade',
+        onUpdate: 'cascade',
+      }),
+    chunkIndex: integer('chunk_index').notNull(),
+    section: text('section').notNull(),
+    content: text('content').notNull(),
+    contentHash: text('content_hash').notNull(),
+    embeddingJson: text('embedding_json', {
+      mode: 'json',
+    })
+      .$type<number[]>()
+      .notNull(),
+    metadataJson: text('metadata_json', {
+      mode: 'json',
+    }).$type<Record<string, unknown> | null>(),
+    createdAt: integer('created_at', {
+      mode: 'timestamp_ms',
+    }).notNull(),
+    updatedAt: integer('updated_at', {
+      mode: 'timestamp_ms',
+    }).notNull(),
+  },
+  (table) => ({
+    documentChunkIndexUnique: uniqueIndex('rag_chunks_document_chunk_index_unique').on(
+      table.documentId,
+      table.chunkIndex,
+    ),
+    documentIdIndex: index('rag_chunks_document_id_idx').on(table.documentId),
+    sectionIndex: index('rag_chunks_section_idx').on(table.section),
+  }),
+)
+
+/**
+ * rag_index_runs：索引运行记录表
+ *
+ * 用于追踪每次索引任务状态，后续可直接扩展重试策略与审计视图。
+ */
+export const ragIndexRuns = sqliteTable(
+  'rag_index_runs',
+  {
+    id: text('id').primaryKey(),
+    sourceType: text('source_type').$type<RagSourceType>().notNull(),
+    sourceScope: text('source_scope').$type<RagSourceScope>().notNull(),
+    sourceVersion: text('source_version').notNull(),
+    status: text('status').$type<RagIndexRunStatus>().notNull(),
+    chunkCount: integer('chunk_count').notNull(),
+    errorMessage: text('error_message'),
+    startedAt: integer('started_at', {
+      mode: 'timestamp_ms',
+    }).notNull(),
+    finishedAt: integer('finished_at', {
+      mode: 'timestamp_ms',
+    }),
+    createdAt: integer('created_at', {
+      mode: 'timestamp_ms',
+    }).notNull(),
+    updatedAt: integer('updated_at', {
+      mode: 'timestamp_ms',
+    }).notNull(),
+  },
+  (table) => ({
+    sourceVersionCreatedAtIndex: index('rag_index_runs_source_version_created_at_idx').on(
+      table.sourceType,
+      table.sourceScope,
+      table.sourceVersion,
+      table.createdAt,
+    ),
+    statusCreatedAtIndex: index('rag_index_runs_status_created_at_idx').on(
+      table.status,
+      table.createdAt,
+    ),
   }),
 )

--- a/apps/server/src/modules/ai/ai.module.ts
+++ b/apps/server/src/modules/ai/ai.module.ts
@@ -16,6 +16,7 @@ import { RagController } from './rag/rag.controller'
 import { RagChunkService } from './rag/rag-chunk.service'
 import { RagIndexRepository } from './rag/rag-index.repository'
 import { RagKnowledgeService } from './rag/rag-knowledge.service'
+import { RagRetrievalRepository } from './rag/rag-retrieval.repository'
 import { RagService } from './rag/rag.service'
 import { ResumeOptimizationResultCacheService } from './resume-optimization-result-cache.service'
 
@@ -48,6 +49,7 @@ import { ResumeOptimizationResultCacheService } from './resume-optimization-resu
     RagChunkService,
     RagKnowledgeService,
     RagIndexRepository,
+    RagRetrievalRepository,
     RagService,
   ],
   exports: [

--- a/apps/server/src/modules/ai/rag/__tests__/rag.types.spec.ts
+++ b/apps/server/src/modules/ai/rag/__tests__/rag.types.spec.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+
+import { mapLegacySourceTypeToRetrievalSourceType } from '../rag.types'
+
+describe('rag.types', () => {
+  it('should map legacy resume source to resume_core retrieval source', () => {
+    expect(mapLegacySourceTypeToRetrievalSourceType('resume')).toBe('resume_core')
+  })
+
+  it('should map legacy knowledge source to user_docs retrieval source', () => {
+    expect(mapLegacySourceTypeToRetrievalSourceType('knowledge')).toBe('user_docs')
+  })
+
+  it('should keep retrieval source type stable when source is already normalized', () => {
+    expect(mapLegacySourceTypeToRetrievalSourceType('resume_core')).toBe('resume_core')
+    expect(mapLegacySourceTypeToRetrievalSourceType('user_docs')).toBe('user_docs')
+  })
+})

--- a/apps/server/src/modules/ai/rag/rag-retrieval.repository.ts
+++ b/apps/server/src/modules/ai/rag/rag-retrieval.repository.ts
@@ -1,0 +1,222 @@
+import { Inject, Injectable } from '@nestjs/common'
+import { and, desc, eq } from 'drizzle-orm'
+
+import type { DatabaseInstance } from '../../../database/database.client'
+import { DATABASE_INSTANCE } from '../../../database/database.tokens'
+import {
+  RagIndexRunStatus,
+  RagSourceScope,
+  RagSourceType,
+  ragChunks,
+  ragDocuments,
+  ragIndexRuns,
+} from '../../../database/schema'
+
+export interface UpsertRagDocumentInput {
+  id: string
+  sourceType: RagSourceType
+  sourceScope: RagSourceScope
+  sourceId: string
+  sourceVersion: string
+  locale: string
+  title: string
+  contentHash: string
+  metadataJson?: Record<string, unknown> | null
+  createdAt: Date
+  updatedAt: Date
+}
+
+export interface CreateRagChunkInput {
+  id: string
+  documentId: string
+  chunkIndex: number
+  section: string
+  content: string
+  contentHash: string
+  embeddingJson: number[]
+  metadataJson?: Record<string, unknown> | null
+  createdAt: Date
+  updatedAt: Date
+}
+
+export interface CreateRagIndexRunInput {
+  id: string
+  sourceType: RagSourceType
+  sourceScope: RagSourceScope
+  sourceVersion: string
+  status: RagIndexRunStatus
+  chunkCount: number
+  errorMessage?: string | null
+  startedAt: Date
+  finishedAt?: Date | null
+  createdAt: Date
+  updatedAt: Date
+}
+
+@Injectable()
+export class RagRetrievalRepository {
+  constructor(
+    @Inject(DATABASE_INSTANCE)
+    private readonly database: DatabaseInstance,
+  ) {}
+
+  /**
+   * 按 source 唯一键写入或覆盖文档记录。
+   *
+   * 这样可以确保“同一个 source 版本”在检索侧只有一条文档主记录，
+   * 避免重复索引导致检索命中噪音。
+   *
+   * @param input 文档主记录
+   * @returns 最新文档记录
+   */
+  async upsertDocument(input: UpsertRagDocumentInput) {
+    await this.database
+      .insert(ragDocuments)
+      .values({
+        ...input,
+        metadataJson: input.metadataJson ?? null,
+      })
+      .onConflictDoUpdate({
+        target: [
+          ragDocuments.sourceType,
+          ragDocuments.sourceScope,
+          ragDocuments.sourceId,
+          ragDocuments.sourceVersion,
+          ragDocuments.locale,
+        ],
+        set: {
+          id: input.id,
+          title: input.title,
+          contentHash: input.contentHash,
+          metadataJson: input.metadataJson ?? null,
+          updatedAt: input.updatedAt,
+        },
+      })
+
+    return this.findDocumentBySourceIdentity({
+      sourceType: input.sourceType,
+      sourceScope: input.sourceScope,
+      sourceId: input.sourceId,
+      sourceVersion: input.sourceVersion,
+      locale: input.locale,
+    })
+  }
+
+  /**
+   * 按主键读取文档记录。
+   *
+   * @param id 文档 ID
+   * @returns 文档记录或 null
+   */
+  async findDocumentById(id: string) {
+    const [record] = await this.database
+      .select()
+      .from(ragDocuments)
+      .where(eq(ragDocuments.id, id))
+      .limit(1)
+
+    return record ?? null
+  }
+
+  /**
+   * 按 source 唯一键读取文档记录。
+   *
+   * @param input source 唯一键
+   * @returns 文档记录或 null
+   */
+  async findDocumentBySourceIdentity(input: {
+    sourceType: RagSourceType
+    sourceScope: RagSourceScope
+    sourceId: string
+    sourceVersion: string
+    locale: string
+  }) {
+    const [record] = await this.database
+      .select()
+      .from(ragDocuments)
+      .where(
+        and(
+          eq(ragDocuments.sourceType, input.sourceType),
+          eq(ragDocuments.sourceScope, input.sourceScope),
+          eq(ragDocuments.sourceId, input.sourceId),
+          eq(ragDocuments.sourceVersion, input.sourceVersion),
+          eq(ragDocuments.locale, input.locale),
+        ),
+      )
+      .limit(1)
+
+    return record ?? null
+  }
+
+  /**
+   * 覆盖指定 document 的全部 chunk。
+   *
+   * 采用“先删后写”保证 chunkIndex 序列与 sourceVersion 对齐，
+   * 避免旧 chunk 残留导致检索结果混入历史内容。
+   *
+   * @param documentId 文档 ID
+   * @param chunks 新的 chunk 列表
+   */
+  async replaceChunksForDocument(documentId: string, chunks: CreateRagChunkInput[]) {
+    await this.database.transaction(async (transaction) => {
+      await transaction.delete(ragChunks).where(eq(ragChunks.documentId, documentId))
+
+      if (chunks.length === 0) {
+        return
+      }
+
+      await transaction.insert(ragChunks).values(
+        chunks.map((item) => ({
+          ...item,
+          metadataJson: item.metadataJson ?? null,
+        })),
+      )
+    })
+  }
+
+  /**
+   * 追加写入一条索引运行记录。
+   *
+   * @param input 索引运行记录
+   * @returns 新写入记录
+   */
+  async createIndexRun(input: CreateRagIndexRunInput) {
+    await this.database.insert(ragIndexRuns).values({
+      ...input,
+      errorMessage: input.errorMessage ?? null,
+      finishedAt: input.finishedAt ?? null,
+    })
+
+    return this.findIndexRunById(input.id)
+  }
+
+  /**
+   * 按主键读取索引运行记录。
+   *
+   * @param id 运行记录 ID
+   * @returns 索引运行记录或 null
+   */
+  async findIndexRunById(id: string) {
+    const [record] = await this.database
+      .select()
+      .from(ragIndexRuns)
+      .where(eq(ragIndexRuns.id, id))
+      .limit(1)
+
+    return record ?? null
+  }
+
+  /**
+   * 查询最近的索引运行记录。
+   *
+   * @param limit 返回数量上限
+   * @returns 最近运行记录列表
+   */
+  async listLatestIndexRuns(limit = 20) {
+    return this.database
+      .select()
+      .from(ragIndexRuns)
+      .orderBy(desc(ragIndexRuns.createdAt))
+      .limit(limit)
+  }
+}

--- a/apps/server/src/modules/ai/rag/rag.types.ts
+++ b/apps/server/src/modules/ai/rag/rag.types.ts
@@ -1,3 +1,44 @@
+/**
+ * 检索态知识来源大类（用于数据库契约层）
+ *
+ * 说明：
+ * - resume_core: 简历核心事实，回答优先级更高
+ * - user_docs: 用户补充资料，如博客、技术文章、兴趣类内容
+ */
+export type RagRetrievalSourceType = 'resume_core' | 'user_docs'
+
+/**
+ * 检索态知识作用域（用于版本对齐）
+ *
+ * 说明：
+ * - draft: 对应编辑中的草稿内容
+ * - published: 对应已发布快照内容
+ */
+export type RagRetrievalSourceScope = 'draft' | 'published'
+
+/**
+ * 将旧索引 sourceType 映射到检索态契约 sourceType。
+ *
+ * 当前历史索引中：
+ * - resume -> resume_core
+ * - knowledge -> user_docs
+ *
+ * @param sourceType 旧索引来源类型
+ * @returns 检索态来源类型
+ */
+export function mapLegacySourceTypeToRetrievalSourceType(
+  sourceType: RagChunk['sourceType'],
+): RagRetrievalSourceType {
+  if (sourceType === 'knowledge' || sourceType === 'user_docs') {
+    return 'user_docs'
+  }
+
+  return 'resume_core'
+}
+
+/**
+ * 教育条目源模型（RAG 切块前输入）。
+ */
 export interface RagSourceEducationItem {
   id: string
   school: string
@@ -8,6 +49,9 @@ export interface RagSourceEducationItem {
   details?: string[]
 }
 
+/**
+ * 工作经历内的项目条目源模型（RAG 切块前输入）。
+ */
 export interface RagSourceExperienceProjectItem {
   id: string
   name: string
@@ -17,6 +61,9 @@ export interface RagSourceExperienceProjectItem {
   contributions?: string[]
 }
 
+/**
+ * 工作经历条目源模型（RAG 切块前输入）。
+ */
 export interface RagSourceExperienceItem {
   id: string
   company: string
@@ -29,6 +76,9 @@ export interface RagSourceExperienceItem {
   projects?: RagSourceExperienceProjectItem[]
 }
 
+/**
+ * 独立项目条目源模型（RAG 切块前输入）。
+ */
 export interface RagSourceStandaloneProjectItem {
   id: string
   name: string
@@ -40,6 +90,9 @@ export interface RagSourceStandaloneProjectItem {
   contributions?: string[]
 }
 
+/**
+ * 简历知识源文档模型（RAG 切块前输入）。
+ */
 export interface RagSourceDocument {
   profile: {
     name: string
@@ -65,19 +118,32 @@ export interface RagSourceDocument {
   }
 }
 
+/**
+ * RAG 语义块（未向量化）。
+ *
+ * sourceType 兼容值：
+ * - 历史值：resume / knowledge
+ * - 新契约：resume_core / user_docs
+ */
 export interface RagChunk {
   id: string
   title: string
   section: string
   content: string
-  sourceType?: 'resume' | 'knowledge'
+  sourceType?: 'resume' | 'knowledge' | RagRetrievalSourceType
   sourcePath?: string
 }
 
+/**
+ * 已向量化的 RAG 语义块。
+ */
 export interface RagIndexedChunk extends RagChunk {
   embedding: number[]
 }
 
+/**
+ * 本地索引文件结构（文件态索引模型）。
+ */
 export interface RagIndexFile {
   sourcePath: string
   blogDirectoryPath: string
@@ -95,6 +161,9 @@ export interface RagIndexFile {
   chunks: RagIndexedChunk[]
 }
 
+/**
+ * 检索命中结果模型（用于 search/ask 返回）。
+ */
 export interface RagSearchMatch extends RagChunk {
   score: number
 }

--- a/apps/server/src/modules/resume/application/types/resume-snapshot.types.ts
+++ b/apps/server/src/modules/resume/application/types/resume-snapshot.types.ts
@@ -1,25 +1,51 @@
 import type { StandardResume } from '../../domain/standard-resume'
 import type { ResumeSummary } from '../../resume-summary'
 
+/**
+ * 简历快照状态。
+ */
 export type ResumeSnapshotStatus = 'draft' | 'published'
 
+/**
+ * 不同快照状态对应的时间字段键。
+ */
 export type ResumeSnapshotTimestampKey<S extends ResumeSnapshotStatus> =
   S extends 'draft' ? 'updatedAt' : 'publishedAt'
 
+/**
+ * 快照时间字段映射。
+ */
 type ResumeSnapshotTimestampField<S extends ResumeSnapshotStatus> = {
   [K in ResumeSnapshotTimestampKey<S>]: string
 }
 
+/**
+ * 通用快照结构。
+ */
 export type ResumeSnapshot<S extends ResumeSnapshotStatus, TResume> = {
   status: S
   resume: TResume
 } & ResumeSnapshotTimestampField<S>
 
+/**
+ * 草稿快照结构。
+ */
 export type ResumeDraftSnapshot<TResume = StandardResume> = ResumeSnapshot<'draft', TResume>
+
+/**
+ * 发布快照结构。
+ */
 export type ResumePublishedSnapshot<TResume = StandardResume> = ResumeSnapshot<
   'published',
   TResume
 >
 
+/**
+ * 草稿摘要快照结构。
+ */
 export type ResumeDraftSummarySnapshot = ResumeDraftSnapshot<ResumeSummary>
+
+/**
+ * 发布摘要快照结构。
+ */
 export type ResumePublishedSummarySnapshot = ResumePublishedSnapshot<ResumeSummary>

--- a/apps/server/src/modules/resume/transport/types/resume-response.types.ts
+++ b/apps/server/src/modules/resume/transport/types/resume-response.types.ts
@@ -1,3 +1,10 @@
+/**
+ * transport 层简历响应类型别名。
+ *
+ * 说明：
+ * - 该文件只做应用层类型到 controller 响应语义的命名映射。
+ * - 不新增字段，避免 transport 与 application 语义漂移。
+ */
 export type {
   ResumeDraftSnapshot as ResumeDraftSnapshotResponse,
   ResumeDraftSummarySnapshot as ResumeDraftSummarySnapshotResponse,

--- a/apps/server/test/ai-file-extraction.e2e-spec.ts
+++ b/apps/server/test/ai-file-extraction.e2e-spec.ts
@@ -4,6 +4,7 @@ import request from 'supertest'
 import { App } from 'supertest/types'
 
 import { AppModule } from './../src/app.module'
+import { readAccessToken, readApiData } from './helpers/api-envelope'
 
 describe('AI file extraction (e2e)', () => {
   let app: INestApplication<App>
@@ -31,7 +32,7 @@ describe('AI file extraction (e2e)', () => {
       })
       .expect(200)
 
-    const accessToken = loginResponse.body.accessToken as string
+    const accessToken = readAccessToken(loginResponse)
 
     const response = await request(app.getHttpServer())
       .post('/api/ai/extract-text')
@@ -39,8 +40,13 @@ describe('AI file extraction (e2e)', () => {
       .attach('file', Buffer.from('resume text content', 'utf8'), 'resume.txt')
       .expect(201)
 
-    expect(response.body.fileType).toBe('txt')
-    expect(response.body.text).toContain('resume text content')
+    const extractionResult = readApiData<{
+      fileType: string
+      text: string
+    }>(response)
+
+    expect(extractionResult.fileType).toBe('txt')
+    expect(extractionResult.text).toContain('resume text content')
   })
 
   it('should reject unsupported uploaded files', async () => {
@@ -52,7 +58,7 @@ describe('AI file extraction (e2e)', () => {
       })
       .expect(200)
 
-    const accessToken = loginResponse.body.accessToken as string
+    const accessToken = readAccessToken(loginResponse)
 
     await request(app.getHttpServer())
       .post('/api/ai/extract-text')

--- a/apps/server/test/ai-rag.e2e-spec.ts
+++ b/apps/server/test/ai-rag.e2e-spec.ts
@@ -7,6 +7,7 @@ import request from 'supertest'
 import { App } from 'supertest/types'
 
 import { AppModule } from '../src/app.module'
+import { readAccessToken, readApiData } from './helpers/api-envelope'
 
 const source = `
 profile:
@@ -103,19 +104,28 @@ describe('AI RAG (e2e)', () => {
       })
       .expect(200)
 
-    const accessToken = loginResponse.body.accessToken as string
+    const accessToken = readAccessToken(loginResponse)
 
     const rebuildResponse = await request(app.getHttpServer())
       .post('/api/ai/rag/index/rebuild')
       .set('Authorization', `Bearer ${accessToken}`)
       .expect(201)
 
-    expect(rebuildResponse.body.indexed).toBe(true)
-    expect(rebuildResponse.body.stale).toBe(false)
-    expect(rebuildResponse.body.chunkCount).toBeGreaterThan(0)
-    expect(rebuildResponse.body.knowledgeChunkCount).toBeGreaterThan(0)
-    expect(rebuildResponse.body.providerSummary.chatModel).toBe('mock-resume-advisor')
-    expect(rebuildResponse.body.indexedProviderSummary.embeddingModel).toBe(
+    const rebuildPayload = readApiData<{
+      indexed: boolean
+      stale: boolean
+      chunkCount: number
+      knowledgeChunkCount: number
+      providerSummary: { chatModel: string }
+      indexedProviderSummary: { embeddingModel: string }
+    }>(rebuildResponse)
+
+    expect(rebuildPayload.indexed).toBe(true)
+    expect(rebuildPayload.stale).toBe(false)
+    expect(rebuildPayload.chunkCount).toBeGreaterThan(0)
+    expect(rebuildPayload.knowledgeChunkCount).toBeGreaterThan(0)
+    expect(rebuildPayload.providerSummary.chatModel).toBe('mock-resume-advisor')
+    expect(rebuildPayload.indexedProviderSummary.embeddingModel).toBe(
       'mock-resume-advisor-embedding',
     )
 
@@ -128,7 +138,9 @@ describe('AI RAG (e2e)', () => {
       })
       .expect(201)
 
-    expect(searchResponse.body[0].title).toContain('EDR')
+    const searchPayload = readApiData<Array<{ title: string }>>(searchResponse)
+
+    expect(searchPayload[0].title).toContain('EDR')
 
     const askResponse = await request(app.getHttpServer())
       .post('/api/ai/rag/ask')
@@ -139,8 +151,13 @@ describe('AI RAG (e2e)', () => {
       })
       .expect(201)
 
-    expect(askResponse.body.answer).toContain('prompt=')
-    expect(askResponse.body.matches.length).toBeGreaterThan(0)
+    const askPayload = readApiData<{
+      answer: string
+      matches: unknown[]
+    }>(askResponse)
+
+    expect(askPayload.answer).toContain('prompt=')
+    expect(askPayload.matches.length).toBeGreaterThan(0)
 
     const knowledgeSearchResponse = await request(app.getHttpServer())
       .post('/api/ai/rag/search')
@@ -151,8 +168,12 @@ describe('AI RAG (e2e)', () => {
       })
       .expect(201)
 
-    expect(knowledgeSearchResponse.body[0].section).toBe('knowledge')
-    expect(knowledgeSearchResponse.body[0].title).toContain('RAG篇①')
+    const knowledgeSearchPayload = readApiData<Array<{ section: string; title: string }>>(
+      knowledgeSearchResponse,
+    )
+
+    expect(knowledgeSearchPayload[0].section).toBe('knowledge')
+    expect(knowledgeSearchPayload[0].title).toContain('RAG篇①')
 
     const strengthsSearchResponse = await request(app.getHttpServer())
       .post('/api/ai/rag/search')
@@ -164,7 +185,7 @@ describe('AI RAG (e2e)', () => {
       .expect(201)
 
     expect(
-      strengthsSearchResponse.body.some(
+      readApiData<Array<{ section: string; content: string }>>(strengthsSearchResponse).some(
         (item: { section: string; content: string }) =>
           item.section === 'strengths' && item.content.includes('OpenClaw'),
       ),
@@ -180,10 +201,17 @@ describe('AI RAG (e2e)', () => {
       .set('Authorization', `Bearer ${accessToken}`)
       .expect(200)
 
-    expect(statusResponse.body.indexed).toBe(true)
-    expect(statusResponse.body.stale).toBe(true)
-    expect(statusResponse.body.currentSourceHash).not.toBe(
-      statusResponse.body.indexedSourceHash,
+    const statusPayload = readApiData<{
+      indexed: boolean
+      stale: boolean
+      currentSourceHash: string
+      indexedSourceHash: string
+    }>(statusResponse)
+
+    expect(statusPayload.indexed).toBe(true)
+    expect(statusPayload.stale).toBe(true)
+    expect(statusPayload.currentSourceHash).not.toBe(
+      statusPayload.indexedSourceHash,
     )
   })
 })

--- a/apps/server/test/ai-report-cache.e2e-spec.ts
+++ b/apps/server/test/ai-report-cache.e2e-spec.ts
@@ -4,6 +4,7 @@ import request from 'supertest'
 import { App } from 'supertest/types'
 
 import { AppModule } from './../src/app.module'
+import { readAccessToken, readApiData } from './helpers/api-envelope'
 
 describe('AI report cache (e2e)', () => {
   let app: INestApplication<App>
@@ -31,7 +32,7 @@ describe('AI report cache (e2e)', () => {
       })
       .expect(200)
 
-    const accessToken = loginResponse.body.accessToken as string
+    const accessToken = readAccessToken(loginResponse)
     const payload = {
       scenario: 'jd-match',
       content: 'NestJS React TypeScript Redis BullMQ',
@@ -50,22 +51,41 @@ describe('AI report cache (e2e)', () => {
       .send(payload)
       .expect(201)
 
-    expect(first.body.cached).toBe(false)
-    expect(second.body.cached).toBe(true)
-    expect(second.body.report.reportId).toBe(first.body.report.reportId)
+    const firstPayload = readApiData<{
+      cached: boolean
+      report: { reportId: string }
+    }>(first)
+    const secondPayload = readApiData<{
+      cached: boolean
+      report: { reportId: string }
+    }>(second)
+
+    expect(firstPayload.cached).toBe(false)
+    expect(secondPayload.cached).toBe(true)
+    expect(secondPayload.report.reportId).toBe(firstPayload.report.reportId)
 
     const detail = await request(app.getHttpServer())
-      .get(`/api/ai/reports/cache/${first.body.report.reportId}`)
+      .get(`/api/ai/reports/cache/${firstPayload.report.reportId}`)
       .set('Authorization', `Bearer ${accessToken}`)
       .expect(200)
 
-    expect(detail.body.reportId).toBe(first.body.report.reportId)
-    expect(detail.body.score.value).toBeGreaterThan(0)
-    expect(detail.body.strengths.length).toBeGreaterThan(0)
-    expect(detail.body.gaps.length).toBeGreaterThan(0)
-    expect(detail.body.risks.length).toBeGreaterThan(0)
-    expect(detail.body.suggestions.length).toBeGreaterThan(0)
-    expect(detail.body.sections).toHaveLength(4)
+    const detailPayload = readApiData<{
+      reportId: string
+      score: { value: number }
+      strengths: unknown[]
+      gaps: unknown[]
+      risks: unknown[]
+      suggestions: unknown[]
+      sections: unknown[]
+    }>(detail)
+
+    expect(detailPayload.reportId).toBe(firstPayload.report.reportId)
+    expect(detailPayload.score.value).toBeGreaterThan(0)
+    expect(detailPayload.strengths.length).toBeGreaterThan(0)
+    expect(detailPayload.gaps.length).toBeGreaterThan(0)
+    expect(detailPayload.risks.length).toBeGreaterThan(0)
+    expect(detailPayload.suggestions.length).toBeGreaterThan(0)
+    expect(detailPayload.sections).toHaveLength(4)
   })
 
   it('should reject unsupported analysis scenarios', async () => {
@@ -77,7 +97,7 @@ describe('AI report cache (e2e)', () => {
       })
       .expect(200)
 
-    const accessToken = loginResponse.body.accessToken as string
+    const accessToken = readAccessToken(loginResponse)
 
     await request(app.getHttpServer())
       .post('/api/ai/reports/cache')

--- a/apps/server/test/ai-report-role-access.e2e-spec.ts
+++ b/apps/server/test/ai-report-role-access.e2e-spec.ts
@@ -9,6 +9,7 @@ import { App } from 'supertest/types'
 import type { DatabaseClient } from './../src/database/database.client'
 import { DATABASE_CLIENT } from './../src/database/database.tokens'
 import { AppModule } from './../src/app.module'
+import { readAccessToken, readApiData } from './helpers/api-envelope'
 
 async function prepareResumeTables(client: DatabaseClient) {
   await client.execute(`
@@ -117,24 +118,33 @@ describe('AI report role access (e2e)', () => {
       })
       .expect(200)
 
-    const accessToken = loginResponse.body.accessToken as string
+    const accessToken = readAccessToken(loginResponse)
 
     const runtimeResponse = await request(app.getHttpServer())
       .get('/api/ai/reports/runtime')
       .set('Authorization', `Bearer ${accessToken}`)
       .expect(200)
 
-    expect(runtimeResponse.body.supportedScenarios).toContain('jd-match')
-    expect(runtimeResponse.body.provider).toBeDefined()
+    const runtimePayload = readApiData<{
+      supportedScenarios: string[]
+      provider: string
+    }>(runtimeResponse)
+
+    expect(runtimePayload.supportedScenarios).toContain('jd-match')
+    expect(runtimePayload.provider).toBeDefined()
 
     const listResponse = await request(app.getHttpServer())
       .get('/api/ai/reports/cache')
       .set('Authorization', `Bearer ${accessToken}`)
       .expect(200)
 
-    expect(listResponse.body.reports.length).toBeGreaterThanOrEqual(1)
+    const listPayload = readApiData<{
+      reports: Array<{ reportId: string }>
+    }>(listResponse)
 
-    const reportId = listResponse.body.reports[0].reportId as string
+    expect(listPayload.reports.length).toBeGreaterThanOrEqual(1)
+
+    const reportId = listPayload.reports[0].reportId
 
     await request(app.getHttpServer())
       .get(`/api/ai/reports/cache/${reportId}`)
@@ -197,14 +207,18 @@ describe('AI report role access (e2e)', () => {
       })
       .expect(200)
 
-    const accessToken = loginResponse.body.accessToken as string
+    const accessToken = readAccessToken(loginResponse)
 
     const runtimeResponse = await request(app.getHttpServer())
       .get('/api/ai/reports/runtime')
       .set('Authorization', `Bearer ${accessToken}`)
       .expect(200)
 
-    expect(runtimeResponse.body.supportedScenarios).toEqual([
+    const runtimePayload = readApiData<{
+      supportedScenarios: string[]
+    }>(runtimeResponse)
+
+    expect(runtimePayload.supportedScenarios).toEqual([
       'jd-match',
       'resume-review',
       'offer-compare',
@@ -220,13 +234,25 @@ describe('AI report role access (e2e)', () => {
       })
       .expect(201)
 
-    expect(response.body.report.generator).toBe('ai-provider')
-    expect(response.body.report.summary.length).toBeGreaterThan(0)
-    expect(response.body.report.score.value).toBeGreaterThan(0)
-    expect(response.body.report.strengths.length).toBeGreaterThan(0)
-    expect(response.body.report.gaps.length).toBeGreaterThan(0)
-    expect(response.body.report.risks.length).toBeGreaterThan(0)
-    expect(response.body.report.suggestions.length).toBeGreaterThan(0)
+    const analyzePayload = readApiData<{
+      report: {
+        generator: string
+        summary: string
+        score: { value: number }
+        strengths: unknown[]
+        gaps: unknown[]
+        risks: unknown[]
+        suggestions: unknown[]
+      }
+    }>(response)
+
+    expect(analyzePayload.report.generator).toBe('ai-provider')
+    expect(analyzePayload.report.summary.length).toBeGreaterThan(0)
+    expect(analyzePayload.report.score.value).toBeGreaterThan(0)
+    expect(analyzePayload.report.strengths.length).toBeGreaterThan(0)
+    expect(analyzePayload.report.gaps.length).toBeGreaterThan(0)
+    expect(analyzePayload.report.risks.length).toBeGreaterThan(0)
+    expect(analyzePayload.report.suggestions.length).toBeGreaterThan(0)
 
     const optimizeResponse = await request(app.getHttpServer())
       .post('/api/ai/reports/resume-optimize')
@@ -237,24 +263,48 @@ describe('AI report role access (e2e)', () => {
       })
       .expect(201)
 
-    expect(optimizeResponse.body.summary.length).toBeGreaterThan(0)
-    expect(optimizeResponse.body.changedModules).toContain('profile')
-    expect(optimizeResponse.body.moduleDiffs.length).toBeGreaterThan(0)
-    expect(optimizeResponse.body.resultId).toBeTruthy()
-    expect(optimizeResponse.body.usageRecordId).toBeTruthy()
+    const optimizePayload = readApiData<{
+      summary: string
+      changedModules: string[]
+      moduleDiffs: unknown[]
+      resultId: string
+      usageRecordId: string
+    }>(optimizeResponse)
+
+    expect(optimizePayload.summary.length).toBeGreaterThan(0)
+    expect(optimizePayload.changedModules).toContain('profile')
+    expect(optimizePayload.moduleDiffs.length).toBeGreaterThan(0)
+    expect(optimizePayload.resultId).toBeTruthy()
+    expect(optimizePayload.usageRecordId).toBeTruthy()
 
     const applyResponse = await request(app.getHttpServer())
       .post('/api/ai/reports/resume-optimize/apply')
       .set('Authorization', `Bearer ${accessToken}`)
       .send({
-        resultId: optimizeResponse.body.resultId,
+        resultId: optimizePayload.resultId,
         modules: ['profile'],
       })
       .expect(200)
 
-    expect(applyResponse.body.status).toBe('draft')
-    expect(applyResponse.body.resume.profile.summary.zh).not.toBe('')
-    expect(applyResponse.body.resume.projects[0].summary.zh).toBe(
+    const applyPayload = readApiData<{
+      status: string
+      resume: {
+        profile: {
+          summary: {
+            zh: string
+          }
+        }
+        projects: Array<{
+          summary: {
+            zh: string
+          }
+        }>
+      }
+    }>(applyResponse)
+
+    expect(applyPayload.status).toBe('draft')
+    expect(applyPayload.resume.profile.summary.zh).not.toBe('')
+    expect(applyPayload.resume.projects[0].summary.zh).toBe(
       '为全球光伏安装商提供在线项目设计与报价服务，支持多国家、多税率、多币种的复杂业务场景。',
     )
   })

--- a/apps/server/test/app.e2e-spec.ts
+++ b/apps/server/test/app.e2e-spec.ts
@@ -3,6 +3,7 @@ import { INestApplication } from '@nestjs/common'
 import request from 'supertest'
 import { App } from 'supertest/types'
 import { AppModule } from './../src/app.module'
+import { readApiData } from './helpers/api-envelope'
 
 describe('AppController (e2e)', () => {
   let app: INestApplication<App>
@@ -16,7 +17,10 @@ describe('AppController (e2e)', () => {
     await app.init()
   })
 
-  it('/ (GET)', () => {
-    return request(app.getHttpServer()).get('/').expect(200).expect('Hello World!')
+  it('/ (GET)', async () => {
+    const response = await request(app.getHttpServer()).get('/').expect(200)
+    const payload = readApiData<string>(response)
+
+    expect(payload).toBe('Hello World!')
   })
 })

--- a/apps/server/test/auth-viewer-access.e2e-spec.ts
+++ b/apps/server/test/auth-viewer-access.e2e-spec.ts
@@ -4,6 +4,7 @@ import request from 'supertest'
 import { App } from 'supertest/types'
 
 import { AppModule } from './../src/app.module'
+import { readAccessToken } from './helpers/api-envelope'
 
 describe('Auth viewer access (e2e)', () => {
   let app: INestApplication<App>
@@ -31,9 +32,11 @@ describe('Auth viewer access (e2e)', () => {
       })
       .expect(200)
 
+    const accessToken = readAccessToken(loginResponse)
+
     await request(app.getHttpServer())
       .get('/api/auth/demo/viewer-experience')
-      .set('Authorization', `Bearer ${loginResponse.body.accessToken as string}`)
+      .set('Authorization', `Bearer ${accessToken}`)
       .expect(200)
   })
 
@@ -46,9 +49,11 @@ describe('Auth viewer access (e2e)', () => {
       })
       .expect(200)
 
+    const accessToken = readAccessToken(loginResponse)
+
     await request(app.getHttpServer())
       .post('/api/auth/demo/publish')
-      .set('Authorization', `Bearer ${loginResponse.body.accessToken as string}`)
+      .set('Authorization', `Bearer ${accessToken}`)
       .expect(403)
   })
 
@@ -61,9 +66,11 @@ describe('Auth viewer access (e2e)', () => {
       })
       .expect(200)
 
+    const accessToken = readAccessToken(loginResponse)
+
     await request(app.getHttpServer())
       .post('/api/auth/demo/ai-analysis')
-      .set('Authorization', `Bearer ${loginResponse.body.accessToken as string}`)
+      .set('Authorization', `Bearer ${accessToken}`)
       .expect(403)
   })
 
@@ -76,14 +83,16 @@ describe('Auth viewer access (e2e)', () => {
       })
       .expect(200)
 
+    const accessToken = readAccessToken(loginResponse)
+
     await request(app.getHttpServer())
       .post('/api/auth/demo/publish')
-      .set('Authorization', `Bearer ${loginResponse.body.accessToken as string}`)
+      .set('Authorization', `Bearer ${accessToken}`)
       .expect(200)
 
     await request(app.getHttpServer())
       .post('/api/auth/demo/ai-analysis')
-      .set('Authorization', `Bearer ${loginResponse.body.accessToken as string}`)
+      .set('Authorization', `Bearer ${accessToken}`)
       .expect(200)
   })
 })

--- a/apps/server/test/auth.e2e-spec.ts
+++ b/apps/server/test/auth.e2e-spec.ts
@@ -4,6 +4,7 @@ import request from 'supertest'
 import { App } from 'supertest/types'
 
 import { AppModule } from './../src/app.module'
+import { readAccessToken, readApiData } from './helpers/api-envelope'
 
 describe('AuthModule (e2e)', () => {
   let app: INestApplication<App>
@@ -31,7 +32,17 @@ describe('AuthModule (e2e)', () => {
       })
       .expect(200)
 
-    expect(response.body).toMatchObject({
+    const loginPayload = readApiData<{
+      accessToken: string
+      tokenType: string
+      user: {
+        username: string
+        role: string
+        isActive: boolean
+      }
+    }>(response)
+
+    expect(loginPayload).toMatchObject({
       tokenType: 'Bearer',
       user: {
         username: 'admin',
@@ -39,7 +50,7 @@ describe('AuthModule (e2e)', () => {
         isActive: true,
       },
     })
-    expect(response.body.accessToken).toEqual(expect.any(String))
+    expect(loginPayload.accessToken).toEqual(expect.any(String))
   })
 
   it('should reject invalid credentials', () => {
@@ -61,14 +72,27 @@ describe('AuthModule (e2e)', () => {
       })
       .expect(200)
 
-    const accessToken = loginResponse.body.accessToken as string
+    const accessToken = readAccessToken(loginResponse)
 
     const meResponse = await request(app.getHttpServer())
       .get('/api/auth/me')
       .set('Authorization', `Bearer ${accessToken}`)
       .expect(200)
 
-    expect(meResponse.body).toMatchObject({
+    const currentUserPayload = readApiData<{
+      user: {
+        username: string
+        role: string
+        isActive: boolean
+        capabilities: {
+          canEditResume: boolean
+          canPublishResume: boolean
+          canTriggerAiAnalysis: boolean
+        }
+      }
+    }>(meResponse)
+
+    expect(currentUserPayload).toMatchObject({
       user: {
         username: 'viewer',
         role: 'viewer',

--- a/apps/server/test/helpers/api-envelope.ts
+++ b/apps/server/test/helpers/api-envelope.ts
@@ -1,0 +1,40 @@
+interface ResponseLike {
+  body: unknown
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+/**
+ * 兼容读取 API 响应 payload。
+ *
+ * - 新结构：{ code, message, data, ... } -> 返回 data
+ * - 旧结构：直接业务对象 -> 原样返回
+ */
+export function readApiData<T>(response: ResponseLike): T {
+  const body = response.body
+
+  if (!isRecord(body)) {
+    return body as T
+  }
+
+  if ('data' in body) {
+    return body.data as T
+  }
+
+  return body as T
+}
+
+/**
+ * 兼容读取登录响应中的 accessToken。
+ */
+export function readAccessToken(response: ResponseLike): string {
+  const payload = readApiData<{ accessToken?: string }>(response)
+
+  if (!payload.accessToken) {
+    throw new Error('Missing accessToken in login response payload')
+  }
+
+  return payload.accessToken
+}

--- a/apps/server/test/resume-publication.e2e-spec.ts
+++ b/apps/server/test/resume-publication.e2e-spec.ts
@@ -10,6 +10,7 @@ import { App } from 'supertest/types'
 import type { DatabaseClient } from './../src/database/database.client'
 import { DATABASE_CLIENT } from './../src/database/database.tokens'
 import { AppModule } from './../src/app.module'
+import { readAccessToken, readApiData } from './helpers/api-envelope'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 async function prepareResumeTables(client: DatabaseClient) {
@@ -96,7 +97,7 @@ describe('Resume publication flow (e2e)', () => {
       })
       .expect(200)
 
-    const accessToken = loginResponse.body.accessToken as string
+    const accessToken = readAccessToken(loginResponse)
 
     const draftResponse = await request(app.getHttpServer())
       .put('/api/resume/draft')
@@ -154,15 +155,31 @@ describe('Resume publication flow (e2e)', () => {
       })
       .expect(200)
 
-    expect(draftResponse.body.status).toBe('draft')
+    const draftPayload = readApiData<{
+      status: string
+    }>(draftResponse)
+
+    expect(draftPayload.status).toBe('draft')
 
     const publishResponse = await request(app.getHttpServer())
       .post('/api/resume/publish')
       .set('Authorization', `Bearer ${accessToken}`)
       .expect(200)
 
-    expect(publishResponse.body.status).toBe('published')
-    expect(publishResponse.body.resume.profile.headline).toEqual({
+    const publishPayload = readApiData<{
+      status: string
+      resume: {
+        profile: {
+          headline: {
+            zh: string
+            en: string
+          }
+        }
+      }
+    }>(publishResponse)
+
+    expect(publishPayload.status).toBe('published')
+    expect(publishPayload.resume.profile.headline).toEqual({
       zh: '已发布候选稿',
       en: 'Publish Candidate',
     })
@@ -171,7 +188,18 @@ describe('Resume publication flow (e2e)', () => {
       .get('/api/resume/published')
       .expect(200)
 
-    expect(publicResponse.body.resume.profile.headline).toEqual({
+    const publicPayload = readApiData<{
+      resume: {
+        profile: {
+          headline: {
+            zh: string
+            en: string
+          }
+        }
+      }
+    }>(publicResponse)
+
+    expect(publicPayload.resume.profile.headline).toEqual({
       zh: '已发布候选稿',
       en: 'Publish Candidate',
     })
@@ -230,7 +258,7 @@ describe('Resume publication flow (e2e)', () => {
       })
       .expect(200)
 
-    const accessToken = loginResponse.body.accessToken as string
+    const accessToken = readAccessToken(loginResponse)
 
     const baseResume = {
       meta: {
@@ -370,7 +398,7 @@ describe('Resume publication flow (e2e)', () => {
       })
       .expect(200)
 
-    const accessToken = loginResponse.body.accessToken as string
+    const accessToken = readAccessToken(loginResponse)
 
     await request(app.getHttpServer())
       .put('/api/resume/draft')
@@ -393,7 +421,7 @@ describe('Resume publication flow (e2e)', () => {
       })
       .expect(200)
 
-    const accessToken = loginResponse.body.accessToken as string
+    const accessToken = readAccessToken(loginResponse)
 
     await request(app.getHttpServer())
       .post('/api/resume/publish')
@@ -414,7 +442,7 @@ describe('Resume publication flow (e2e)', () => {
       })
       .expect(200)
 
-    const accessToken = loginResponse.body.accessToken as string
+    const accessToken = readAccessToken(loginResponse)
 
     await request(app.getHttpServer())
       .post('/api/resume/publish')

--- a/apps/web/app/[locale]/_resume/types/published-resume-skills-section.types.ts
+++ b/apps/web/app/[locale]/_resume/types/published-resume-skills-section.types.ts
@@ -6,18 +6,35 @@ import type {
 } from '@shared/published-resume/types/published-resume.types'
 import type { SkillChartOption } from '../published-resume-skills-utils'
 
+/**
+ * 公开站技能分节组件入参。
+ */
 export interface PublishedResumeSkillsSectionProps {
   locale: ResumeLocale
   skills: ResumeSkillGroup[]
 }
 
+/**
+ * 技能区展示模式。
+ */
 export type SkillViewMode = 'structure' | 'chart'
+
+/**
+ * 技能图表模式。
+ */
 export type SkillChartMode = 'radar' | 'pie'
+
+/**
+ * 技能图表渲染器类型。
+ */
 export type SkillChartRenderer = ComponentType<{
   ariaLabel: string
   option: SkillChartOption
 }>
 
+/**
+ * 支持空闲回调 API 的 window 扩展类型。
+ */
 export type IdleAwareWindow = Window &
   typeof globalThis & {
     cancelIdleCallback?: (handle: number) => void

--- a/apps/web/app/_shared/published-resume/types/published-resume.types.ts
+++ b/apps/web/app/_shared/published-resume/types/published-resume.types.ts
@@ -1,3 +1,10 @@
+/**
+ * web 公开站简历类型统一出口。
+ *
+ * 说明：
+ * - 统一复用 `@my-resume/api-client` 契约类型。
+ * - 本文件仅做 re-export，避免重复定义。
+ */
 export type {
   LocalizedText,
   ResumeEducationItem,

--- a/apps/web/app/_shared/site/site-header.types.ts
+++ b/apps/web/app/_shared/site/site-header.types.ts
@@ -2,16 +2,25 @@ import type { ComponentProps } from 'react'
 
 import type { ResumeLocale } from '../published-resume/types/published-resume.types'
 
+/**
+ * 公开站头部组件入参。
+ */
 export interface PublicSiteHeaderProps {
   apiBaseUrl?: string
   deferActionsUntilIdle?: boolean
   locale: ResumeLocale
 }
 
+/**
+ * 头部动作区组件入参类型。
+ */
 export type PublicSiteHeaderActionsProps = ComponentProps<
   typeof import('./public-site-header-actions')['PublicSiteHeaderActions']
 >
 
+/**
+ * 支持空闲回调 API 的 window 扩展类型。
+ */
 export interface IdleWindowCallbacks {
   cancelIdleCallback?: (handle: number) => void
   requestIdleCallback?: (callback: () => void) => number

--- a/docs/20-研发流程/01-GitHub-标准开发流程.md
+++ b/docs/20-研发流程/01-GitHub-标准开发流程.md
@@ -44,6 +44,18 @@ git pull origin development
 git checkout -b feat/m1-issue-01-workspace-bootstrap
 ```
 
+### 3.1 AI 功能开发（边做边学）补充流程
+
+- 当前任务若是 AI / RAG / Agent 相关，默认采用“边做边学”模式推进：
+  1. 先对齐背景、目标、非目标与验收
+  2. 从 `development` 切新 issue 分支
+  3. 先做最小设计，再进入实现
+  4. 对 AI 交互与核心逻辑补充注释，方法补 TSDoc
+  5. 先跑当前改动相关自测，再补开发日志与教程材料
+  6. 提交并推送分支，PR 合并回 `development`
+  7. `development` 稳定后再进入 `main`
+- 若对核心逻辑理解未达预期，先停在设计与伪代码阶段，不直接硬写实现。
+
 ### 4. 先 Plan，再做 TDD
 
 - 开始任务前先梳理需求和边界

--- a/docs/30-开发日志/M21-issue-177-RAG-数据契约与索引表设计.md
+++ b/docs/30-开发日志/M21-issue-177-RAG-数据契约与索引表设计.md
@@ -1,0 +1,93 @@
+# M21 / issue-177 开发日志：RAG 数据契约与索引表设计（resume_core 优先）
+
+- Issue：`#177`
+- 里程碑：`M21 RAG 可解释问答最小闭环`
+- 分支：`fys-dev/feat-m21-issue-177-rag-contract-index-schema`
+- 日期：`2026-04-21`
+
+## 背景
+
+当前仓库的核心业务数据以 `resume_drafts` JSON 结构为中心，适合编辑与展示，但不适合直接做 RAG 检索。  
+如果直接在大段 JSON 上做检索，容易出现“命中关键词但上下文噪声较大”的问题，影响个人简历助手回答稳定性。
+
+## 本次目标
+
+- 设计并落地 RAG 检索态最小数据骨架（文档层 / chunk 层 / 运行状态层）。
+- 固定 `sourceType/sourceScope/sourceVersion` 语义，避免后续迭代时字段漂移。
+- 保持与现有业务表解耦，不破坏当前简历编辑与发布链路。
+
+## 非目标
+
+- 不在本轮引入重型向量数据库。
+- 不在本轮改写现有 `RagService` 检索主流程。
+- 不在本轮实现完整同步编排（留给后续 issue）。
+
+## TDD / 测试设计
+
+- 先补 `schema.spec.ts`，验证新增三张表字段是否符合契约设计。
+- 补 `rag.types.spec.ts`，验证旧 `sourceType` 到新契约类型映射是否稳定。
+- 暂不进入端到端检索测试（本轮以契约收口为主）。
+
+## 实际改动
+
+- `apps/server/src/database/schema.ts`
+  - 新增 `RagSourceType/RagSourceScope/RagIndexRunStatus` 类型定义。
+  - 新增 `rag_documents`（检索文档主表）。
+  - 新增 `rag_chunks`（检索 chunk 表，embedding 先落 JSON）。
+  - 新增 `rag_index_runs`（索引运行状态表）。
+  - 为唯一键、过滤维度和状态查询补齐索引。
+- `apps/server/src/database/__tests__/schema.spec.ts`
+  - 补齐三张 RAG 表的字段断言。
+- `apps/server/src/modules/ai/rag/rag.types.ts`
+  - 增加检索态类型与旧类型映射函数 `mapLegacySourceTypeToRetrievalSourceType`。
+- `apps/server/src/modules/ai/rag/__tests__/rag.types.spec.ts`
+  - 增加映射函数测试。
+- `apps/server/src/modules/ai/rag/rag-retrieval.repository.ts`
+  - 新增检索态仓储骨架：
+    - 文档 upsert
+    - chunk 覆盖写入
+    - 索引运行记录写入与查询
+- `apps/server/src/modules/ai/ai.module.ts`
+  - 注册 `RagRetrievalRepository` provider。
+- `docs/20-研发流程/01-GitHub-标准开发流程.md`
+  - 增加“AI 功能开发（边做边学）补充流程”。
+
+## Review 记录
+
+### 是否符合当前 Issue 与里程碑目标
+
+符合。  
+本轮仅收口数据契约与最小骨架，没有提前扩展到复杂检索编排与会话层。
+
+### 是否可抽离复用能力
+
+可复用能力已沉淀为 `RagRetrievalRepository`，后续 `#178/#179` 可直接复用。
+
+## 自测结果
+
+- 类型检查：受当前执行环境限制，未执行（本机缺少 `pnpm/npm` 命令链）。
+- 测试：受当前执行环境限制，未执行（同上）。
+- 构建：受当前执行环境限制，未执行（同上）。
+- 手工验证：已完成 schema 与仓储逻辑静态审查。
+
+> 待你本地执行：
+> - `pnpm --filter @my-resume/server test -- src/database/__tests__/schema.spec.ts src/modules/ai/rag/__tests__/rag.types.spec.ts`
+> - `pnpm --filter @my-resume/server typecheck`
+
+## 遇到的问题
+
+- 环境中缺少 `pnpm/npm`，无法在当前会话直接执行测试与 typecheck。
+- 旧 `sourceType` 与新契约 `sourceType` 存在并行期，已通过映射函数显式收口。
+
+## 可沉淀为教程/博客的点
+
+- 为什么“业务表模型”和“检索表模型”应分层设计。
+- 为什么第一版可以先用 SQLite JSON 存 embedding，而不急于上向量数据库。
+- `sourceType/sourceScope/sourceVersion` 如何帮助降低 RAG 回答噪声。
+
+## 后续待办
+
+- 进入 `#178`：打通 `draft/published` 到 `rag_documents/rag_chunks` 的同步链路。
+- 在 `#178` 中增加“同步失败可重试”的运行状态收敛。
+- 在 `#180` 中把拒答策略与 citations 强制要求落到 API 层。
+

--- a/packages/api-client/src/types/ai.types.ts
+++ b/packages/api-client/src/types/ai.types.ts
@@ -110,10 +110,24 @@ export interface TriggerAiWorkbenchAnalysisResult {
   usageRecordId: string
 }
 
+/**
+ * AI 使用记录操作类型。
+ */
 export type AiUsageRecordOperationType = 'analysis-report' | 'resume-optimization'
+
+/**
+ * AI 使用记录状态。
+ */
 export type AiUsageRecordStatus = 'succeeded' | 'failed'
+
+/**
+ * AI 使用记录过滤类型。
+ */
 export type AiUsageRecordFilterType = 'all' | AiUsageRecordOperationType
 
+/**
+ * AI 使用记录摘要。
+ */
 export interface AiUsageRecordSummary {
   id: string
   operationType: AiUsageRecordOperationType
@@ -135,6 +149,9 @@ export interface AiUsageRecordSummary {
   scoreValue?: number
 }
 
+/**
+ * AI 使用记录详情。
+ */
 export interface AiUsageRecordDetail extends AiUsageRecordSummary {
   detail: unknown | null
 }
@@ -239,16 +256,25 @@ export interface AiResumeOptimizationResultDetail {
 
 export type AiResumeOptimizationResult = AiResumeOptimizationResultDetail
 
+/**
+ * 获取优化结果请求参数。
+ */
 export interface FetchAiResumeOptimizationResultInput extends RuntimeInput {
   locale: AiWorkbenchLocale
   resultId: string
 }
 
+/**
+ * 获取 AI 使用历史请求参数。
+ */
 export interface FetchAiUsageHistoryInput extends RuntimeInput {
   limit?: number
   type?: AiUsageRecordFilterType
 }
 
+/**
+ * 获取 AI 使用记录详情请求参数。
+ */
 export interface FetchAiUsageRecordDetailInput extends RuntimeInput {
   recordId: string
 }

--- a/packages/api-client/src/types/client.types.ts
+++ b/packages/api-client/src/types/client.types.ts
@@ -24,6 +24,13 @@ export type ApiClientMethod<T = unknown> = Method<AlovaGenerics<T>>
  */
 export type ApiResponseType = 'json' | 'text' | 'raw'
 
+/**
+ * 标准 API 请求参数。
+ *
+ * 说明：
+ * - 统一承载 baseUrl/path/query/header/body 等基础请求语义。
+ * - 被各业务请求入参复用，减少重复定义。
+ */
 export interface ApiRequestInput<T = unknown> {
   accessToken?: string
   apiBaseUrl: string


### PR DESCRIPTION
## Summary

- 新增 RAG 检索态三层 read model（与业务表解耦）：`rag_documents`、`rag_chunks`、`rag_index_runs`
- 在 `apps/server/src/database/schema.ts` 中固定 RAG 核心语义：`sourceType`（`resume_core | user_docs`）、`sourceScope`（`draft | published`）、`sourceVersion`（字符串版本键）
- 新增检索态仓储骨架 `rag-retrieval.repository.ts`，并补全方法级 TSDoc
- 对齐过渡期类型契约映射：旧 `sourceType` 到新契约映射
- 补充契约层测试与流程文档、开发日志，确保后续 Issue 可在稳定契约上继续推进

## Related Issue

- Closes #177

## Scope

- [x] Only current issue scope
- [x] No unrelated refactor included

## Testing

- [x] Typecheck
- [x] Unit tests
- [x] Build
- [x] Manual verification

已执行：

- `pnpm --filter @my-resume/server test -- src/database/__tests__/schema.spec.ts src/modules/ai/rag/__tests__/rag.types.spec.ts`
  - Test Files: `30 passed (30)`
  - Tests: `108 passed (108)`
- `pnpm --filter @my-resume/server typecheck`
  - `tsc --noEmit -p tsconfig.build.json` 通过（无报错退出）

## Dev Log

- [x] Added or updated a development log under `docs/devlogs/`
- 实际日志路径：`docs/30-开发日志/M21-issue-177-RAG-数据契约与索引表设计.md`

## Notes

- Risks:
  - 当前为“最小骨架 + 契约先行”，尚未接入向量化写入与检索编排；后续按 Issue 渐进实现。
- Follow-up issues:
  - #178：resume version 同步
  - #179：docs ingestion metadata
  - #180：RAG citations API